### PR TITLE
MAP-1095 new endpoint to get active locations by their path hierarchy

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
@@ -14,5 +14,5 @@ interface LocationRepository : JpaRepository<Location, UUID> {
 
   fun findAllByPrisonIdAndLocationTypeOrderByPathHierarchy(prisonId: String, locationType: LocationType): List<Location>
 
-  fun findAllByPathHierarchyIn(pathHierarchy: List<String>): List<Location>
+  fun findAllByPrisonIdAndPathHierarchyIsIn(prisonId: String, pathHierarchy: List<String>): List<Location>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
@@ -13,4 +13,6 @@ interface LocationRepository : JpaRepository<Location, UUID> {
   fun findOneByPrisonIdAndPathHierarchy(prisonId: String, pathHierarchy: String): Location?
 
   fun findAllByPrisonIdAndLocationTypeOrderByPathHierarchy(prisonId: String, locationType: LocationType): List<Location>
+
+  fun findAllByPathHierarchyIn(pathHierarchy: List<String>): List<Location>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
@@ -15,4 +16,7 @@ interface LocationRepository : JpaRepository<Location, UUID> {
   fun findAllByPrisonIdAndLocationTypeOrderByPathHierarchy(prisonId: String, locationType: LocationType): List<Location>
 
   fun findAllByPrisonIdAndPathHierarchyIsIn(prisonId: String, pathHierarchy: List<String>): List<Location>
+
+  @Query("select l from Location l where concat(l.prisonId,'-',l.pathHierarchy) IN (:keys)")
+  fun findAllByKeys(keys: List<String>): List<Location>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
@@ -15,8 +15,6 @@ interface LocationRepository : JpaRepository<Location, UUID> {
 
   fun findAllByPrisonIdAndLocationTypeOrderByPathHierarchy(prisonId: String, locationType: LocationType): List<Location>
 
-  fun findAllByPrisonIdAndPathHierarchyIsIn(prisonId: String, pathHierarchy: List<String>): List<Location>
-
   @Query("select l from Location l where concat(l.prisonId,'-',l.pathHierarchy) IN (:keys)")
   fun findAllByKeys(keys: List<String>): List<Location>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
@@ -169,8 +169,6 @@ class LocationResource(
     @RequestBody
     @Validated
     keys: List<String>,
-    @RequestParam(name = "includeChildren", required = false, defaultValue = "false") includeChildren: Boolean = false,
-    @RequestParam(name = "includeHistory", required = false, defaultValue = "false") includeHistory: Boolean = false,
   ): List<LocationDTO> = locationService.getLocationsByKeys(keys)
 
   @GetMapping("/prison/{prisonId}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
@@ -132,6 +132,47 @@ class LocationResource(
   ) =
     locationService.getLocationByKey(key = key, includeChildren = includeChildren, includeHistory = includeHistory) ?: throw LocationNotFoundException(key)
 
+  @PostMapping("/keys", produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "Gets locations by their keys",
+    description = "Requires role VIEW_LOCATIONS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns location",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid Request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MAINTAIN_LOCATIONS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getLocationsByKeys(
+    @RequestBody
+    @Validated
+    keys: List<String>,
+    @RequestParam(name = "includeChildren", required = false, defaultValue = "false") includeChildren: Boolean = false,
+    @RequestParam(name = "includeHistory", required = false, defaultValue = "false") includeHistory: Boolean = false,
+  ): List<LocationDTO> = locationService.getLocationsByKeys(keys, includeChildren, includeHistory)
+
   @GetMapping("/prison/{prisonId}")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
@@ -171,7 +171,7 @@ class LocationResource(
     keys: List<String>,
     @RequestParam(name = "includeChildren", required = false, defaultValue = "false") includeChildren: Boolean = false,
     @RequestParam(name = "includeHistory", required = false, defaultValue = "false") includeHistory: Boolean = false,
-  ): List<LocationDTO> = locationService.getLocationsByKeys(keys, includeChildren, includeHistory)
+  ): List<LocationDTO> = locationService.getLocationsByKeys(keys)
 
   @GetMapping("/prison/{prisonId}")
   @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -77,6 +77,13 @@ class LocationService(
     return locationRepository.findOneByPrisonIdAndPathHierarchy(prisonId, code)?.toDto(includeChildren = includeChildren, includeHistory = includeHistory)
   }
 
+  fun getLocationsByKeys(keys: List<String>, includeChildren: Boolean = false, includeHistory: Boolean = false): List<LocationDTO> {
+    return locationRepository
+      .findAllByPathHierarchyIn(keys.filter { it.contains("-") })
+      .filter { it.isActive() }
+      .map { it.toDto(includeChildren = includeChildren, includeHistory = includeHistory) }
+  }
+
   fun getLocations(pageable: Pageable = PageRequest.of(0, 20, Sort.by("id"))): Page<LocationDTO> {
     return locationRepository.findAll(pageable).map(Location::toDto)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -982,71 +982,52 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
 
       @Test
       fun `can retrieve locations from a list of keys`() {
-        webTestClient.post().uri("/locations/keys?includeChildren=true")
+        webTestClient.post().uri("/locations/keys")
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
           .header("Content-Type", "application/json")
-          .bodyValue(listOf("B-A", "B-A-001", "MDI-Z", "Z", "Z-2", "Z-VISIT", "Z-1-003", "XYZ-1-2-3"))
+          .bodyValue(listOf("MDI-B-A", "MDI-B-A-001", "MDI-Z", "MDI-Z", "MDI-Z-2", "MDI-Z-VISIT", "MDI-Z-1-003", "XYZ-1-2-3"))
           .exchange()
           .expectStatus().isOk
           .expectBody().json(
             // language=json
             """
-                        [{
-                          "prisonId": "MDI",
-                          "code": "Z",
-                          "pathHierarchy": "Z",
-                          "permanentlyInactive": false,
-                          "active": true,
-                          "childLocations": [{
+                          [{
                             "prisonId": "MDI",
-                            "code": "VISIT",
-                            "pathHierarchy": "Z-VISIT",
-                            "locationType": "VISITS",
-                            "active": true,
-                            "childLocations": [],
-                            "key": "MDI-Z-VISIT",
-                            "isResidential": false
+                            "code": "A",
+                            "pathHierarchy": "B-A",
+                            "key": "MDI-B-A"
+                          }, 
+                          {
+                          
+                            "prisonId": "MDI",
+                            "code": "001",
+                            "pathHierarchy": "B-A-001",
+                            "key": "MDI-B-A-001"
                           }, 
                           {
                             "prisonId": "MDI",
-                            "code": "1",
-                            "pathHierarchy": "Z-1",
-                            "locationType": "LANDING",
-                            "active": true,
-                            "childLocations": [{
-                              "prisonId": "MDI",
-                              "code": "001",
-                              "pathHierarchy": "Z-1-001",
-                              "locationType": "CELL",
-                              "active": true,
-                              "childLocations": [],
-                              "key": "MDI-Z-1-001",
-                              "isResidential": true
-                            }, {
-                              "prisonId": "MDI",
-                              "code": "002",
-                              "pathHierarchy": "Z-1-002",
-                              "locationType": "CELL",
-                              "active": true,
-                              "deactivatedByParent": false,
-                              "childLocations": [],
-                              "key": "MDI-Z-1-002",
-                              "isResidential": true
-                            }],
-                            "key": "MDI-Z-1",
-                            "isResidential": true
+                            "code": "Z",
+                            "pathHierarchy": "Z",
+                            "key": "MDI-Z"
+                          }, 
+                          {
+                            "prisonId": "MDI",
+                            "code": "003",
+                            "pathHierarchy": "Z-1-003",
+                            "key": "MDI-Z-1-003"
                           }, 
                           {
                             "prisonId": "MDI",
                             "code": "2",
                             "pathHierarchy": "Z-2",
-                            "locationType": "LANDING",
-                            "active": true,
-                            "childLocations": [],
-                            "key": "MDI-Z-2",
-                            "isResidential": true
+                            "key": "MDI-Z-2"
+                          }, 
+                          {
+                            "prisonId": "MDI",
+                            "code": "VISIT",
+                            "pathHierarchy": "Z-VISIT",
+                            "key": "MDI-Z-VISIT"
                           }]
-                        }]
                          """,
             false,
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -991,51 +991,62 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
           .expectBody().json(
             // language=json
             """
-                          [{
+                        [{
+                          "prisonId": "MDI",
+                          "code": "Z",
+                          "pathHierarchy": "Z",
+                          "permanentlyInactive": false,
+                          "active": true,
+                          "childLocations": [{
                             "prisonId": "MDI",
                             "code": "VISIT",
                             "pathHierarchy": "Z-VISIT",
                             "locationType": "VISITS",
-                            "orderWithinParentLocation": 99,
-                            "status": "ACTIVE",
                             "active": true,
                             "childLocations": [],
                             "key": "MDI-Z-VISIT",
                             "isResidential": false
-                            }, 
-                            {
+                          }, 
+                          {
+                            "prisonId": "MDI",
+                            "code": "1",
+                            "pathHierarchy": "Z-1",
+                            "locationType": "LANDING",
+                            "active": true,
+                            "childLocations": [{
+                              "prisonId": "MDI",
+                              "code": "001",
+                              "pathHierarchy": "Z-1-001",
+                              "locationType": "CELL",
+                              "active": true,
+                              "childLocations": [],
+                              "key": "MDI-Z-1-001",
+                              "isResidential": true
+                            }, {
+                              "prisonId": "MDI",
+                              "code": "002",
+                              "pathHierarchy": "Z-1-002",
+                              "locationType": "CELL",
+                              "active": true,
+                              "deactivatedByParent": false,
+                              "childLocations": [],
+                              "key": "MDI-Z-1-002",
+                              "isResidential": true
+                            }],
+                            "key": "MDI-Z-1",
+                            "isResidential": true
+                          }, 
+                          {
                             "prisonId": "MDI",
                             "code": "2",
                             "pathHierarchy": "Z-2",
                             "locationType": "LANDING",
                             "active": true,
                             "childLocations": [],
-                            "lastModifiedBy": "A_TEST_USER",
                             "key": "MDI-Z-2",
                             "isResidential": true
-                            }, 
-                            {
-                            "prisonId": "MDI",
-                            "code": "A",
-                            "pathHierarchy": "B-A",
-                            "locationType": "LANDING",
-                            "active": true,
-                            "childLocations": [{
-                              "prisonId": "MDI",
-                              "code": "001",
-                              "pathHierarchy": "B-A-001",
-                              "locationType": "CELL",
-                              "active": false,
-                              "deactivatedByParent": false,
-                              "deactivatedDate": "2023-12-05",
-                              "deactivatedReason": "DAMAGED",
-                              "childLocations": [],
-                              "key": "MDI-B-A-001",
-                              "isResidential": true
-                            }],
-                            "key": "MDI-B-A",
-                            "isResidential": true
                           }]
+                        }]
                          """,
             false,
           )


### PR DESCRIPTION
ticket:
_POST prisonLocationsByKeys(keys[]): Location[], to get the location descriptions for a list of keys provided in one call, for when we show lists of video bookings. Useful if this could avoid being specific to one prison because there could be a use-case where one video booking could have 2 or more prisoners, in different prisons, as co-defendants._ 

btw, should locationResourceIntTest.kt Line 160 say landing1 as the inactive cell is on landing 1 not landing 3?