### PR TITLE
MAP-875 Upgrade dependencies in build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,8 @@ import uk.gov.justice.digital.hmpps.gradle.RevealSecretsTask
 
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.3"
-  kotlin("plugin.spring") version "1.9.22"
-  kotlin("plugin.jpa") version "1.9.22"
+  kotlin("plugin.spring") version "1.9.23"
+  kotlin("plugin.jpa") version "1.9.23"
   idea
 }
 
@@ -15,32 +15,32 @@ configurations {
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:0.2.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:0.2.2")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-validation")
 
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:3.1.1")
-  implementation("io.opentelemetry:opentelemetry-api:1.34.1")
-  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:1.32.0")
+  implementation("io.opentelemetry:opentelemetry-api:1.36.0")
+  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.2.0")
 
   implementation("org.flywaydb:flyway-core")
   implementation("com.zaxxer:HikariCP:5.1.0")
   runtimeOnly("org.postgresql:postgresql")
 
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
-  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.16.1")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0")
+  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
 
   developmentOnly("org.springframework.boot:spring-boot-devtools")
 
-  testImplementation("org.wiremock:wiremock-standalone:3.3.1")
+  testImplementation("org.wiremock:wiremock-standalone:3.4.2")
 
   testImplementation("com.pauldijou:jwt-core_2.11:5.0.0")
-  testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
+  testImplementation("org.awaitility:awaitility-kotlin:4.2.1")
   testImplementation("io.jsonwebtoken:jjwt-impl:0.12.5")
   testImplementation("io.jsonwebtoken:jjwt-jackson:0.12.5")
   testImplementation("org.mockito:mockito-inline:5.2.0")
-  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.20")
+  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.21")
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation("org.testcontainers:localstack:1.19.7")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/ResourceSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/ResourceSecurityTest.kt
@@ -53,5 +53,5 @@ class ResourceSecurityTest : SqsIntegrationTestBase() {
 private fun RequestMappingInfo.getMappings() =
   methodsCondition.methods.map { it.name }.flatMap {
       method ->
-    pathPatternsCondition.patternValues.map { "$method $it" }
+    pathPatternsCondition?.patternValues!!.map { "$method $it" }
   }


### PR DESCRIPTION
This update carries out upgrades to versions of used dependencies in the build.gradle.kts file. The changes include, but are not limited to, upgrading Kotlin plugin versions, updating the version of the HMPPS and OpenTelemetry libraries, and advancing test implementation versions.