### PR TITLE
MAP-614 Enable orphanRemoval for multiple OneToMany relationships

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -62,7 +62,7 @@ abstract class Location(
   open var deactivatedReason: DeactivatedReason? = null,
   open var proposedReactivationDate: LocalDate? = null,
 
-  @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+  @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   protected open var childLocations: MutableList<Location> = mutableListOf(),
 
   @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -33,7 +33,7 @@ class NonResidentialLocation(
   whenUpdated: LocalDateTime,
   updatedBy: String,
 
-  @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+  @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   private var nonResidentialUsages: MutableSet<NonResidentialUsage> = mutableSetOf(),
 
 ) : Location(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -47,7 +47,7 @@ class ResidentialLocation(
   @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], optional = true)
   var certification: Certification? = null,
 
-  @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+  @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   private var attributes: MutableSet<ResidentialAttribute> = mutableSetOf(),
 
 ) : Location(
@@ -119,10 +119,12 @@ class ResidentialLocation(
     }
     this.certification = upsert.certification?.toNewEntity() ?: this.certification
 
-    recordHistoryOfAttributesChanges(upsert, updatedBy, clock)
-    this.attributes = upsert.attributes?.map { attribute ->
-      this.addAttribute(attribute)
-    }?.toMutableSet() ?: this.attributes
+    if (upsert.attributes != null) {
+      recordHistoryOfAttributesChanges(upsert, updatedBy, clock)
+      this.attributes = upsert.attributes?.map { attribute ->
+        this.addAttribute(attribute)
+      }?.toMutableSet() ?: this.attributes
+    }
     return this
   }
 


### PR DESCRIPTION
Orphan removal attribute has been added to three OneToMany relationships in the Location, NonResidentialLocation, and ResidentialLocation classes. This ensures that when a parent entity is removed, all its related children entities will be automatically deleted, improving data cleanup. Furthermore, the update method in Residential class now checks if attributes are not null before invoking the function to record history of attributes changes.