### PR TITLE
MAP-614 Update fetching strategy and edit tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -33,8 +33,8 @@ class NonResidentialLocation(
   whenUpdated: LocalDateTime,
   updatedBy: String,
 
-  @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-  private var nonResidentialUsages: MutableSet<NonResidentialUsage> = mutableSetOf(),
+  @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  private val nonResidentialUsages: MutableSet<NonResidentialUsage> = mutableSetOf(),
 
 ) : Location(
   id = id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialUsage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialUsage.kt
@@ -18,7 +18,7 @@ class NonResidentialUsage(
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long? = null,
 
-  @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+  @ManyToOne(fetch = FetchType.LAZY)
   val location: Location,
   @Enumerated(EnumType.STRING)
   val usageType: NonResidentialUsageType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialAttribute.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialAttribute.kt
@@ -17,7 +17,7 @@ class ResidentialAttribute(
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long? = null,
 
-  @ManyToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+  @ManyToOne(fetch = FetchType.LAZY)
   val location: Location,
   @Enumerated(EnumType.STRING)
   val attributeType: ResidentialAttributeType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -47,8 +47,8 @@ class ResidentialLocation(
   @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], optional = true)
   var certification: Certification? = null,
 
-  @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-  private var attributes: MutableSet<ResidentialAttribute> = mutableSetOf(),
+  @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  private val attributes: MutableSet<ResidentialAttribute> = mutableSetOf(),
 
 ) : Location(
   id = id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -1606,6 +1606,41 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
           """,
             false,
           )
+
+        webTestClient.get().uri("/locations/${landing1.id}?includeHistory=true")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+               {
+              "prisonId": "MDI",
+              "code": "1",
+              "pathHierarchy": "Z-1",
+              "locationType": "LANDING",
+              "active": true,
+              "key": "MDI-Z-1",
+              "residentialHousingType": "NORMAL_ACCOMMODATION",
+              "capacity": {
+                "capacity": 4,
+                "operationalCapacity": 4
+              },
+              "attributes": [],
+              "changeHistory": [
+                {
+                  "attribute": "Attributes",
+                  "oldValue": "DOUBLE_OCCUPANCY"
+                },
+                {
+                  "attribute": "Attributes",
+                  "oldValue": "CAT_B"
+                }
+              ]
+            }
+            """,
+            false,
+          )
       }
 
       @Test
@@ -1641,80 +1676,80 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
           )
       }
 
-      /*      @Test
-            fun `can update details of a locations non-res usage`() {
-              webTestClient.patch().uri("/locations/${visitRoom.id}")
-                .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
-                .header("Content-Type", "application/json")
-                .bodyValue(jsonString(changeUsage))
-                .exchange()
-                .expectStatus().isOk
-                .expectBody().json(
-                  // language=json
-                  """
-                   {
-                    "prisonId": "MDI",
-                    "code": "MEDICAL",
-                    "pathHierarchy": "Z-MEDICAL",
-                    "locationType": "APPOINTMENTS",
-                    "active": true,
-                    "key": "MDI-Z-MEDICAL",
-                    "usage": [
-                      {
-                        "usageType": "APPOINTMENT",
-                        "capacity": 20,
-                        "sequence": 1
-                      }
-                    ]
-                  }
-                """,
-                  false,
-                )
+      @Test
+      fun `can update details of a locations non-res usage`() {
+        webTestClient.patch().uri("/locations/${visitRoom.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(changeUsage))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+             {
+              "prisonId": "MDI",
+              "code": "MEDICAL",
+              "pathHierarchy": "Z-MEDICAL",
+              "locationType": "APPOINTMENTS",
+              "active": true,
+              "key": "MDI-Z-MEDICAL",
+              "usage": [
+                {
+                  "usageType": "APPOINTMENT",
+                  "capacity": 20,
+                  "sequence": 1
+                }
+              ]
+            }
+          """,
+            false,
+          )
 
-              webTestClient.get().uri("/locations/${visitRoom.id}?includeHistory=true")
-                .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
-                .exchange()
-                .expectStatus().isOk
-                .expectBody().json(
-                  """
-                     {
-                       "key": "MDI-Z-MEDICAL",
-                       "usage": [
-                         {
-                           "usageType": "APPOINTMENT",
-                           "capacity": 20,
-                           "sequence": 1
-                         }
-                       ],
-                       "changeHistory": [
-                          {
-                            "attribute": "Code",
-                            "oldValue": "VISIT",
-                            "newValue": "MEDICAL"
-                          },
-                          {
-                            "attribute": "Location Type",
-                            "oldValue": "Visits",
-                            "newValue": "Appointments"
-                          },
-                          {
-                            "attribute": "Usage",
-                            "oldValue": "VISIT"
-                          },
-                          {
-                            "attribute": "Usage",
-                            "newValue": "APPOINTMENT"
-                          },
-                          {
-                            "attribute": "Non Residential Capacity",
-                            "newValue": "20"
-                          }
-                        ]
-                     }
-                  """.trimIndent(),
-                  false,
-                )
-            }*/
+        webTestClient.get().uri("/locations/${visitRoom.id}?includeHistory=true")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            """
+               {
+                 "key": "MDI-Z-MEDICAL",
+                 "usage": [
+                   {
+                     "usageType": "APPOINTMENT",
+                     "capacity": 20,
+                     "sequence": 1
+                   }
+                 ],
+                 "changeHistory": [
+                    {
+                      "attribute": "Code",
+                      "oldValue": "VISIT",
+                      "newValue": "MEDICAL"
+                    },
+                    {
+                      "attribute": "Location Type",
+                      "oldValue": "Visits",
+                      "newValue": "Appointments"
+                    },
+                    {
+                      "attribute": "Usage",
+                      "oldValue": "VISIT"
+                    },
+                    {
+                      "attribute": "Usage",
+                      "newValue": "APPOINTMENT"
+                    },
+                    {
+                      "attribute": "Non Residential Capacity",
+                      "newValue": "20"
+                    }
+                  ]
+               }
+            """.trimIndent(),
+            false,
+          )
+      }
 
       @Test
       fun `can remove details of a locations non-res usage`() {
@@ -1735,6 +1770,33 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
               "active": true,
               "key": "MDI-Z-VISIT",
               "usage": []
+            }
+          """,
+            false,
+          )
+
+        webTestClient.get().uri("/locations/key/MDI-Z-VISIT?includeHistory=true")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+             {
+              "prisonId": "MDI",
+              "code": "VISIT",
+              "pathHierarchy": "Z-VISIT",
+              "locationType": "VISITS",
+              "active": true,
+              "key": "MDI-Z-VISIT",
+              "usage": [],
+              "changeHistory": [
+                {
+                  "attribute": "Usage",
+                  "oldValue": "VISIT"
+                }
+              ]
             }
           """,
             false,


### PR DESCRIPTION
The CascadeType for @ManyToOne has been removed in both ResidentialAttribute.kt and NonResidentialUsage.kt.

The orphanRemoval property is now set to true in ResidentialLocation.kt and NonResidentialLocation.kt.

Multiple tests related to location have been updated