### PR TITLE
MAP-1284 Increase database pool size and add max lifetime

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,7 +57,8 @@ spring:
     password: ${DATABASE_PASSWORD}
     hikari:
       pool-name: LIP-DB-CP
-      maximum-pool-size: 10
+      maximum-pool-size: 20
+      max-lifetime: 600000
       connection-timeout: 1000
       validation-timeout: 500
 


### PR DESCRIPTION
In the application configuration, the maximum pool size for the database connection has been increased from 10 to 20. Additionally, a new max lifetime setting has been introduced at a value of 600000ms, aiming to improve the application's management of database connections.