### PR TITLE
MAP-1354 Remove-working-cap-value-from-inactive-cells

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -484,8 +484,6 @@ class Cell(
 
   override fun toDto(includeChildren: Boolean, includeParent: Boolean, includeHistory: Boolean, countInactiveCells: Boolean): LocationDto {
     return super.toDto(includeChildren = includeChildren, includeParent = includeParent, includeHistory = includeHistory, countInactiveCells = countInactiveCells).copy(
-      capacity = capacity?.toDto(),
-      certification = certification?.toDto(),
       convertedCellType = convertedCellType,
       otherConvertedCellType = otherConvertedCellType,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -59,7 +59,7 @@ open class ResidentialLocation(
 ) {
 
   private fun getWorkingCapacity(): Int {
-    return cellLocations().filter { it.isActiveAndAllParentsActive() || it == this }
+    return cellLocations().filter { it.isActiveAndAllParentsActive() }
       .sumOf { it.getWorkingCapacity() ?: 0 }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -1689,7 +1689,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                   "permanentlyInactive": false,
                   "capacity": {
                     "maxCapacity": 2,
-                    "workingCapacity": 2
+                    "workingCapacity": 0
                   },
                   "certification": {
                     "certified": true,
@@ -1749,7 +1749,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                   "permanentlyInactive": false,
                   "capacity": {
                     "maxCapacity": 2,
-                    "workingCapacity": 2
+                    "workingCapacity": 0
                   },
                   "certification": {
                     "certified": true,
@@ -1794,7 +1794,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                   "permanentlyInactive": false,
                   "capacity": {
                     "maxCapacity": 2,
-                    "workingCapacity": 2
+                    "workingCapacity": 0
                   },
                   "certification": {
                     "certified": true,
@@ -2604,7 +2604,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
                       "permanentlyInactive": false,
                       "capacity": {
                         "maxCapacity": 2,
-                        "workingCapacity": 2
+                        "workingCapacity": 0
                       },
                       "certification": {
                         "certified": true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -800,7 +800,7 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
               "key": "ZZGHI-B-1-002",
               "capacity": {
                 "maxCapacity": 1,
-                "workingCapacity": 1
+                "workingCapacity": 0
               },
               "deactivatedReason": "${migrateRequest.deactivationReason}",
               "proposedReactivationDate": "${migrateRequest.proposedReactivationDate}",


### PR DESCRIPTION
The method for calculating cell capacity in ResidentialLocation.kt has been updated to exclude the cell itself from the calculation. Additionally, 'capacity' and 'certification' fields have been omitted from the conversion to DTO in Cell.kt. Changes have also been reflected in the corresponding test files, modifying the expected working capacity to zero in these tests.