### PR TITLE
SDIT-1619 Locations reconciliation: history duplicates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -203,8 +203,11 @@ abstract class Location(
         amendedBy = amendedBy,
         amendedDate = amendedDate,
       )
-      history.add(locationHistory)
-      return locationHistory
+      return if (history.add(locationHistory)) {
+        locationHistory
+      } else {
+        null
+      }
     } else {
       null
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -581,6 +581,8 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
           )
           .exchange()
           .expectStatus().isCreated
+          .expectBody()
+          .isEmpty
 
         assertThat(locationHistoryRepository.findAllByLocationIdOrderByAmendedDate(cell.id!!)).hasSize(1)
 
@@ -600,6 +602,8 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
           )
           .exchange()
           .expectStatus().isCreated
+          .expectBody()
+          .jsonPath("$.attribute").isEqualTo("Local Name")
 
         assertThat(locationHistoryRepository.findAllByLocationIdOrderByAmendedDate(cell.id!!)).hasSize(2)
       }


### PR DESCRIPTION
The Nomis reconciliation process has uncovered a problem whereby duplicate history items are getting created in the locations db during a migration.
This change is intended to flag them.