### PR TITLE
MAP-1202 🐛 Update wheelchair accessible cells in DB

### DIFF
--- a/src/main/resources/db/migration/V1_29__data_fix_wheelchair.sql
+++ b/src/main/resources/db/migration/V1_29__data_fix_wheelchair.sql
@@ -1,0 +1,6 @@
+UPDATE specialist_cell ra
+set specialist_cell_type = 'ACCESSIBLE_CELL' WHERE specialist_cell_type = 'WHEELCHAIR_ACCESSIBLE'
+                                               and not exists (select 1 from specialist_cell sc where sc.location_id = ra.location_id and sc.specialist_cell_type = 'ACCESSIBLE_CELL');
+
+delete  from specialist_cell where specialist_cell_type = 'WHEELCHAIR_ACCESSIBLE';
+


### PR DESCRIPTION
This PR updates specialist_cell records in the database where the specialist_cell_type is 'WHEELCHAIR_ACCESSIBLE', setting them to 'ACCESSIBLE_CELL'. It also removes any lingering records with the 'WHEELCHAIR_ACCESSIBLE' type to ensure data consistency.
