### PR TITLE
MAP-614 Add location history migration endpoint and functionality

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/MigrateHistoryRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/MigrateHistoryRequest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationAttribute
+import java.time.LocalDateTime
+
+@Schema(description = "Request to migrate a location's history")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class MigrateHistoryRequest(
+  @Schema(description = "Location Attribute", example = "CAPACITY", required = true)
+  val attribute: LocationAttribute,
+
+  @Schema(description = "Previous value of this attribute, null if NEW", example = "2", required = false)
+  val oldValue: String? = null,
+
+  @Schema(description = "New value of this attribute, null if REMOVED", example = "1", required = false)
+  val newValue: String? = null,
+
+  @Schema(description = "User who made the change", example = "username", required = true)
+  val amendedBy: String,
+
+  @Schema(description = "Date the change was made", example = "2023-01-23T10:15:30", required = true)
+  val amendedDate: LocalDateTime,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -156,8 +156,8 @@ abstract class Location(
     return leafLocations
   }
 
-  fun addHistory(attributeName: LocationAttribute, oldValue: String?, newValue: String?, amendedBy: String, amendedDate: LocalDateTime) {
-    if (oldValue != newValue) {
+  fun addHistory(attributeName: LocationAttribute, oldValue: String?, newValue: String?, amendedBy: String, amendedDate: LocalDateTime): LocationHistory? {
+    return if (oldValue != newValue) {
       val locationHistory = LocationHistory(
         location = this,
         attributeName = attributeName,
@@ -167,6 +167,9 @@ abstract class Location(
         amendedDate = amendedDate,
       )
       history = history + locationHistory
+      return locationHistory
+    } else {
+      null
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialUsage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialUsage.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa
 
-import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialAttribute.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialAttribute.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa
 
-import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/MigrationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/MigrationResource.kt
@@ -9,13 +9,17 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ChangeHistory
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.MigrateHistoryRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.UpsertLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.SyncService
+import java.util.*
 
 @RestController
 @Validated
@@ -29,7 +33,7 @@ class MigrationResource(
   private val syncService: SyncService,
 ) : EventBaseResource() {
 
-  @PostMapping("")
+  @PostMapping("/location")
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
     summary = "Migrate a location",
@@ -61,9 +65,50 @@ class MigrationResource(
       ),
     ],
   )
-  fun migrate(
+  fun migrateLocation(
     @RequestBody
     @Validated
-    syncRequest: UpsertLocationRequest,
-  ) = syncService.migrate(syncRequest)
+    migrateRequest: UpsertLocationRequest,
+  ) = syncService.migrate(migrateRequest)
+
+  @PostMapping("/location/{id}/history")
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(
+    summary = "Migrate a location history",
+    description = "Requires role MIGRATE_LOCATIONS and write scope",
+    responses = [
+      ApiResponse(
+        responseCode = "201",
+        description = "Migrated history",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid Request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MIGRATE_LOCATIONS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun migrateHistory(
+    @Schema(description = "The location Id", example = "de91dfa7-821f-4552-a427-bf2f32eafeb0", required = true)
+    @PathVariable
+    id: UUID,
+    @RequestBody
+    @Validated
+    locationHistory: MigrateHistoryRequest,
+  ): ChangeHistory? = syncService.migrateHistory(id, locationHistory)
 }


### PR DESCRIPTION
Updated the SyncService to include a method for migrating location history. A new endpoint has been added to the MigrationResource that calls this method. The unnecessary CascadeType imports in ResidentialAttribute and NonResidentialUsage have been removed. Additionally, test coverage was expanded to include the new endpoint and service method.