### PR TITLE
MAP-1291 Add support for permanently deactivated locations in NOMIS legacy view

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LegacyLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LegacyLocation.kt
@@ -64,6 +64,9 @@ data class LegacyLocation(
   @Schema(description = "Proposed Date for location reactivation", example = "2026-01-24", required = false)
   val proposedReactivationDate: LocalDate? = null,
 
+  @Schema(description = "Indicates that this location has been permanently deactivated and should not be changed in NOMIS", example = "false", defaultValue = "false", required = true)
+  val permanentlyDeactivated: Boolean = false,
+
   @Schema(description = "Parent Location Id", example = "57718979-573c-433a-9e51-2d83f887c11c", required = false)
   val parentId: UUID?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -715,6 +715,7 @@ abstract class Location(
       deactivatedDate = findDeactivatedLocationInHierarchy()?.deactivatedDate?.toLocalDate(),
       deactivatedReason = findDeactivatedLocationInHierarchy()?.deactivatedReason,
       proposedReactivationDate = findDeactivatedLocationInHierarchy()?.proposedReactivationDate,
+      permanentlyDeactivated = isPermanentlyDeactivated(),
       changeHistory = if (includeHistory) history.map { it.toDto() } else null,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorResponse.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.HttpStatus
 
 @Schema(description = "Error response")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class ErrorResponse(
   @Schema(description = "HTTP status code", example = "500", required = true)
   val status: Int,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -57,6 +57,7 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
   lateinit var wingB: ResidentialLocation
   lateinit var landing1: ResidentialLocation
   lateinit var cell: Cell
+  lateinit var permDeactivated: Cell
   lateinit var room: ResidentialLocation
   lateinit var nonRes: NonResidentialLocation
   lateinit var locationHistory: LocationHistory
@@ -105,6 +106,15 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
         locationType = LocationType.ROOM,
       ),
     )
+
+    permDeactivated = repository.save(
+      buildCell(
+        prisonId = "ZZGHI",
+        pathHierarchy = "B-1-013",
+        archived = true,
+        active = false,
+      ),
+    )
     locationHistory = cell.addHistory(
       attributeName = LocationAttribute.DESCRIPTION,
       oldValue = "2",
@@ -116,6 +126,7 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
 
     wingB.addChildLocation(landing1)
     landing1.addChildLocation(cell)
+    landing1.addChildLocation(permDeactivated)
     landing1.addChildLocation(room)
     landing1.addChildLocation(nonRes)
     repository.save(wingB)
@@ -299,6 +310,55 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
                 "certified": false,
                 "capacityOfCertifiedCell": 0
               }
+            }
+          """,
+            false,
+          )
+      }
+
+      @Test
+      fun `cannot sync an existing permanently deactivated location`() {
+        webTestClient.post().uri("/sync/upsert")
+          .headers(setAuthorisation(roles = listOf("ROLE_SYNC_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              syncResRequest.copy(
+                id = permDeactivated.id,
+                code = "013",
+                capacity = CapacityDTO(3, 3),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isEqualTo(409)
+          .expectBody().json(
+            // language=json
+            """ 
+                {
+                  "status": 409,
+                  "userMessage": "Deactivated Location Exception: Location Location ZZGHI-B-1-013 cannot be updated as permanently deactivated cannot be updated as permanently deactivated",
+                  "developerMessage": "Location Location ZZGHI-B-1-013 cannot be updated as permanently deactivated cannot be updated as permanently deactivated",
+                  "errorCode": 107
+                }
+          """,
+            false,
+          )
+
+        webTestClient.get().uri("/sync/id/${permDeactivated.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """ 
+             {
+              "prisonId": "ZZGHI",
+              "code": "013",
+              "pathHierarchy": "B-1-013",
+              "active": false,
+              "permanentlyDeactivated": true
             }
           """,
             false,


### PR DESCRIPTION


The code now properly handles locations that have been permanently deactivated. A new boolean field, "permanentlyDeactivated", has been added to the LegacyLocation class. Additionally, sync tests have been updated to include cases where the location has been permanently deactivated and can't be updated in NOMIS. Non-NULL JSON object is now included for error responses.