### PR TITLE
MAP-1030 provide alternative value for dto.name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -362,7 +362,7 @@ abstract class Location(
   fun toLocationGroupDto(): LocationGroupDto {
     return LocationGroupDto(
       key = code,
-      name = getDerivedLocalName()?: code,
+      name = getDerivedLocalName() ?: code,
       children = getActiveResidentialLocationsBelowThisLevel()
         .filter { it.isWingLandingSpur() }
         .map { it.toLocationGroupDto() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -362,7 +362,7 @@ abstract class Location(
   fun toLocationGroupDto(): LocationGroupDto {
     return LocationGroupDto(
       key = code,
-      name = getDerivedLocalName(),
+      name = getDerivedLocalName()?: code,
       children = getActiveResidentialLocationsBelowThisLevel()
         .filter { it.isWingLandingSpur() }
         .map { it.toLocationGroupDto() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationTest.kt
@@ -52,7 +52,6 @@ fun generateWingLocation(localName: String?) = ResidentialLocation(
   childLocations = mutableListOf(),
 )
 
-
 fun generateCellLocation() = Cell(
   code = "001",
   prisonId = "MDI",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationTest.kt
@@ -25,7 +25,33 @@ class LocationTest {
     assertThat(history1).isEqualTo(history2)
     assertThat(location.getHistoryAsList()).hasSize(1)
   }
+
+  @Test
+  fun `toLocationGroupDto sets name to code`() {
+    val location = generateWingLocation(null)
+    val dto = location.toLocationGroupDto()
+    assertThat(dto.name).isEqualTo("A")
+  }
+
+  @Test
+  fun `toLocationGroupDto sets name to local name`() {
+    val location = generateWingLocation("Wing A")
+    val dto = location.toLocationGroupDto()
+    assertThat(dto.name).isEqualTo("Wing A")
+  }
 }
+
+fun generateWingLocation(localName: String?) = ResidentialLocation(
+  code = "A",
+  prisonId = "MDI",
+  locationType = LocationType.WING,
+  localName = localName,
+  pathHierarchy = "MDI-A",
+  createdBy = "user",
+  whenCreated = LocalDateTime.now(),
+  childLocations = mutableListOf(),
+)
+
 
 fun generateCellLocation() = Cell(
   code = "001",


### PR DESCRIPTION
This is to display an alternative when 'localName'  has not been set for a wing/landing/spur