### PR TITLE
MAP-1365 Add active prisons info to service config

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,6 +11,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search-dev.prison.service.justice.gov.uk
+    SERVICE_ACTIVE_PRISONS: "***"
 
   scheduledDowntime:
     enabled: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,6 +11,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     API_BASE_URL_OAUTH: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search-preprod.prison.service.justice.gov.uk
+    SERVICE_ACTIVE_PRISONS: "***"
 
   scheduledDowntime:
     enabled: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,6 +8,7 @@ generic-service:
   env:
     API_BASE_URL_OAUTH: https://sign-in.hmpps.service.justice.gov.uk/auth
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search.prison.service.justice.gov.uk
+    SERVICE_ACTIVE_PRISONS: ""
 
   postgresDatabaseRestore:
     enabled: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/ActivePrisonConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/ActivePrisonConfig.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ActivePrisonConfig(
+  @Value("\${service.active.prisons}")
+  val activePrisons: List<String>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/ActivePrisonsInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/ActivePrisonsInfo.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.config
+
+import org.springframework.boot.actuate.info.Info
+import org.springframework.boot.actuate.info.InfoContributor
+import org.springframework.stereotype.Component
+
+@Component
+class ActivePrisonsInfo(
+  private val activePrisonConfig: ActivePrisonConfig,
+) : InfoContributor {
+  override fun contribute(builder: Info.Builder?) {
+    builder?.withDetail("activeAgencies", activePrisonConfig.activePrisons)
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,3 +23,6 @@ spring:
   jpa:
     show-sql: true
 
+service:
+  active:
+    prisons: ${SERVICE_ACTIVE_PRISONS:***}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/health/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/health/InfoTest.kt
@@ -28,4 +28,15 @@ class InfoTest : SqsIntegrationTestBase() {
         assertThat(it).startsWith(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
       }
   }
+
+  @Test
+  fun `Info page reports active agencies`() {
+    webTestClient.get().uri("/info")
+      .exchange()
+      .expectStatus().isOk
+      .expectBody().jsonPath("activeAgencies").value<List<String>> {
+        assertThat(it).hasSize(1)
+        assertThat(it[0]).isEqualTo("***")
+      }
+  }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -36,3 +36,7 @@ hmpps.sqs:
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
+
+service:
+  active:
+    prisons: ${SERVICE_ACTIVE_PRISONS:***}


### PR DESCRIPTION
Introduced a new config value, SERVICE_ACTIVE_PRISONS, to manage the list of active prisons. This info is now available through the /info endpoint, and is configurable via environment variables. Added corresponding tests to verify this change.
