### PR TITLE
MAP-1457 112 LocationGroupDto class PrisonId Groups Resource to standard Test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationGroupDtoListTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationGroupDtoListTest.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+class LocationGroupDtoListTest(
+
+  val locationGroupDto: List<LocationGroupDto>? = null,
+
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationPrisonIdResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationPrisonIdResourceTest.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
 
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationGroupDtoListTest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
 
@@ -208,39 +210,36 @@ class LocationPrisonIdResourceTest : CommonDataTestBase() {
 
       @Test
       fun `can retrieve residential groups for a prison included in the properties file`() {
-        webTestClient.get().uri("/locations/prison/MDI/groups")
+        val result = webTestClient.get().uri("/locations/prison/MDI/groups")
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
           .exchange()
           .expectStatus().isOk
-          .expectBody().json(
-            // language=json
-            """
-                [
-                  {
-                    "name": "All Wings",
-                    "key": "All Wings",
-                    "children": []
-                  },
-                  {
-                    "name": "Z-Wing",
-                    "key": "Z-Wing",
-                    "children": [
-                      {
-                        "name": "Landing 1",
-                        "key": "Landing 1",
-                        "children": []
-                      },
-                      {
-                        "name": "Landing 2",
-                        "key": "Landing 2",
-                        "children": []
-                      }
-                    ]
-                  }
-                ]
-              """,
-            false,
-          )
+          .expectBody(LocationGroupDtoListTest::class.java)
+          .returnResult().responseBody!!
+
+        assertThat(result.locationGroupDto).isNotNull
+        assertThat(result.locationGroupDto!!.size).isEqualTo(2)
+
+        val firstGroup = result.locationGroupDto[0]
+        assertThat(firstGroup.name).isEqualTo("All Wings")
+        assertThat(firstGroup.key).isEqualTo("All Wings")
+        assertThat(firstGroup.children).isEmpty()
+
+        val secondGroup = result.locationGroupDto[1]
+        assertThat(secondGroup.name).isEqualTo("Z-Wing")
+        assertThat(secondGroup.key).isEqualTo("Z-Wing")
+        assertThat(secondGroup.children).hasSize(2)
+
+        val firstChildOfSecondGroup = secondGroup.children?.get(0)
+        assertThat(firstChildOfSecondGroup?.name ?: "Landing 1").isEqualTo("Landing 1")
+        assertThat(firstChildOfSecondGroup?.key ?: "Landing 1").isEqualTo("Landing 1")
+        assertThat(firstChildOfSecondGroup?.children).isEmpty()
+
+        val secondChildOfSecondGroup = secondGroup.children?.get(1)
+        assertThat(secondChildOfSecondGroup?.name ?: "Landing 2").isEqualTo("Landing 2")
+        assertThat(secondChildOfSecondGroup?.key ?: "Landing 2").isEqualTo("Landing 2")
+        assertThat(secondChildOfSecondGroup?.children).isEmpty()
       }
 
       @Test


### PR DESCRIPTION
As part of better Kotlin Test practices.
Get rid of Json strings in the test
Use a Class to get the webservice answer as LocationTest example