### PR TITLE
MAP-1288 Add accommodation type mapping and conditionals in migrations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -338,13 +338,15 @@ data class CreateResidentialLocationRequest(
           capacityOfCertifiedCell = 0,
         ),
       )
+      if (location.accommodationType == AccommodationType.NORMAL_ACCOMMODATION) {
+        location.addUsedFor(UsedForType.STANDARD_ACCOMMODATION, createdBy, clock)
+      }
       usedFor?.forEach {
         location.addUsedFor(it, createdBy, clock)
-      } ?: location.addUsedFor(UsedForType.STANDARD_ACCOMMODATION, createdBy, clock)
-
-      specialistCellTypes?.forEach {
-        location.addSpecialistCellType(it, createdBy, clock)
       }
+        ?: specialistCellTypes?.forEach {
+          location.addSpecialistCellType(it, createdBy, clock)
+        }
       return location
     } else {
       ResidentialLocationJPA(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/NomisMigrationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/NomisMigrationRequest.kt
@@ -63,7 +63,7 @@ interface NomisMigrationRequest {
           deactivatedReason = null,
           proposedReactivationDate = null,
           childLocations = mutableListOf(),
-          accommodationType = mapAccommodationType(residentialHousingType!!),
+          accommodationType = residentialHousingType!!.mapToAccommodationType(),
           parent = null,
           capacity = capacity?.let {
             CapacityJPA(
@@ -82,7 +82,9 @@ interface NomisMigrationRequest {
           location.addAttribute(attribute)
           attribute.mapTo?.let { location.addSpecialistCellType(it) }
         }
-        location.addUsedFor(UsedForType.STANDARD_ACCOMMODATION, lastUpdatedBy, clock)
+        if (location.accommodationType == AccommodationType.NORMAL_ACCOMMODATION) {
+          location.addUsedFor(UsedForType.STANDARD_ACCOMMODATION, lastUpdatedBy, clock)
+        }
         if (residentialHousingType == HOLDING_CELL) {
           location.convertToNonResidentialCell(convertedCellType = ConvertedCellType.HOLDING_ROOM, userOrSystemInContext = lastUpdatedBy, clock = clock)
         }
@@ -133,20 +135,6 @@ interface NomisMigrationRequest {
   }
 
   fun isDeactivated() = deactivationReason != null
-
-  fun mapAccommodationType(residentialHousingType: ResidentialHousingType): AccommodationType {
-    return when (residentialHousingType) {
-      ResidentialHousingType.NORMAL_ACCOMMODATION -> AccommodationType.NORMAL_ACCOMMODATION
-      ResidentialHousingType.HEALTHCARE -> AccommodationType.HEALTHCARE_INPATIENTS
-      ResidentialHousingType.SEGREGATION -> AccommodationType.CARE_AND_SEPARATION
-
-      ResidentialHousingType.SPECIALIST_CELL,
-      HOLDING_CELL,
-      ResidentialHousingType.OTHER_USE,
-      ResidentialHousingType.RECEPTION,
-      -> AccommodationType.OTHER_NON_RESIDENTIAL
-    }
-  }
 }
 
 enum class NomisDeactivatedReason {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -126,7 +126,7 @@ class Cell(
       userOrSystemInContext,
       LocalDateTime.now(clock),
     )
-    this.accommodationType = AccommodationType.OTHER_NON_RESIDENTIAL
+    setAccommodationTypeForCell(AccommodationType.OTHER_NON_RESIDENTIAL, userOrSystemInContext, clock)
 
     if (convertedCellType == ConvertedCellType.OTHER) {
       addHistory(
@@ -183,7 +183,7 @@ class Cell(
       userOrSystemInContext,
       LocalDateTime.now(clock),
     )
-    this.accommodationType = accommodationType
+    setAccommodationTypeForCell(accommodationType, userOrSystemInContext, clock)
 
     usedForTypes?.forEach {
       addUsedFor(it, userOrSystemInContext, clock)
@@ -320,19 +320,18 @@ class Cell(
     return cellUsedFor
   }
 
+  fun removeUsedFor(typeToRemove: UsedForType, userOrSystemInContext: String, clock: Clock) {
+    val usedForToRemove = usedFor.find { it.usedFor == typeToRemove }
+    if (usedForToRemove != null) {
+      addHistory(LocationAttribute.USED_FOR, typeToRemove.description, null, userOrSystemInContext, LocalDateTime.now(clock))
+      usedFor.remove(usedForToRemove)
+    }
+  }
+
   override fun update(upsert: PatchResidentialLocationRequest, userOrSystemInContext: String, clock: Clock): Cell {
     super.update(upsert, userOrSystemInContext, clock)
 
-    if (upsert.accommodationType != null && this.accommodationType != upsert.accommodationType) {
-      addHistory(
-        LocationAttribute.ACCOMMODATION_TYPE,
-        this.accommodationType.description,
-        upsert.accommodationType.description,
-        userOrSystemInContext,
-        LocalDateTime.now(clock),
-      )
-    }
-    this.accommodationType = upsert.accommodationType ?: this.accommodationType
+    setAccommodationTypeForCell(upsert.accommodationType ?: this.accommodationType, userOrSystemInContext, clock)
 
     if (upsert.specialistCellTypes != null) {
       updateSpecialistCellTypes(upsert.specialistCellTypes, userOrSystemInContext, clock)
@@ -374,17 +373,7 @@ class Cell(
   override fun sync(upsert: NomisSyncLocationRequest, userOrSystemInContext: String, clock: Clock): Cell {
     super.sync(upsert, userOrSystemInContext, clock)
 
-    if (this.accommodationType != residentialHousingType.mapToAccommodationType()) {
-      addHistory(
-        LocationAttribute.ACCOMMODATION_TYPE,
-        this.accommodationType.description,
-        residentialHousingType.mapToAccommodationType().description,
-        userOrSystemInContext,
-        LocalDateTime.now(clock),
-      )
-      this.accommodationType = residentialHousingType.mapToAccommodationType()
-    }
-
+    setAccommodationTypeForCell(residentialHousingType.mapToAccommodationType(), userOrSystemInContext, clock)
     handleNomisCapacitySync(upsert, userOrSystemInContext, clock)
 
     if (upsert.attributes != null) {
@@ -393,6 +382,23 @@ class Cell(
     }
 
     return this
+  }
+
+  private fun setAccommodationTypeForCell(accommodationType: AccommodationType, userOrSystemInContext: String, clock: Clock) {
+    addHistory(
+      LocationAttribute.ACCOMMODATION_TYPE,
+      this.accommodationType.description,
+      accommodationType.description,
+      userOrSystemInContext,
+      LocalDateTime.now(clock),
+    )
+    this.accommodationType = accommodationType
+
+    if (this.accommodationType == AccommodationType.NORMAL_ACCOMMODATION) {
+      addUsedFor(UsedForType.STANDARD_ACCOMMODATION, userOrSystemInContext, clock)
+    } else {
+      removeUsedFor(UsedForType.STANDARD_ACCOMMODATION, userOrSystemInContext, clock)
+    }
   }
 
   private fun handleNomisCapacitySync(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -374,6 +374,17 @@ class Cell(
   override fun sync(upsert: NomisSyncLocationRequest, userOrSystemInContext: String, clock: Clock): Cell {
     super.sync(upsert, userOrSystemInContext, clock)
 
+    if (this.accommodationType != residentialHousingType.mapToAccommodationType()) {
+      addHistory(
+        LocationAttribute.ACCOMMODATION_TYPE,
+        this.accommodationType.description,
+        residentialHousingType.mapToAccommodationType().description,
+        userOrSystemInContext,
+        LocalDateTime.now(clock),
+      )
+      this.accommodationType = residentialHousingType.mapToAccommodationType()
+    }
+
     handleNomisCapacitySync(upsert, userOrSystemInContext, clock)
 
     if (upsert.attributes != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -191,4 +191,19 @@ enum class ResidentialHousingType(
   RECEPTION("Reception"),
   SEGREGATION("Segregation"),
   SPECIALIST_CELL("Specialist Cell"),
+  ;
+
+  fun mapToAccommodationType(): AccommodationType {
+    return when (this) {
+      NORMAL_ACCOMMODATION -> AccommodationType.NORMAL_ACCOMMODATION
+      HEALTHCARE -> AccommodationType.HEALTHCARE_INPATIENTS
+      SEGREGATION -> AccommodationType.CARE_AND_SEPARATION
+
+      SPECIALIST_CELL,
+      HOLDING_CELL,
+      OTHER_USE,
+      RECEPTION,
+      -> AccommodationType.OTHER_NON_RESIDENTIAL
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationRepository.kt
@@ -24,11 +24,11 @@ interface LocationRepository : JpaRepository<Location, UUID> {
   @Query("select l from Location l where concat(l.prisonId,'-',l.pathHierarchy) IN (:keys)")
   fun findAllByKeys(keys: List<String>): List<Location>
 
-  @Query("update location set residential_housing_type = :residentialHousingType where id = :id", nativeQuery = true)
+  @Query("update location set residential_housing_type = :residentialHousingType, accommodation_type = :accommodationType where id = :id", nativeQuery = true)
   @Modifying
-  fun updateResidentialHousingType(id: UUID, residentialHousingType: String)
+  fun updateResidentialHousingType(id: UUID, residentialHousingType: String, accommodationType: String)
 
-  @Query("update location set residential_housing_type = null where id = :id", nativeQuery = true)
+  @Query("update location set residential_housing_type = null, accommodation_type = null where id = :id", nativeQuery = true)
   @Modifying
   fun updateResidentialHousingTypeToNull(id: UUID)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SyncService.kt
@@ -131,7 +131,7 @@ class SyncService(
         locationRepository.updateResidentialHousingType(
           id,
           location.residentialHousingType.name,
-          location.residentialHousingType.mapToAccommodationType().name
+          location.residentialHousingType.mapToAccommodationType().name,
         )
       }
       clearSessionRequired = true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SyncService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.NomisMigrationRequ
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.NomisSyncLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LocationRepository
@@ -116,7 +117,7 @@ class SyncService(
     } else {
       if (location is NonResidentialLocation) {
         location.updateUsage(emptySet(), upsert.lastUpdatedBy, clock)
-        locationRepository.updateResidentialHousingType(id, upsert.residentialHousingType.name)
+        locationRepository.updateResidentialHousingType(id, upsert.residentialHousingType.name, upsert.residentialHousingType.mapToAccommodationType().name)
         clearSessionRequired = true
       }
     }
@@ -126,6 +127,13 @@ class SyncService(
         location.convertToNonCell()
       }
       locationRepository.updateLocationType(id, upsert.locationType.name)
+      if (location is ResidentialLocation && upsert.locationType == LocationType.CELL) {
+        locationRepository.updateResidentialHousingType(
+          id,
+          location.residentialHousingType.name,
+          location.residentialHousingType.mapToAccommodationType().name
+        )
+      }
       clearSessionRequired = true
     }
 

--- a/src/main/resources/db/migration/V1_32_data_fix_missing_accommodation_types.sql
+++ b/src/main/resources/db/migration/V1_32_data_fix_missing_accommodation_types.sql
@@ -1,0 +1,17 @@
+UPDATE location
+SET accommodation_type =
+        CASE
+            WHEN residential_housing_type = 'NORMAL_ACCOMMODATION'  THEN 'NORMAL_ACCOMMODATION'
+            WHEN residential_housing_type = 'HEALTHCARE'  THEN 'HEALTHCARE_INPATIENTS'
+            WHEN residential_housing_type = 'SEGREGATION'  THEN 'CARE_AND_SEPARATION'
+            ELSE 'OTHER_NON_RESIDENTIAL'
+            END
+WHERE accommodation_type is null
+  and (case when residential_housing_type IS NULL then 'NON_RESIDENTIAL' when location_type = 'CELL' then 'CELL' else 'RESIDENTIAL' end) = 'CELL';
+
+INSERT INTO cell_used_for (location_id, used_for)
+SELECT id as location_id, 'STANDARD_ACCOMMODATION' as used_for
+from location
+where accommodation_type = 'NORMAL_ACCOMMODATION'
+  and (case when residential_housing_type IS NULL then 'NON_RESIDENTIAL' when location_type = 'CELL' then 'CELL' else 'RESIDENTIAL' end) = 'CELL'
+  and not exists (select 1 from cell_used_for cuf where cuf.location_id = location.id and used_for = 'STANDARD_ACCOMMODATION')

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/LocalStackContainer.kt
@@ -29,7 +29,7 @@ object LocalStackContainer {
       withServices(LocalStackContainer.Service.SQS, LocalStackContainer.Service.SNS)
       withEnv("DEFAULT_REGION", "eu-west-2")
       waitingFor(
-        Wait.forLogMessage(".*Running on.*", 1),
+        Wait.forLogMessage(".*Ready.*", 1),
       )
       start()
       followOutput(logConsumer)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -430,6 +430,40 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
           """,
             false,
           )
+
+        webTestClient.get().uri("/locations/${room.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """ 
+             {
+              "prisonId": "ZZGHI",
+              "code": "012",
+              "pathHierarchy": "B-1-012",
+              "locationType": "CELL",
+              "accommodationTypes": [ 
+                "NORMAL_ACCOMMODATION"
+              ],
+              "usedFor": [
+                "STANDARD_ACCOMMODATION"
+              ],
+              "active": true,
+              "key": "ZZGHI-B-1-012",
+              "capacity": {
+                "maxCapacity": 1,
+                "workingCapacity": 1
+              },
+              "certification": {
+                "certified": true,
+                "capacityOfCertifiedCell": 1
+              }
+            }
+          """,
+            false,
+          )
       }
 
       @Test
@@ -830,11 +864,6 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
                 {
                   "attribute": "Converted Cell Type",
                   "newValue": "Holding room",
-                  "amendedBy": "user"
-                },
-                {
-                  "attribute": "Used For",
-                  "newValue": "Standard accommodation",
                   "amendedBy": "user"
                 }
               ]


### PR DESCRIPTION
Added an accommodation type mapping function in the ResidentialLocation.kt file and revised SQL scripts to update and insert accommodation types based on conditions in the V1_32_data_fix_missing_accommodation_types.sql file. Modified methods in NomisMigrationRequest.kt, Cell.kt, and LocationDto.kt to add 'STANDARD_ACCOMMODATION' for 'NORMAL_ACCOMMODATION' types and adjust the flow, allowing for more accurate data representation.