### PR TITLE
MAP-1395 Separate endpoint for updating specialist cell types to allow removal of all types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 .kotlin/
 build/
 
+.DS_Store
+
 # CMake
 cmake-build-debug/
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PatchLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PatchLocationRequest.kt
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.AccommodationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocationType
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.UsedForType
 import java.util.*
 
@@ -34,9 +33,6 @@ data class PatchResidentialLocationRequest(
 
   @Schema(description = "used For types", required = false)
   val usedFor: Set<UsedForType>? = null,
-
-  @Schema(description = "Specialist cell types", required = false)
-  val specialistCellTypes: Set<SpecialistCellType>? = null,
 ) : PatchLocationRequest
 
 @Schema(description = "Request to update a non-res location")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -333,10 +333,6 @@ class Cell(
 
     setAccommodationTypeForCell(upsert.accommodationType ?: this.accommodationType, userOrSystemInContext, clock)
 
-    if (upsert.specialistCellTypes != null) {
-      updateSpecialistCellTypes(upsert.specialistCellTypes, userOrSystemInContext, clock)
-    }
-
     if (upsert.usedFor != null) {
       updateUsedFor(upsert.usedFor, userOrSystemInContext, clock)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
@@ -1185,6 +1185,53 @@ class LocationResource(
     }
   }
 
+  @PutMapping("/{id}/specialist-cell-types", produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasRole('ROLE_MAINTAIN_LOCATIONS') and hasAuthority('SCOPE_write')")
+  @Operation(
+    summary = "Update specialist cell types for a cell",
+    description = "Requires role MAINTAIN_LOCATIONS and write scope",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns details of the updated cell",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid Request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MAINTAIN_LOCATIONS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Location not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun updateSpecialistCellTypes(
+    @Schema(description = "The location Id", example = "de91dfa7-821f-4552-a427-bf2f32eafeb0", required = true)
+    @PathVariable
+    id: UUID,
+    @RequestBody
+    @Validated
+    specialistCellTypes: Set<SpecialistCellType>,
+  ): LocationDTO {
+    return eventPublishAndAudit(
+      InternalLocationDomainEventType.LOCATION_AMENDED,
+    ) {
+      locationService.updateSpecialistCellTypes(id = id, specialistCellTypes = specialistCellTypes)
+    }
+  }
+
   @GetMapping("/prison/{prisonId}/location-type/{locationType}")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -392,11 +392,10 @@ class LocationService(
       throw ValidationException("Cannot change the specialist cell types of a permanently deactivated location")
     }
 
-    // TODO check for empty sets when 0 working cap etc (e.g. validation rules)
-//    val prisoners = prisonerLocationService.prisonersInLocations(cell)
-//    if (maxCapacity < prisoners.size) {
-//      throw CapacityException(locCapChange.getKey(), "Max capacity ($maxCapacity) cannot be decreased below current cell occupancy (${prisoners.size})")
-//    }
+    // Check that the workingCapacity is not set to 0 for normal accommodations when removing the specialists cell types
+    if (specialistCellTypes.isEmpty() && cell.accommodationType.equals(AccommodationType.NORMAL_ACCOMMODATION) && cell.getWorkingCapacity() == 0) {
+      throw ValidationException("Cannot removes specialist cell types for a normal accommodation with a working capacity of 0")
+    }
 
     cell.updateSpecialistCellTypes(
       specialistCellTypes,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -2090,7 +2090,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
 
       @Test
       fun `can update specialist cell types successfully`() {
-        val expectedUsedFor = setOf(SpecialistCellType.BIOHAZARD_DIRTY_PROTEST)
+        val expectedSpecialistCell = setOf(SpecialistCellType.BIOHAZARD_DIRTY_PROTEST)
 
         val result = webTestClient.put().uri("/locations/${cell1.id}/specialist-cell-types")
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
@@ -2101,7 +2101,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
           .expectBody(LocationTest::class.java)
           .returnResult().responseBody!!
 
-        assertThat(result.usedFor == expectedUsedFor)
+        assertThat(result.specialistCellTypes!! == expectedSpecialistCell)
 
         getDomainEvents(1).let {
           assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
@@ -2112,7 +2112,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
 
       @Test
       fun `can remove specialist cell types successfully`() {
-        val expectedUsedFor = null
+        val specialistCellTypes = null
 
         val result = webTestClient.put().uri("/locations/${cell2.id}/specialist-cell-types")
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
@@ -2123,7 +2123,7 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
           .expectBody(LocationTest::class.java)
           .returnResult().responseBody!!
 
-        assertThat(result.usedFor == expectedUsedFor)
+        assertThat(result.specialistCellTypes == specialistCellTypes)
 
         getDomainEvents(1).let {
           assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -2174,6 +2174,25 @@ class LocationResourceIntTest : SqsIntegrationTestBase() {
           .exchange()
           .expectStatus().isEqualTo(404)
       }
+
+      @Test
+      fun `cannot remove specialists cell types if capacity is 0 for normal accommodations`() {
+        val testCell = repository.save(
+          buildCell(
+            pathHierarchy = "Z-1-005",
+            capacity = Capacity(maxCapacity = 2, workingCapacity = 0),
+            certification = Certification(certified = true, capacityOfCertifiedCell = 2),
+            specialistCellType = SpecialistCellType.ACCESSIBLE_CELL,
+          ),
+        )
+
+        webTestClient.put().uri("/locations/${testCell.id}/specialist-cell-types")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(emptySet<SpecialistCellType>()))
+          .exchange()
+          .expectStatus().isEqualTo(400)
+      }
     }
 
     @Nested


### PR DESCRIPTION
Initial version, still need to add to the validation logic, see [issue](https://dsdmoj.atlassian.net/browse/MAP-1395?focusedCommentId=480549)

Adds a new endpoint and removes the update of the specialist cell types as part of **PATCH  /locations/residential/{id}**