### PR TITLE
[MAP-1359] Add Kover plugin to generate code coverage reports

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+API_BASE_URL_OAUTH=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+API_BASE_URL_PRISON=https://prison-api-dev.prison.service.justice.gov.uk
+LOCATIONS_INSIDE_PRISON_API_CLIENT_ID=[choose a suitable hmpps-auth client]
+LOCATIONS_INSIDE_PRISON_API_CLIENT_SECRET=

--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-API_BASE_URL_OAUTH=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
-API_BASE_URL_PRISON=https://prison-api-dev.prison.service.justice.gov.uk
-LOCATIONS_INSIDE_PRISON_API_CLIENT_ID=[choose a suitable hmpps-auth client]
-LOCATIONS_INSIDE_PRISON_API_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ Then run the API.
 ## Architecture
 
 Architecture decision records start [here](docs/0001-use-adr.md)
+
+## Testing coverage report
+
+Run:
+
+```
+./gradlew koverHtmlReport
+```
+
+Then view output file for coverage report.
+
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.1"
   kotlin("plugin.spring") version "2.0.0"
   kotlin("plugin.jpa") version "2.0.0"
+  id("org.jetbrains.kotlinx.kover") version "0.8.2"
   idea
 }
 


### PR DESCRIPTION
Introduce a test coverage plugin to allow developers to track their testing

Documentation:
https://kotlin.github.io/kotlinx-kover/gradle-plugin/

Example command to generate a HTML report locally:
`./gradlew koverHtmlReport`

Example report output:

![image](https://github.com/ministryofjustice/hmpps-locations-inside-prison-api/assets/173043740/cf6e3648-a8e6-4053-823a-8531f93475df)

Later on we can look at ways of generating these automatically with CircleCI and adopt it in our other projects using Kotlin.