### PR TITLE
MAP-1030 changed dto to use code and do sort

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.NomisSyncLocationR
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.capitalizeWords
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.helper.GeneratedUuidV7
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationCannotBeReactivatedException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.NaturalOrderComparator
 import java.io.Serializable
 import java.time.Clock
 import java.time.LocalDate
@@ -360,11 +361,12 @@ abstract class Location(
 
   fun toLocationGroupDto(): LocationGroupDto {
     return LocationGroupDto(
-      key = pathHierarchy,
+      key = code,
       name = getDerivedLocalName(),
       children = getActiveResidentialLocationsBelowThisLevel()
         .filter { it.isWingLandingSpur() }
-        .map { it.toLocationGroupDto() },
+        .map { it.toLocationGroupDto() }
+        .sortedWith(NaturalOrderComparator()),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -1562,7 +1562,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                   "children": [
                     {
                       "name": "Landing A",
-                      "key": "A-1",
+                      "key": "1",
                       "children": []
                     }
                   ]


### PR DESCRIPTION
refactored so that dto has same data and structure as the corresponding dto in whereaboutsApi
The two should match but currently in the case of the location api, the dto didn't sort children and the key value for the group didn't match