### PR TITLE
MAP-1571 revert the removal of gradle property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@
 #
 # To stop the dps-gradle-spring-boot project from overwriting any project specific customisations here, remove the
 # warning at the top of this file.
+kotlin.incremental.useClasspathSnapshot=false


### PR DESCRIPTION
Removal was done in previous commit and is possibly the cause of a build fail in Circle