### PR TITLE
MAP-1285 Remove standard accommodations from non-normal types

### DIFF
--- a/src/main/resources/db/migration/V1_31__remove_standard_accommodation_from_non_normal.sql
+++ b/src/main/resources/db/migration/V1_31__remove_standard_accommodation_from_non_normal.sql
@@ -1,0 +1,2 @@
+delete from cell_used_for
+where id IN (select cuf.id FROM location l join cell_used_for cuf on cuf.location_id = l.id where l.accommodation_type != 'NORMAL_ACCOMMODATION');


### PR DESCRIPTION
This commit represents a new SQL migration script that deletes standard accommodations associated with non-normal locations from the 'cell_used_for' table. It ensures that only normal accommodations are in the database, maintaining data integrity and consistency.