### PR TITLE
MAP-896 Add deactivation details and update location indexes


### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateLocationRequest.kt
@@ -20,4 +20,5 @@ interface UpdateLocationRequest {
   val deactivationReason: DeactivatedReason?
   val proposedReactivationDate: LocalDate?
   val deactivatedDate: LocalDate?
+  fun isDeactivated() = deactivationReason != null && deactivatedDate != null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateLocationRequest.kt
@@ -20,5 +20,5 @@ interface UpdateLocationRequest {
   val deactivationReason: DeactivatedReason?
   val proposedReactivationDate: LocalDate?
   val deactivatedDate: LocalDate?
-  fun isDeactivated() = deactivationReason != null && deactivatedDate != null
+  fun isDeactivated() = deactivationReason != null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpsertLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpsertLocationRequest.kt
@@ -170,7 +170,7 @@ data class UpsertLocationRequest(
       location
     }
 
-    if (deactivationReason != null) {
+    if (deactivationReason != null && deactivatedDate != null) {
       location.deactivatedReason = deactivationReason
       location.deactivatedDate = deactivatedDate
       location.proposedReactivationDate = proposedReactivationDate

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpsertLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpsertLocationRequest.kt
@@ -105,7 +105,7 @@ data class UpsertLocationRequest(
           code = code,
           locationType = locationType,
           pathHierarchy = code,
-          active = deactivationReason == null,
+          active = !isDeactivated(),
           localName = localName,
           residentialHousingType = residentialHousingType,
           comments = comments,
@@ -140,7 +140,7 @@ data class UpsertLocationRequest(
           code = code,
           locationType = locationType,
           pathHierarchy = code,
-          active = deactivationReason == null,
+          active = !isDeactivated(),
           localName = localName,
           residentialHousingType = residentialHousingType,
           comments = comments,
@@ -156,7 +156,7 @@ data class UpsertLocationRequest(
         code = code,
         locationType = locationType,
         pathHierarchy = code,
-        active = deactivationReason == null,
+        active = !isDeactivated(),
         localName = localName,
         comments = comments,
         orderWithinParentLocation = orderWithinParentLocation,
@@ -170,7 +170,7 @@ data class UpsertLocationRequest(
       location
     }
 
-    if (deactivationReason != null && deactivatedDate != null) {
+    if (isDeactivated()) {
       location.deactivatedReason = deactivationReason
       location.deactivatedDate = deactivatedDate
       location.proposedReactivationDate = proposedReactivationDate

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -182,6 +182,7 @@ class LocationService(
       deactivatedDate = LocalDateTime.now(clock),
       proposedReactivationDate = proposedReactivationDate,
       userOrSystemInContext = authenticationFacade.getUserOrSystemInContext(),
+      clock = clock,
     )
 
     telemetryClient.trackEvent(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -115,6 +115,10 @@ class LocationService(
 
   @Transactional
   fun updateLocation(id: UUID, patchLocationRequest: PatchLocationRequest): UpdateLocationResult {
+    if (patchLocationRequest.deactivationReason != null && patchLocationRequest.deactivatedDate == null) {
+      throw ValidationException("When deactivating a location, the deactivated date must be provided")
+    }
+
     val locationToUpdate = locationRepository.findById(id)
       .orElseThrow { LocationNotFoundException(id.toString()) }
 
@@ -173,7 +177,12 @@ class LocationService(
     val locationToUpdate = locationRepository.findById(id)
       .orElseThrow { LocationNotFoundException(id.toString()) }
 
-    locationToUpdate.deactivate(deactivatedReason, proposedReactivationDate, authenticationFacade.getUserOrSystemInContext(), clock)
+    locationToUpdate.deactivate(
+      deactivatedReason = deactivatedReason,
+      deactivatedDate = LocalDateTime.now(clock),
+      proposedReactivationDate = proposedReactivationDate,
+      userOrSystemInContext = authenticationFacade.getUserOrSystemInContext(),
+    )
 
     telemetryClient.trackEvent(
       "Deactivated Location",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -195,7 +195,7 @@ class LocationService(
       null,
     )
 
-    return locationToUpdate.toDto(includeChildren = false)
+    return locationToUpdate.toDto(includeParent = true)
   }
 
   @Transactional
@@ -215,7 +215,7 @@ class LocationService(
       null,
     )
 
-    return locationToUpdate.toDto(includeChildren = false)
+    return locationToUpdate.toDto(includeParent = true)
   }
 
   private fun buildNewPathHierarchy(parentLocation: Location?, code: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SyncService.kt
@@ -70,10 +70,6 @@ class SyncService(
     val locationToUpdate = locationRepository.findById(upsert.id!!)
       .orElseThrow { LocationNotFoundException(upsert.toString()) }
 
-    if (upsert.deactivationReason != null && upsert.deactivatedDate == null) {
-      throw ValidationException("When deactivating a location, the deactivated date must be provided")
-    }
-
     findParent(upsert)?.let { parent ->
       if (parent.id == locationToUpdate.id) throw ValidationException("Cannot set parent to self")
       locationToUpdate.setParent(parent)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SyncService.kt
@@ -70,6 +70,10 @@ class SyncService(
     val locationToUpdate = locationRepository.findById(upsert.id!!)
       .orElseThrow { LocationNotFoundException(upsert.toString()) }
 
+    if (upsert.deactivationReason != null && upsert.deactivatedDate == null) {
+      throw ValidationException("When deactivating a location, the deactivated date must be provided")
+    }
+
     findParent(upsert)?.let { parent ->
       if (parent.id == locationToUpdate.id) throw ValidationException("Cannot set parent to self")
       locationToUpdate.setParent(parent)

--- a/src/main/resources/db/migration/V1_13__location_indexes.sql
+++ b/src/main/resources/db/migration/V1_13__location_indexes.sql
@@ -1,0 +1,3 @@
+DROP INDEX idx_location_residential_housing_type;
+CREATE INDEX location_housing_type_idx ON location (residential_housing_type, location_type);
+CREATE INDEX location_history_location_id_idx ON location_history (location_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -2228,10 +2228,12 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
             false,
           )
 
-        getDomainEvents(3).let {
+        getDomainEvents(5).let {
           assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
             "location.inside.prison.reactivated" to "MDI-Z",
             "location.inside.prison.deactivated" to "MDI-Z-1-001",
+            "location.inside.prison.amended" to "MDI-Z-1",
+            "location.inside.prison.amended" to "MDI-Z",
             "location.inside.prison.deactivated" to "MDI-Z",
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -372,7 +372,6 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
       orderWithinParentLocation = 1,
       lastUpdatedBy = "user",
       parentLocationPath = "B-1",
-      deactivatedDate = LocalDateTime.now(clock).minusDays(2).toLocalDate(),
       deactivationReason = DeactivatedReason.DAMAGED,
       proposedReactivationDate = LocalDateTime.now(clock).plusMonths(1).toLocalDate(),
       lastModifiedDate = LocalDateTime.now(clock).minusYears(2),
@@ -463,7 +462,6 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
                 "workingCapacity": 1
               },
               "attributes": ["CAT_B"],
-              "deactivatedDate": "${migrateRequest.deactivatedDate}",
               "deactivatedReason": "${migrateRequest.deactivationReason}",
               "proposedReactivationDate": "${migrateRequest.proposedReactivationDate}"
             }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -372,6 +372,9 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
       orderWithinParentLocation = 1,
       lastUpdatedBy = "user",
       parentLocationPath = "B-1",
+      deactivatedDate = LocalDateTime.now(clock).minusDays(2).toLocalDate(),
+      deactivationReason = DeactivatedReason.DAMAGED,
+      proposedReactivationDate = LocalDateTime.now(clock).plusMonths(1).toLocalDate(),
       lastModifiedDate = LocalDateTime.now(clock).minusYears(2),
       capacity = CapacityDTO(1, 1),
       certification = CertificationDTO(true, 1),
@@ -450,7 +453,7 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
               "pathHierarchy": "B-1-002",
               "locationType": "CELL",
               "residentialHousingType": "NORMAL_ACCOMMODATION",
-              "active": true,
+              "active": false,
               "key": "ZZGHI-B-1-002",
               "comments": "This is a new cell",
               "localName": "A New Cell",
@@ -459,7 +462,10 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
                 "maxCapacity": 1,
                 "workingCapacity": 1
               },
-              "attributes": ["CAT_B"]
+              "attributes": ["CAT_B"],
+              "deactivatedDate": "${migrateRequest.deactivatedDate}",
+              "deactivatedReason": "${migrateRequest.deactivationReason}",
+              "proposedReactivationDate": "${migrateRequest.proposedReactivationDate}"
             }
           """,
             false,


### PR DESCRIPTION

Added deactivation details such as deactivatedDate, deactivationReason, and proposedReactivationDate to SyncAndMigrateResourceIntTest and UpsertLocationRequest files. Also created new indexes and dropped the old index in the V1_13__location_indexes.sql file.

In addition to updating the deactivated attribute from active to false for a location, deactivation details are now added to ensure better tracking and management of deactivated locations. Modifying the database indexes is intended to improve query performance related to location and location history.