### PR TITLE
MAP-1457 112 LocationGroupDto class PrisonId Groups Resource to standard Test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationGroupDtoListTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationGroupDtoListTest.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+class LocationGroupDtoListTest(
+
+  val LocationGroupDto: List<LocationGroupDto>? = null,
+
+)


### PR DESCRIPTION
As part of better Kotlin Test practices.
Get rid of Json strings in the test
Use a Class to get the webservice answer as LocationTest example
