### PR TITLE
MAP-897 Update Spring Boot Gradle plugin version


### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.gradle.PortForwardRedisTask
 import uk.gov.justice.digital.hmpps.gradle.RevealSecretsTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.3"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.4"
   kotlin("plugin.spring") version "1.9.23"
   kotlin("plugin.jpa") version "1.9.23"
   idea


### PR DESCRIPTION

The version of the Spring Boot Gradle plugin (uk.gov.justice.hmpps.gradle-spring-boot) has been updated from 5.15.3 to 5.15.4 to keep up with the latest improvements and bug fixes.