### PR TITLE
MAP-801 Refactor attributes representation in Location objects

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeValue
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialHousingType
 import java.time.Clock
@@ -54,7 +53,7 @@ data class Location(
   val certification: Certification? = null,
 
   @Schema(description = "Location Attributes", required = false)
-  val attributes: Map<ResidentialAttributeType, List<ResidentialAttributeValue>>? = null,
+  val attributes: List<ResidentialAttributeValue>? = null,
 
   @Schema(description = "Location Usage", required = false)
   val usage: List<NonResidentialUsageDto>? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PatchLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PatchLocationRequest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeValue
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialHousingType
 import java.util.*
@@ -48,7 +47,7 @@ data class PatchLocationRequest(
   override val certification: Certification? = null,
 
   @Schema(description = "Location Attributes", required = false)
-  override val attributes: Map<ResidentialAttributeType, Set<ResidentialAttributeValue>>? = null,
+  override val attributes: Set<ResidentialAttributeValue>? = null,
 
   @Schema(description = "Location Usage", required = false)
   override val usage: Set<NonResidentialUsageDto>? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateLocationRequest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
 
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeValue
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialHousingType
 
@@ -14,6 +13,6 @@ interface UpdateLocationRequest {
   val residentialHousingType: ResidentialHousingType?
   val capacity: Capacity?
   val certification: Certification?
-  val attributes: Map<ResidentialAttributeType, Set<ResidentialAttributeValue>>?
+  val attributes: Set<ResidentialAttributeValue>?
   val usage: Set<NonResidentialUsageDto>?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpsertLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpsertLocationRequest.kt
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocation
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeValue
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialHousingType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
@@ -59,7 +58,7 @@ data class UpsertLocationRequest(
   override val certification: Certification? = null,
 
   @Schema(description = "Location Attributes", required = false)
-  override val attributes: Map<ResidentialAttributeType, Set<ResidentialAttributeValue>>? = null,
+  override val attributes: Set<ResidentialAttributeValue>? = null,
 
   @Schema(description = "Location Usage", required = false)
   override val usage: Set<NonResidentialUsageDto>? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -76,17 +76,17 @@ class ResidentialLocation(
     return residentialAttribute
   }
 
-  fun getOperationalCapacity(): Int {
+  private fun getOperationalCapacity(): Int {
     return cellLocations()
       .sumOf { it.capacity?.operationalCapacity ?: 0 }
   }
 
-  fun getMaxCapacity(): Int {
+  private fun getMaxCapacity(): Int {
     return cellLocations()
       .sumOf { it.capacity?.capacity ?: 0 }
   }
 
-  fun getBaselineCapacity(): Int {
+  private fun getBaselineCapacity(): Int {
     return cellLocations()
       .sumOf { it.certification?.capacityOfCertifiedCell ?: 0 }
   }
@@ -98,11 +98,9 @@ class ResidentialLocation(
     this.residentialHousingType = upsert.residentialHousingType ?: this.residentialHousingType
     this.capacity = upsert.capacity?.toNewEntity() ?: this.capacity
     this.certification = upsert.certification?.toNewEntity() ?: this.certification
-    this.attributes = upsert.attributes?.map { attributeGroup ->
-      attributeGroup.value.map { attribute ->
-        this.addAttribute(attribute)
-      }
-    }?.flatten()?.toMutableSet() ?: this.attributes
+    this.attributes = upsert.attributes?.map { attribute ->
+      this.addAttribute(attribute)
+    }?.toMutableSet() ?: this.attributes
     return this
   }
 
@@ -125,7 +123,7 @@ class ResidentialLocation(
         )
       },
       residentialHousingType = residentialHousingType,
-      attributes = attributes.groupBy { it.attributeType }.mapValues { type -> type.value.map { it.attributeValue } },
+      attributes = attributes.map { it.attributeValue },
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -21,7 +21,6 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeValue
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialHousingType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
@@ -421,14 +420,10 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                                 "certified": true,
                                 "capacityOfCertifiedCell": 2
                               },
-                              "attributes": {
-                                "LOCATION_ATTRIBUTE": [
-                                  "DOUBLE_OCCUPANCY"
-                                ],
-                                "SECURITY": [
-                                  "CAT_B"
-                                ]
-                              },
+                              "attributes": [
+                                "DOUBLE_OCCUPANCY",
+                                "CAT_B"
+                              ],
                               "isResidential": true,
                               "key": "MDI-Z-1-001"
                             },
@@ -448,14 +443,10 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                                 "certified": true,
                                 "capacityOfCertifiedCell": 2
                               },
-                              "attributes": {
-                                "LOCATION_ATTRIBUTE": [
-                                  "DOUBLE_OCCUPANCY"
-                                ],
-                                "SECURITY": [
-                                  "CAT_B"
-                                ]
-                              },
+                              "attributes": [
+                                "DOUBLE_OCCUPANCY",
+                                "CAT_B"
+                              ],
                               "isResidential": true,
                               "key": "MDI-Z-1-002"
                             }
@@ -471,14 +462,10 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                             "certified": false,
                             "capacityOfCertifiedCell": 4
                           },
-                          "attributes": {
-                            "LOCATION_ATTRIBUTE": [
-                              "DOUBLE_OCCUPANCY"
-                            ],
-                            "SECURITY": [
-                              "CAT_B"
-                            ]
-                          },
+                          "attributes": [
+                            "DOUBLE_OCCUPANCY",
+                            "CAT_B"
+                          ],
                           "isResidential": true,
                           "key": "MDI-Z-1"
                         },
@@ -513,14 +500,10 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                         "certified": false,
                         "capacityOfCertifiedCell": 4
                       },
-                      "attributes": {
-                        "SECURITY": [
-                          "CAT_B"
-                        ],
-                        "LOCATION_ATTRIBUTE": [
-                          "DOUBLE_OCCUPANCY"
-                        ]
-                      },
+                      "attributes": [
+                        "DOUBLE_OCCUPANCY",
+                        "CAT_B"
+                      ],
                       "isResidential": true,
                       "key": "MDI-Z"
                     }
@@ -1042,18 +1025,14 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
     )
 
     val changeAttribute = PatchLocationRequest(
-      attributes = mapOf(
-        ResidentialAttributeType.LOCATION_ATTRIBUTE to setOf(
-          ResidentialAttributeValue.SINGLE_OCCUPANCY,
-        ),
-        ResidentialAttributeType.SECURITY to setOf(
-          ResidentialAttributeValue.CAT_C,
-        ),
+      attributes = setOf(
+        ResidentialAttributeValue.SINGLE_OCCUPANCY,
+        ResidentialAttributeValue.CAT_C,
       ),
     )
 
     val removeAttributes = PatchLocationRequest(
-      attributes = emptyMap(),
+      attributes = emptySet(),
     )
 
     val changeUsage = PatchLocationRequest(
@@ -1356,14 +1335,10 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                   "certified": true,
                   "capacityOfCertifiedCell": 2
                 },
-                "attributes": {
-                  "LOCATION_ATTRIBUTE": [
-                    "DOUBLE_OCCUPANCY"
-                  ],
-                  "SECURITY": [
-                    "CAT_B"
-                  ]
-                },
+                "attributes": [
+                  "DOUBLE_OCCUPANCY",
+                  "CAT_B"
+                ],
                 "isResidential": true,
                 "key": "MDI-Z-1-001"
               }
@@ -1482,14 +1457,10 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                   "certified": false,
                   "capacityOfCertifiedCell": 3
                 },
-                "attributes": {
-                  "LOCATION_ATTRIBUTE": [
-                    "DOUBLE_OCCUPANCY"
-                  ],
-                  "SECURITY": [
-                    "CAT_B"
-                  ]
-                },
+                "attributes": [
+                  "DOUBLE_OCCUPANCY",
+                  "CAT_B"
+                ],
                 "isResidential": true,
                 "key": "MDI-Z-1-001"
               }
@@ -1606,7 +1577,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                 "capacity": 4,
                 "operationalCapacity": 4
               },
-              "attributes": {}
+              "attributes": []
             }
           """,
             false,
@@ -1636,14 +1607,10 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                 "capacity": 4,
                 "operationalCapacity": 4
               },
-              "attributes": {
-                "LOCATION_ATTRIBUTE": [
-                  "SINGLE_OCCUPANCY"
-                ],
-                "SECURITY": [
-                  "CAT_C"
-                ]
-              }
+              "attributes": [
+                "SINGLE_OCCUPANCY",
+                "CAT_C"
+              ]
             }
           """,
             false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.UpsertLocationRequ
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeValue
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialHousingType
 import java.time.Clock
@@ -41,7 +40,7 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
       orderWithinParentLocation = 1,
       lastUpdatedBy = "user",
       lastModifiedDate = LocalDateTime.now(),
-      attributes = mapOf(ResidentialAttributeType.USED_FOR to setOf(ResidentialAttributeValue.IMMIGRATION_DETAINEES)),
+      attributes = setOf(ResidentialAttributeValue.IMMIGRATION_DETAINEES),
     )
 
     var syncNonResRequest = UpsertLocationRequest(


### PR DESCRIPTION
This commit includes changes to refactor how attributes are represented in 'Location' objects across various files. The attributes are now represented as a 'Set' of 'ResidentialAttributeValue' objects rather than a 'Map'. This simplifies the structure of the 'Location' entities.