### PR TITLE
MAP-848 Add functionality to create prison wings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CreateWingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CreateWingRequest.kt
@@ -1,0 +1,124 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Size
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Capacity
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Certification
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeValue
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationService
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Schema(description = "Request to create a wing")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CreateWingRequest(
+  @Schema(description = "Prison ID", example = "MDI", required = true)
+  val prisonId: String,
+  @Schema(description = "Code assigned to a wing", example = "B", required = true)
+  @field:Size(max = 12, message = "Max of 12 characters")
+  val wingCode: String,
+  @Schema(description = "Alternative description to display for location", example = "Wing A", required = false)
+  @field:Size(max = 80, message = "Max of 80 characters")
+  val wingDescription: String?,
+  @Schema(description = "Number of landings required", example = "3", required = false)
+  @field:Max(value = 10, message = "Max of 10")
+  val numberOfLandings: Int? = null,
+  @Schema(description = "Number of spurs required", example = "2", required = false)
+  @field:Max(value = 10, message = "Max of 10")
+  val numberOfSpursPerLanding: Int? = null,
+  @Schema(description = "Number of cells required in each section (wing,landing or spur)", example = "40", required = true)
+  @field:Max(value = 999, message = "Max of 999")
+  val numberOfCellsPerSection: Int,
+  @Schema(description = "Default Cell Capacity", example = "1", required = true, defaultValue = "1")
+  @field:Max(value = 10, message = "Max of 10")
+  val defaultCellCapacity: Int = 1,
+  @Schema(description = "Default set of attributes", example = "SINGLE_OCCUPANCY", required = false)
+  val defaultAttributesOfCells: Set<ResidentialAttributeValue>?,
+) {
+
+  fun toEntity(createdBy: String, clock: Clock): ResidentialLocation {
+    val wing = ResidentialLocation(
+      prisonId = prisonId,
+      code = wingCode,
+      locationType = LocationType.WING,
+      pathHierarchy = wingCode,
+      description = wingDescription,
+      orderWithinParentLocation = 1,
+      createdBy = createdBy,
+      whenCreated = LocalDateTime.now(clock),
+      childLocations = mutableListOf(),
+    )
+    LocationService.log.info("Created Wing [${wing.getKey()}]")
+
+    numberOfLandings?.let { numberOfLandings ->
+      for (landingNumber in 1..numberOfLandings) {
+        val landing = ResidentialLocation(
+          prisonId = prisonId,
+          code = "$landingNumber",
+          locationType = LocationType.LANDING,
+          pathHierarchy = "$wingCode-$landingNumber",
+          description = "Landing $landingNumber on Wing $wingCode",
+          orderWithinParentLocation = landingNumber,
+          createdBy = createdBy,
+          whenCreated = LocalDateTime.now(clock),
+          childLocations = mutableListOf(),
+        )
+        wing.addChildLocation(landing)
+        LocationService.log.info("Created Landing [${landing.getKey()}]")
+      }
+    }
+
+    wing.findAllLeafLocations().forEach { landing ->
+      numberOfSpursPerLanding?.let { numberOfSpurs ->
+        for (spurNumber in 1..numberOfSpurs) {
+          val spur = ResidentialLocation(
+            prisonId = prisonId,
+            code = "$spurNumber",
+            locationType = LocationType.SPUR,
+            pathHierarchy = "${landing.getPathHierarchy()}-$spurNumber",
+            description = "Spur $spurNumber on Landing ${landing.getCode()}",
+            orderWithinParentLocation = spurNumber,
+            createdBy = createdBy,
+            whenCreated = LocalDateTime.now(clock),
+            childLocations = mutableListOf(),
+          )
+          landing.addChildLocation(spur)
+          LocationService.log.info("Created Spur [${spur.getKey()}]")
+        }
+      }
+    }
+
+    wing.findAllLeafLocations().forEach { leaf ->
+      for (cellNumber in 1..numberOfCellsPerSection) {
+        val code = "%03d".format(cellNumber)
+        val cell = Cell(
+          prisonId = prisonId,
+          code = code,
+          pathHierarchy = "${leaf.getPathHierarchy()}-$code",
+          description = "Cell $cellNumber on ${leaf.getCode()}",
+          orderWithinParentLocation = cellNumber,
+          createdBy = createdBy,
+          whenCreated = LocalDateTime.now(clock),
+          childLocations = mutableListOf(),
+          capacity = Capacity(
+            capacity = defaultCellCapacity,
+            operationalCapacity = defaultCellCapacity,
+          ),
+          certification = Certification(
+            certified = true,
+            capacityOfCertifiedCell = defaultCellCapacity,
+          ),
+        )
+        defaultAttributesOfCells?.map { cell.addAttribute(it) }
+        leaf.addChildLocation(cell)
+        LocationService.log.info("Created Cell [${cell.getKey()}]")
+      }
+    }
+    return wing
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -71,7 +71,11 @@ data class Location(
   @Schema(description = "Reason for deactivation", example = "DAMAGED", required = false)
   val deactivatedReason: DeactivatedReason? = null,
 
-  @Schema(description = "Date the location was reactivated", example = "2023-01-24", required = false)
+  @Schema(description = "Proposed Date for location reactivation", example = "2026-01-24", required = false)
+  val proposedReactivationDate: LocalDate? = null,
+
+  @Schema(description = "Date the location was reactivated (deprecated)", example = "2023-01-24", required = false)
+  @Deprecated("Use proposedReactivationDate instead")
   val reactivatedDate: LocalDate? = null,
 
   @Schema(description = "Top Level Location Id", example = "57718979-573c-433a-9e51-2d83f887c11c", required = true)
@@ -285,7 +289,6 @@ data class CreateResidentialLocationRequest(
   override fun toNewEntity(createdBy: String, clock: Clock): ResidentialLocationJPA {
     return if (locationType == LocationType.CELL) {
       val location = CellJPA(
-        id = null,
         prisonId = prisonId,
         code = code,
         locationType = locationType,
@@ -294,15 +297,9 @@ data class CreateResidentialLocationRequest(
         residentialHousingType = residentialHousingType,
         comments = comments,
         orderWithinParentLocation = orderWithinParentLocation,
-        active = true,
-        updatedBy = createdBy,
+        createdBy = createdBy,
         whenCreated = LocalDateTime.now(clock),
-        whenUpdated = LocalDateTime.now(clock),
-        deactivatedDate = null,
-        deactivatedReason = null,
-        proposedReactivationDate = null,
         childLocations = mutableListOf(),
-        parent = null,
         capacity = capacity?.let { CapacityJPA(capacity = it.capacity, operationalCapacity = it.operationalCapacity) },
         certification = certification?.let {
           CertificationJPA(
@@ -326,15 +323,9 @@ data class CreateResidentialLocationRequest(
         residentialHousingType = residentialHousingType,
         comments = comments,
         orderWithinParentLocation = orderWithinParentLocation,
-        active = true,
-        updatedBy = createdBy,
+        createdBy = createdBy,
         whenCreated = LocalDateTime.now(clock),
-        whenUpdated = LocalDateTime.now(clock),
-        deactivatedDate = null,
-        deactivatedReason = null,
-        proposedReactivationDate = null,
         childLocations = mutableListOf(),
-        parent = null,
       )
     }
   }
@@ -384,15 +375,9 @@ data class CreateNonResidentialLocationRequest(
       description = description,
       comments = comments,
       orderWithinParentLocation = orderWithinParentLocation,
-      active = true,
-      updatedBy = createdBy,
+      createdBy = createdBy,
       whenCreated = LocalDateTime.now(clock),
-      whenUpdated = LocalDateTime.now(clock),
-      deactivatedDate = null,
-      deactivatedReason = null,
-      reactivatedDate = null,
       childLocations = mutableListOf(),
-      parent = null,
     )
     usage?.forEach { usage ->
       location.addUsage(usage.usageType, usage.capacity, usage.sequence)
@@ -410,5 +395,5 @@ data class DeactivationLocationRequest(
   @Schema(description = "Reason for deactivation", example = "DAMAGED", required = true)
   val deactivationReason: DeactivatedReason,
   @Schema(description = "Proposed re-activation date", example = "2025-01-05", required = false)
-  val reactivationDate: LocalDate? = null,
+  val proposedReactivationDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpsertLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpsertLocationRequest.kt
@@ -92,9 +92,8 @@ data class UpsertLocationRequest(
           comments = comments,
           orderWithinParentLocation = orderWithinParentLocation,
           active = true,
-          updatedBy = lastUpdatedBy,
+          createdBy = lastUpdatedBy,
           whenCreated = createDate ?: now,
-          whenUpdated = lastModifiedDate ?: now,
           deactivatedDate = null,
           deactivatedReason = null,
           proposedReactivationDate = null,
@@ -119,7 +118,6 @@ data class UpsertLocationRequest(
         location
       } else {
         ResidentialLocation(
-          id = null,
           prisonId = prisonId,
           code = code,
           locationType = locationType,
@@ -128,20 +126,13 @@ data class UpsertLocationRequest(
           residentialHousingType = residentialHousingType,
           comments = comments,
           orderWithinParentLocation = orderWithinParentLocation,
-          active = true,
-          updatedBy = lastUpdatedBy,
+          createdBy = lastUpdatedBy,
           whenCreated = createDate ?: now,
-          whenUpdated = lastModifiedDate ?: now,
-          deactivatedDate = null,
-          deactivatedReason = null,
-          proposedReactivationDate = null,
           childLocations = mutableListOf(),
-          parent = null,
         )
       }
     } else {
       val location = NonResidentialLocation(
-        id = null,
         prisonId = prisonId,
         code = code,
         locationType = locationType,
@@ -150,14 +141,9 @@ data class UpsertLocationRequest(
         comments = comments,
         orderWithinParentLocation = orderWithinParentLocation,
         active = true,
-        updatedBy = lastUpdatedBy,
+        createdBy = lastUpdatedBy,
         whenCreated = createDate ?: now,
-        whenUpdated = lastModifiedDate ?: now,
-        deactivatedDate = null,
-        deactivatedReason = null,
-        reactivatedDate = null,
         childLocations = mutableListOf(),
-        parent = null,
       )
       usage?.forEach { usage ->
         location.addUsage(usage.usageType, usage.capacity, usage.sequence)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -16,24 +16,23 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Location as Locati
 @Entity
 @DiscriminatorValue("CELL")
 class Cell(
-  id: UUID?,
+  id: UUID? = null,
   code: String,
   pathHierarchy: String,
-  locationType: LocationType,
+  locationType: LocationType = LocationType.CELL,
   prisonId: String,
-  parent: Location?,
-  description: String?,
-  comments: String?,
-  orderWithinParentLocation: Int?,
-  active: Boolean,
-  deactivatedDate: LocalDate?,
-  deactivatedReason: DeactivatedReason?,
-  proposedReactivationDate: LocalDate?,
+  parent: Location? = null,
+  description: String? = null,
+  comments: String? = null,
+  orderWithinParentLocation: Int? = null,
+  active: Boolean = true,
+  deactivatedDate: LocalDate? = null,
+  deactivatedReason: DeactivatedReason? = null,
+  proposedReactivationDate: LocalDate? = null,
   childLocations: MutableList<Location>,
   whenCreated: LocalDateTime,
-  whenUpdated: LocalDateTime,
-  updatedBy: String,
-  residentialHousingType: ResidentialHousingType,
+  createdBy: String,
+  residentialHousingType: ResidentialHousingType = ResidentialHousingType.NORMAL_ACCOMMODATION,
 
   @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], optional = true, orphanRemoval = true)
   var capacity: Capacity? = null,
@@ -60,8 +59,7 @@ class Cell(
   proposedReactivationDate = proposedReactivationDate,
   childLocations = childLocations,
   whenCreated = whenCreated,
-  whenUpdated = whenUpdated,
-  updatedBy = updatedBy,
+  createdBy = createdBy,
   residentialHousingType = residentialHousingType,
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -188,6 +188,7 @@ abstract class Location(
       active = active,
       deactivatedDate = deactivatedDate,
       deactivatedReason = deactivatedReason,
+      proposedReactivationDate = proposedReactivationDate,
       reactivatedDate = proposedReactivationDate,
       childLocations = if (includeChildren) childLocations.map { it.toDto(includeChildren = true, includeHistory = includeHistory) } else null,
       parentLocation = if (includeParent) getParent()?.toDto(includeChildren = false, includeParent = true, includeHistory = includeHistory) else null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -15,23 +15,22 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Location as Locati
 @Entity
 @DiscriminatorValue("NON_RESIDENTIAL")
 class NonResidentialLocation(
-  id: UUID?,
+  id: UUID? = null,
   code: String,
   pathHierarchy: String,
   locationType: LocationType,
   prisonId: String,
-  parent: Location?,
-  description: String?,
-  comments: String?,
-  orderWithinParentLocation: Int?,
-  active: Boolean,
-  deactivatedDate: LocalDate?,
-  deactivatedReason: DeactivatedReason?,
-  reactivatedDate: LocalDate?,
+  parent: Location? = null,
+  description: String? = null,
+  comments: String? = null,
+  orderWithinParentLocation: Int? = 1,
+  active: Boolean = true,
+  deactivatedDate: LocalDate? = null,
+  deactivatedReason: DeactivatedReason? = null,
+  proposedReactivationDate: LocalDate? = null,
   childLocations: MutableList<Location>,
   whenCreated: LocalDateTime,
-  whenUpdated: LocalDateTime,
-  updatedBy: String,
+  createdBy: String,
 
   @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   private val nonResidentialUsages: MutableSet<NonResidentialUsage> = mutableSetOf(),
@@ -49,11 +48,11 @@ class NonResidentialLocation(
   active = active,
   deactivatedDate = deactivatedDate,
   deactivatedReason = deactivatedReason,
-  proposedReactivationDate = reactivatedDate,
+  proposedReactivationDate = proposedReactivationDate,
   childLocations = childLocations,
   whenCreated = whenCreated,
-  whenUpdated = whenUpdated,
-  updatedBy = updatedBy,
+  whenUpdated = whenCreated,
+  updatedBy = createdBy,
 ) {
 
   fun addUsage(usageType: NonResidentialUsageType, capacity: Int? = null, sequence: Int = 99): NonResidentialUsage {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -16,26 +16,25 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Location as Locati
 @Entity
 @DiscriminatorValue("RESIDENTIAL")
 open class ResidentialLocation(
-  id: UUID?,
+  id: UUID? = null,
   code: String,
   pathHierarchy: String,
   locationType: LocationType,
   prisonId: String,
-  parent: Location?,
-  description: String?,
-  comments: String?,
-  orderWithinParentLocation: Int?,
-  active: Boolean,
-  deactivatedDate: LocalDate?,
-  deactivatedReason: DeactivatedReason?,
-  proposedReactivationDate: LocalDate?,
+  parent: Location? = null,
+  description: String? = null,
+  comments: String? = null,
+  orderWithinParentLocation: Int? = 1,
+  active: Boolean = true,
+  deactivatedDate: LocalDate? = null,
+  deactivatedReason: DeactivatedReason? = null,
+  proposedReactivationDate: LocalDate? = null,
   childLocations: MutableList<Location>,
   whenCreated: LocalDateTime,
-  whenUpdated: LocalDateTime,
-  updatedBy: String,
+  createdBy: String,
 
   @Enumerated(EnumType.STRING)
-  var residentialHousingType: ResidentialHousingType,
+  var residentialHousingType: ResidentialHousingType = ResidentialHousingType.NORMAL_ACCOMMODATION,
 
 ) : Location(
   id = id,
@@ -53,8 +52,8 @@ open class ResidentialLocation(
   proposedReactivationDate = proposedReactivationDate,
   childLocations = childLocations,
   whenCreated = whenCreated,
-  whenUpdated = whenUpdated,
-  updatedBy = updatedBy,
+  whenUpdated = whenCreated,
+  updatedBy = createdBy,
 ) {
 
   private fun getOperationalCapacity(): Int {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateNonResidentialLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateResidentialLocationRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateWingRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.DeactivationLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PatchLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.AuditType
@@ -253,6 +254,53 @@ class LocationResource(
     )
   }
 
+  @PostMapping("/create-wing", produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasRole('ROLE_MAINTAIN_LOCATIONS') and hasAuthority('SCOPE_write')")
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(
+    summary = "Creates a residential wing with landings and cells",
+    description = "Requires role MAINTAIN_LOCATIONS and write scope",
+    responses = [
+      ApiResponse(
+        responseCode = "201",
+        description = "Returns created locations",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid Request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MAINTAIN_LOCATIONS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "Location already exists",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun createWing(
+    @RequestBody
+    @Validated
+    createWingRequest: CreateWingRequest,
+  ): LocationDTO {
+    return eventPublishAndAudit(
+      InternalLocationDomainEventType.LOCATION_CREATED,
+      {
+        locationService.createWing(createWingRequest)
+      },
+      InformationSource.DPS,
+    )
+  }
+
   @PostMapping("/non-residential", produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasRole('ROLE_MAINTAIN_LOCATIONS') and hasAuthority('SCOPE_write')")
   @ResponseStatus(HttpStatus.CREATED)
@@ -418,7 +466,7 @@ class LocationResource(
         locationService.deactivateLocation(
           id,
           deactivatedReason = deactivationLocationRequest.deactivationReason,
-          proposedReactivationDate = deactivationLocationRequest.reactivationDate,
+          proposedReactivationDate = deactivationLocationRequest.proposedReactivationDate,
         )
       },
       InformationSource.DPS,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateNonResidentialLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateResidentialLocationRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateWingRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PatchLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
@@ -26,7 +27,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.utils.AuthenticationFa
 import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 import kotlin.jvm.optionals.getOrNull
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Location as LocationDTO
 
@@ -101,6 +102,15 @@ class LocationService(
     )
 
     return location
+  }
+
+  @Transactional
+  fun createWing(createWingRequest: CreateWingRequest): LocationDTO {
+    locationRepository.findOneByPrisonIdAndPathHierarchy(createWingRequest.prisonId, createWingRequest.wingCode)
+      ?.let { throw LocationAlreadyExistsException("${createWingRequest.prisonId}-${createWingRequest.wingCode}") }
+
+    val wing = createWingRequest.toEntity(authenticationFacade.getUserOrSystemInContext(), clock)
+    return locationRepository.save(wing).toDto(includeChildren = true)
   }
 
   @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationBuilder.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialAttributeValue
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialHousingType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.EXPECTED_USERNAME
 import java.time.LocalDateTime
@@ -23,20 +22,10 @@ fun buildResidentialLocation(
     code = pathHierarchy.split("-").last(),
     pathHierarchy = pathHierarchy,
     locationType = locationType,
-    updatedBy = EXPECTED_USERNAME,
+    createdBy = EXPECTED_USERNAME,
     whenCreated = LocalDateTime.now(TestBase.clock),
-    whenUpdated = LocalDateTime.now(TestBase.clock),
-    deactivatedDate = null,
-    deactivatedReason = null,
-    proposedReactivationDate = null,
     childLocations = mutableListOf(),
-    parent = null,
-    active = true,
-    description = null,
-    comments = null,
     orderWithinParentLocation = 99,
-    residentialHousingType = ResidentialHousingType.NORMAL_ACCOMMODATION,
-    id = null,
   )
 }
 
@@ -51,23 +40,12 @@ fun buildCell(
     prisonId = prisonId,
     code = pathHierarchy.split("-").last(),
     pathHierarchy = pathHierarchy,
-    locationType = LocationType.CELL,
-    updatedBy = EXPECTED_USERNAME,
+    createdBy = EXPECTED_USERNAME,
     whenCreated = LocalDateTime.now(TestBase.clock),
-    whenUpdated = LocalDateTime.now(TestBase.clock),
-    deactivatedDate = null,
-    deactivatedReason = null,
-    proposedReactivationDate = null,
     childLocations = mutableListOf(),
-    parent = null,
-    active = true,
-    description = null,
-    comments = null,
     orderWithinParentLocation = 99,
-    residentialHousingType = ResidentialHousingType.NORMAL_ACCOMMODATION,
     capacity = capacity,
     certification = certification,
-    id = null,
   )
   cell.addAttributes(residentialAttributeValues)
   return cell
@@ -75,7 +53,7 @@ fun buildCell(
 fun buildNonResidentialLocation(
   prisonId: String = "MDI",
   pathHierarchy: String,
-  locationType: LocationType = LocationType.CELL,
+  locationType: LocationType,
   nonResidentialUsageType: NonResidentialUsageType,
 ): NonResidentialLocation {
   val nonResidentialLocationJPA = NonResidentialLocation(
@@ -83,19 +61,10 @@ fun buildNonResidentialLocation(
     code = pathHierarchy.split("-").last(),
     pathHierarchy = pathHierarchy,
     locationType = locationType,
-    updatedBy = EXPECTED_USERNAME,
+    createdBy = EXPECTED_USERNAME,
     whenCreated = LocalDateTime.now(TestBase.clock),
-    whenUpdated = LocalDateTime.now(TestBase.clock),
-    deactivatedDate = null,
-    deactivatedReason = null,
-    reactivatedDate = null,
     childLocations = mutableListOf(),
-    parent = null,
-    active = true,
-    description = null,
-    comments = null,
     orderWithinParentLocation = 99,
-    id = null,
   )
   nonResidentialLocationJPA.addUsage(nonResidentialUsageType, 15, 1)
   return nonResidentialLocationJPA

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepositoryTest.kt
@@ -134,8 +134,7 @@ class LocationRepositoryTest : TestBase() {
       prisonId = prisonId,
       locationType = locationType,
       active = active,
-      updatedBy = SYSTEM_USERNAME,
-      whenUpdated = now,
+      createdBy = SYSTEM_USERNAME,
       whenCreated = now,
       parent = parent,
       description = "$locationType $prisonId $pathHierarchy",
@@ -145,8 +144,7 @@ class LocationRepositoryTest : TestBase() {
       residentialHousingType = ResidentialHousingType.NORMAL_ACCOMMODATION,
       comments = "comments",
       childLocations = mutableListOf(),
-      deactivatedReason = null,
-      id = null,
+
     )
   }
 
@@ -164,8 +162,7 @@ class LocationRepositoryTest : TestBase() {
       prisonId = prisonId,
       locationType = LocationType.CELL,
       active = active,
-      updatedBy = SYSTEM_USERNAME,
-      whenUpdated = now,
+      createdBy = SYSTEM_USERNAME,
       whenCreated = now,
       parent = parent,
       capacity = Capacity(capacity = 1, operationalCapacity = 1),
@@ -177,8 +174,6 @@ class LocationRepositoryTest : TestBase() {
       residentialHousingType = ResidentialHousingType.NORMAL_ACCOMMODATION,
       comments = "comments",
       childLocations = mutableListOf(),
-      deactivatedReason = null,
-      id = null,
     )
     location.addAttributes(residentialAttributeValues)
     return location
@@ -198,18 +193,13 @@ class LocationRepositoryTest : TestBase() {
       prisonId = prisonId,
       locationType = locationType,
       active = active,
-      updatedBy = SYSTEM_USERNAME,
-      whenUpdated = now,
+      createdBy = SYSTEM_USERNAME,
       whenCreated = now,
       parent = parent,
       description = "$locationType $prisonId $pathHierarchy",
-      deactivatedDate = null,
-      reactivatedDate = null,
       orderWithinParentLocation = 1,
       comments = "Non Res comments",
       childLocations = mutableListOf(),
-      deactivatedReason = null,
-      id = null,
     )
     location.addUsage(NonResidentialUsageType.ADJUDICATION_HEARING)
     return location


### PR DESCRIPTION
This commit introduces a feature for creating prison wings with defined landings and cells. This implementation also includes unit tests for the functions added, ensuring the correct status responses are returned. As part of this new feature, the request body validation has been included to prevent incorrect requests or the creation of duplicate locations. Additionally, a minor typo fix in a variable name from `reactivationDate` to `proposedReactivationDate` was implemented.