### PR TITLE
MAP-1371 Provide cells with capacity endpoint 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/ResidentialLocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/ResidentialLocationRepository.kt
@@ -7,6 +7,7 @@ import java.util.UUID
 
 @Repository
 interface ResidentialLocationRepository : JpaRepository<ResidentialLocation, UUID> {
+  fun findOneByPrisonIdAndId(prisonId: String, id: UUID): ResidentialLocation?
   fun findAllByPrisonIdAndParentId(prisonId: String, parentId: UUID): List<ResidentialLocation>
   fun findAllByPrisonIdAndParentIsNull(prisonId: String): List<ResidentialLocation>
   fun findAllByPrisonIdAndArchivedIsTrue(prisonId: String): List<ResidentialLocation>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationOccupancyResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationOccupancyResource.kt
@@ -1,0 +1,121 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationService
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.Prisoner
+import java.util.*
+
+@RestController
+@Validated
+@RequestMapping("/location-occupancy", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Tag(
+  name = "Location Occupancy",
+  description = "Returns location information with occupancy information",
+)
+class LocationOccupancyResource(
+  private val locationService: LocationService,
+) {
+
+  @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")
+  @GetMapping("/cells-with-capacity/{prisonId}")
+  @ResponseStatus(HttpStatus.OK)
+  @Operation(
+    summary = "List of cells by group at prison which have capacity.",
+    description = "Requires role VIEW_LOCATIONS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns cells with capacity available",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the VIEW_LOCATIONS role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getCellsWithCapacity(
+    @Schema(description = "Prison Id", example = "MDI", required = true, minLength = 3, maxLength = 5, pattern = "^[A-Z]{2}I|ZZGHI$")
+    @Size(min = 3, message = "Prison ID cannot be blank")
+    @Size(max = 5, message = "Prison ID must be 3 characters or ZZGHI")
+    @Pattern(regexp = "^[A-Z]{2}I|ZZGHI$", message = "Prison ID must be 3 characters or ZZGHI")
+    @PathVariable prisonId: String,
+    @Schema(description = "Location Id in the prison below which to find cells", example = "de91dfa7-821f-4552-a427-bf2f32eafeb0", required = false)
+    @RequestParam(name = "locationId", required = false) locationId: UUID? = null,
+    @Schema(description = "Group name for a sub location to find cells", example = "Wing A", required = false)
+    @RequestParam(name = "groupName", required = false) groupName: String? = null,
+    @Schema(description = "Only return cells of a specified specialist type", example = "CSU", required = false)
+    @RequestParam(name = "specialistCellType", required = false) specialistCellType: SpecialistCellType? = null,
+    @Schema(description = "Include prisoner details in this cell", required = false, defaultValue = "false")
+    @RequestParam(name = "includePrisonerInformation", required = false, defaultValue = "false") includePrisonerInformation: Boolean = false,
+  ): List<CellWithSpecialistCellTypes> =
+    locationService.getCellsWithCapacity(
+      prisonId = prisonId,
+      locationId = locationId,
+      groupName = groupName,
+      specialistCellType = specialistCellType,
+      includePrisonerInformation = includePrisonerInformation,
+    )
+}
+
+@Schema(description = "Cell with specialist cell attributes details")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CellWithSpecialistCellTypes(
+  @Schema(required = true, title = "Location identifier.", example = "de91dfa7-821f-4552-a427-bf2f32eafeb0")
+  val id: UUID,
+  @Schema(description = "Prison ID", example = "MDI", required = true)
+  val prisonId: String,
+  @Schema(description = "Full path of the location within the prison", example = "A-1-001", required = true)
+  val pathHierarchy: String,
+  @Schema(required = true, title = "Current occupancy of location.", example = "1")
+  val noOfOccupants: Int,
+  @Schema(required = true, title = "Max capacity of the location.", example = "2")
+  val maxCapacity: Int,
+  @Schema(required = true, title = "Working capacity of the location.", example = "1")
+  val workingCapacity: Int,
+  @Schema(title = "Local Name of the location.", example = "RES-HB1-ALE")
+  val localName: String? = null,
+  @Schema(title = "List of specialist types for the cell.", example = "LISTENER_CRISIS")
+  val specialistCellTypes: List<SpecialistCellType> = listOf(),
+  @Schema(title = "List prisoners in this cell", required = true)
+  val prisonersInCell: List<Prisoner>? = null,
+) {
+  @Schema(description = "Business Key for a location", example = "MDI-A-1-001", required = true)
+  fun getKey(): String {
+    return "$prisonId-$pathHierarchy"
+  }
+
+  @JsonIgnore
+  fun hasSpace() = noOfOccupants < getActualCapacity()
+
+  private fun getActualCapacity() = if (workingCapacity != 0) workingCapacity else maxCapacity
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonerSearchService.kt
@@ -63,16 +63,35 @@ data class SearchResult(
 data class Prisoner(
   @Schema(description = "Prisoner Information", example = "A1234AA", required = true)
   val prisonerNumber: String,
-  @Schema(description = "Prisoner first name", example = "Dave", required = true)
-  val firstName: String,
-  @Schema(description = "Prisoner last name", example = "Jones", required = true)
-  val lastName: String,
   @Schema(description = "Prison ID", example = "LEI", required = false)
   val prisonId: String?,
   @Schema(description = "Prison Name", example = "HMP Leeds", required = false)
   val prisonName: String?,
   @Schema(description = "Cell location of the prisoner", example = "1-1-001", required = true)
   val cellLocation: String,
+  @Schema(description = "Prisoner first name", example = "Dave", required = true)
+  val firstName: String,
+  @Schema(description = "Prisoner last name", example = "Jones", required = true)
+  val lastName: String,
+  @Schema(description = "Prisoner gender", example = "Male", required = true)
+  val gender: String,
+  @Schema(description = "Prisoner CSRA", example = "High", required = false)
+  val csra: String? = null,
+  @Schema(description = "Prisoner category", example = "C", required = false)
+  val category: String? = null,
+  @Schema(description = "Prisoner alerts", required = false)
+  val alerts: List<Alert>? = null,
+)
+
+data class Alert(
+  @Schema(description = "Alert type", example = "X", required = true)
+  val alertType: String,
+  @Schema(description = "Alert code", example = "XA", required = true)
+  val alertCode: String,
+  @Schema(description = "Active alert", example = "true", required = true)
+  val active: Boolean,
+  @Schema(description = "Expired", example = "false", required = true)
+  val expired: Boolean,
 )
 
 data class AttributeSearch(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/PrisonerSearchMockServer.kt
@@ -46,7 +46,7 @@ class PrisonerSearchMockServer : WireMockServer(WIREMOCK_PORT) {
           AttributeQuery(
             matchers = listOf(
               Matcher(attribute = "prisonId", condition = "IS", searchTerm = prisonId),
-              Matcher(attribute = "cellLocation", condition = "IN", searchTerm = locations.sorted().joinToString(",")),
+              Matcher(attribute = "cellLocation", condition = "IN", searchTerm = locations.distinct().sorted().joinToString(",")),
             ),
           ),
         ),
@@ -58,24 +58,17 @@ class PrisonerSearchMockServer : WireMockServer(WIREMOCK_PORT) {
     )
     if (returnResult) {
       result = result.copy(
-        content = listOf(
+        content = locations.mapIndexed { index, location ->
           Prisoner(
-            prisonerNumber = "A1234AA",
-            firstName = "Test",
-            lastName = "Test",
+            prisonerNumber = "A${index.toString().padStart(4, '0') }AA",
+            firstName = "Firstname-$index",
+            lastName = "Surname-$index",
             prisonId = prisonId,
             prisonName = prisonId,
-            cellLocation = locations.first(),
-          ),
-          Prisoner(
-            prisonerNumber = "A1234AB",
-            firstName = "Test2",
-            lastName = "Test2",
-            prisonId = prisonId,
-            prisonName = prisonId,
-            cellLocation = locations.first(),
-          ),
-        ),
+            cellLocation = location,
+            gender = "MALE",
+          )
+        },
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationCapacityResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationCapacityResourceIntTest.kt
@@ -1,0 +1,330 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.SqsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Capacity
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Certification
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LocationRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.buildCell
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.buildResidentialLocation
+import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
+import java.time.Clock
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation as ResidentialLocationJPA
+
+@WithMockAuthUser(username = EXPECTED_USERNAME)
+class LocationCapacityResourceIntTest : SqsIntegrationTestBase() {
+
+  @TestConfiguration
+  class FixedClockConfig {
+    @Primary
+    @Bean
+    fun fixedClock(): Clock = clock
+  }
+
+  @Autowired
+  lateinit var repository: LocationRepository
+  lateinit var cell1: Cell
+  lateinit var cell2: Cell
+  lateinit var cell3: Cell
+  lateinit var cell4: Cell
+  lateinit var landingZ1: ResidentialLocationJPA
+  lateinit var landingZ2: ResidentialLocationJPA
+  lateinit var wingZ: ResidentialLocationJPA
+
+  @BeforeEach
+  fun setUp() {
+    prisonerSearchMockServer.resetAll()
+    repository.deleteAll()
+
+    wingZ = repository.save(
+      buildResidentialLocation(
+        pathHierarchy = "Z",
+        locationType = LocationType.WING,
+      ),
+    )
+    landingZ1 = repository.save(
+      buildResidentialLocation(
+        pathHierarchy = "Z-1",
+        locationType = LocationType.LANDING,
+      ),
+    )
+    landingZ2 = repository.save(
+      buildResidentialLocation(
+        pathHierarchy = "Z-2",
+        locationType = LocationType.LANDING,
+      ),
+    )
+    cell1 = repository.save(
+      buildCell(
+        pathHierarchy = "Z-1-001",
+        capacity = Capacity(maxCapacity = 2, workingCapacity = 1),
+        certification = Certification(certified = true, capacityOfCertifiedCell = 2),
+        specialistCellType = SpecialistCellType.LOCATE_FLAT_CELL,
+      ),
+    )
+    cell2 = repository.save(
+      buildCell(
+        pathHierarchy = "Z-1-002",
+        capacity = Capacity(maxCapacity = 2, workingCapacity = 2),
+        certification = Certification(certified = true, capacityOfCertifiedCell = 2),
+        specialistCellType = SpecialistCellType.LISTENER_CRISIS,
+      ),
+    )
+    cell3 = repository.save(
+      buildCell(
+        pathHierarchy = "Z-2-001",
+        capacity = Capacity(maxCapacity = 2, workingCapacity = 0),
+        certification = Certification(certified = true, capacityOfCertifiedCell = 1),
+        specialistCellType = SpecialistCellType.SAFE_CELL,
+      ),
+    )
+    cell4 = repository.save(
+      buildCell(
+        pathHierarchy = "Z-2-002",
+        capacity = Capacity(maxCapacity = 1, workingCapacity = 0),
+        certification = Certification(certified = false, capacityOfCertifiedCell = 0),
+      ),
+    )
+    wingZ.addChildLocation(
+      landingZ1
+        .addChildLocation(cell1)
+        .addChildLocation(cell2),
+    ).addChildLocation(
+      landingZ2
+        .addChildLocation(cell3)
+        .addChildLocation(cell4),
+    )
+    repository.save(wingZ)
+  }
+
+  @DisplayName("GET /location-occupancy/cells-with-capacity/{prisonId}")
+  @Nested
+  inner class CellsWithCapacityTest {
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no authority`() {
+        webTestClient.get().uri("/location-occupancy/cells-with-capacity/${wingZ.prisonId}")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get().uri("/location-occupancy/cells-with-capacity/${wingZ.prisonId}")
+          .headers(setAuthorisation(roles = listOf()))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.get().uri("/location-occupancy/cells-with-capacity/${wingZ.prisonId}")
+          .header("Content-Type", "application/json")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @Test
+      fun `access client error bad prison ID`() {
+        webTestClient.get().uri("/location-occupancy/cells-with-capacity/HFIFHOHF")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().is4xxClientError
+      }
+
+      @Test
+      fun `access client error bad specialist cell type`() {
+        webTestClient.get().uri("/location-occupancy/cells-with-capacity/${wingZ.prisonId}?specialistCellType=BLOB")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().is4xxClientError
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `can view cells with capacity`() {
+        prisonerSearchMockServer.stubSearchByLocations(
+          cell1.prisonId,
+          listOf(
+            cell1.getPathHierarchy(),
+            cell2.getPathHierarchy(),
+            cell2.getPathHierarchy(),
+            cell3.getPathHierarchy(),
+          ),
+          true,
+        )
+
+        webTestClient.get().uri("/location-occupancy/cells-with-capacity/${wingZ.prisonId}")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+            [
+              {
+                "id": "${cell3.id}",
+                "key": "${cell3.getKey()}",
+                "prisonId": "${cell3.prisonId}",
+                "pathHierarchy": "${cell3.getPathHierarchy()}",
+                "noOfOccupants": 1,
+                "maxCapacity": ${cell3.getMaxCapacity()},
+                "workingCapacity": ${cell3.getWorkingCapacity()},
+                "specialistCellTypes": [
+                  "SAFE_CELL"
+                ]
+              }
+            ]
+          """,
+            false,
+          )
+      }
+
+      @Test
+      fun `can view cells with capacity filtered by specialistCellType`() {
+        prisonerSearchMockServer.stubSearchByLocations(
+          cell1.prisonId,
+          listOf(
+            cell3.getPathHierarchy(),
+          ),
+          true,
+        )
+
+        webTestClient.get().uri("/location-occupancy/cells-with-capacity/${wingZ.prisonId}?specialistCellType=SAFE_CELL")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+            [
+              {
+                "id": "${cell3.id}",
+                "key": "${cell3.getKey()}",
+                "prisonId": "${cell3.prisonId}",
+                "pathHierarchy": "${cell3.getPathHierarchy()}",
+                "noOfOccupants": 1,
+                "maxCapacity": ${cell3.getMaxCapacity()},
+                "workingCapacity": ${cell3.getWorkingCapacity()},
+                "specialistCellTypes": [
+                  "SAFE_CELL"
+                ]
+              }
+            ]
+          """,
+            false,
+          )
+      }
+
+      @Test
+      fun `can view cells with capacity from sub location`() {
+        prisonerSearchMockServer.stubSearchByLocations(
+          cell3.prisonId,
+          listOf(
+            cell3.getPathHierarchy(),
+          ),
+          true,
+        )
+
+        webTestClient.get().uri("/location-occupancy/cells-with-capacity/${wingZ.prisonId}?locationId=${landingZ2.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+            [
+              {
+                "id": "${cell3.id}",
+                "key": "${cell3.getKey()}",
+                "prisonId": "${cell3.prisonId}",
+                "pathHierarchy": "${cell3.getPathHierarchy()}",
+                "noOfOccupants": 1,
+                "maxCapacity": ${cell3.getMaxCapacity()},
+                "workingCapacity": ${cell3.getWorkingCapacity()},
+                "specialistCellTypes": [
+                  "SAFE_CELL"
+                ]
+              }
+            ]
+          """,
+            false,
+          )
+      }
+
+      @Test
+      fun `can view cells with capacity and prisoner information`() {
+        prisonerSearchMockServer.stubSearchByLocations(
+          cell1.prisonId,
+          listOf(
+            cell1.getPathHierarchy(),
+            cell2.getPathHierarchy(),
+            cell2.getPathHierarchy(),
+            cell3.getPathHierarchy(),
+          ),
+          true,
+        )
+
+        webTestClient.get().uri("/location-occupancy/cells-with-capacity/${wingZ.prisonId}?includePrisonerInformation=true")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+            [
+              {
+                "id": "${cell3.id}",
+                "key": "${cell3.getKey()}",
+                "prisonId": "${cell3.prisonId}",
+                "pathHierarchy": "${cell3.getPathHierarchy()}",
+                "noOfOccupants": 1,
+                "maxCapacity": ${cell3.getMaxCapacity()},
+                "workingCapacity": ${cell3.getWorkingCapacity()},
+                "specialistCellTypes": [
+                  "SAFE_CELL"
+                ],
+                "prisonersInCell": [
+                  {
+                    "prisonerNumber": "A0003AA",
+                    "firstName": "Firstname-3",
+                    "lastName": "Surname-3",
+                    "gender": "MALE",
+                    "cellLocation": "${cell3.getPathHierarchy()}",
+                    "prisonId": "${cell3.prisonId}"
+                  }
+                ]
+              }
+            ]
+          """,
+            false,
+          )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -2857,8 +2857,8 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
       }
 
       @Test
-      fun `cannot reduce max capacity of a cell below prisoners in cell`() {
-        prisonerSearchMockServer.stubSearchByLocations(cell1.prisonId, listOf(cell1.getPathHierarchy()), true)
+      fun `cannot reduce max capacity of a cell below number of prisoners in cell`() {
+        prisonerSearchMockServer.stubSearchByLocations(cell1.prisonId, listOf(cell1.getPathHierarchy(), cell1.getPathHierarchy()), true)
 
         webTestClient.put().uri("/locations/${cell1.id}/capacity")
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonLocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonLocationServiceTest.kt
@@ -20,12 +20,14 @@ class PrisonLocationServiceTest {
 
   @Test
   fun `Get prisoners by prison id when cell location exist and location is active`() {
-    val cell: Cell = mock()
-    val prisoner1 = Prisoner("P1", "First Name", "Last Name", "MDI", "Prison Name", "C1")
-    val prisoner2 = Prisoner("P2", "First Name", "Last Name", "MDI", "Prison Name", "C2")
-    val prisoner3 = Prisoner("P3", "First Name", "Last Name", "MDI", "Prison Name", "C2")
-    whenever(cell.getPathHierarchy()).thenReturn("path")
-    whenever(cellLocationRepository.findAllByPrisonIdAndActive(any(), any())).thenReturn(listOf(cell))
+    val cell1: Cell = mock()
+    val cell2: Cell = mock()
+    val prisoner1 = Prisoner("P1", "First Name", "Last Name", "A", "Prison Name", "C1", gender = "MALE")
+    val prisoner2 = Prisoner("P2", "First Name", "Last Name", "B", "Prison Name", "C2", gender = "MALE")
+    val prisoner3 = Prisoner("P3", "First Name", "Last Name", "B", "Prison Name", "C2", gender = "MALE")
+    whenever(cell1.getPathHierarchy()).thenReturn("A")
+    whenever(cell2.getPathHierarchy()).thenReturn("B")
+    whenever(cellLocationRepository.findAllByPrisonIdAndActive(any(), any())).thenReturn(listOf(cell1, cell2))
     whenever(prisonerSearchService.findPrisonersInLocations(any(), any())).thenReturn(
       listOf(
         prisoner1,
@@ -55,7 +57,7 @@ class PrisonLocationServiceTest {
     whenever(cell.getPathHierarchy()).thenReturn("path")
     whenever(cell.cellLocations()).thenReturn(listOf(cell))
     whenever(cell.prisonId).thenReturn("MDI")
-    val prisoner = Prisoner("P1", "First Name", "Last Name", "MDI", "Prison Name", "C1")
+    val prisoner = Prisoner("P1", "First Name", "Last Name", "MDI", "Prison Name", "C1", gender = "MALE")
 
     whenever(locationRepository.findOneByKey(any())).thenReturn(cell)
 
@@ -80,7 +82,7 @@ class PrisonLocationServiceTest {
     whenever(cell.getPathHierarchy()).thenReturn("path")
     whenever(cell.cellLocations()).thenReturn(listOf(cell))
     whenever(cell.prisonId).thenReturn("MDI")
-    val prisoner = Prisoner("P1", "First Name", "Last Name", "MDI", "Prison Name", "C1")
+    val prisoner = Prisoner("P1", "First Name", "Last Name", "MDI", "Prison Name", "C1", gender = "MALE")
 
     whenever(locationRepository.findById(any())).thenReturn(Optional.of(cell))
 


### PR DESCRIPTION
This replaces the prison API and whereabouts API endpoints that find capacity of cells within prison.

It makes use of prisoner search to look up locations and check if prisoners are in the cells.  Capacity is then used to work out if space is available based on existing logic.