### PR TITLE
MAP-862 Fix event type in EventPublishAndAuditService

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/EventPublishAndAuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/EventPublishAndAuditService.kt
@@ -37,7 +37,7 @@ class EventPublishAndAuditService(
     traverseUp(eventType = InternalLocationDomainEventType.LOCATION_AMENDED, location = locationDetail.parentLocation, source = source)
 
     locationDetail.getSubLocations().forEach {
-      publishEvent(event = InternalLocationDomainEventType.LOCATION_AMENDED, location = it, source = source)
+      publishEvent(event = eventType, location = it, source = source)
     }
 
     auditData?.let {


### PR DESCRIPTION

The commit changes the hardcoded event type 'LOCATION_AMENDED' to use the method parameter 'eventType' in the publishEvent calls for sublocations. This ensures the correct event type is sent for each sublocation.