### PR TITLE
MAP-1457 301 NomisMigrationRequest coverage and DTO responseBody refactor


### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -64,6 +64,42 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
   lateinit var nonRes: NonResidentialLocation
   lateinit var locationHistory: LocationHistory
 
+  fun migrateRequestGeneration(deactivationReason: NomisDeactivatedReason): NomisMigrateLocationRequest {
+    var migrateRequest = NomisMigrateLocationRequest(
+      prisonId = "ZZGHI",
+      code = "002",
+      locationType = LocationType.CELL,
+      residentialHousingType = ResidentialHousingType.NORMAL_ACCOMMODATION,
+      comments = "This is a new cell",
+      orderWithinParentLocation = 1,
+      lastUpdatedBy = "user",
+      parentLocationPath = "B-1",
+      deactivationReason = deactivationReason,
+      proposedReactivationDate = LocalDateTime.now(clock).plusMonths(1).toLocalDate(),
+      lastModifiedDate = LocalDateTime.now(clock).minusYears(2),
+      capacity = CapacityDTO(1, 1),
+      certification = CertificationDTO(true, 1),
+      attributes = setOf(ResidentialAttributeValue.CAT_B),
+      history = listOf(
+        ChangeHistory(
+          attribute = LocationAttribute.DESCRIPTION.name,
+          oldValue = null,
+          newValue = "A New Cell",
+          amendedBy = "user2",
+          amendedDate = LocalDateTime.now(clock).minusYears(2),
+        ),
+        ChangeHistory(
+          attribute = LocationAttribute.COMMENTS.name,
+          oldValue = "Old comment",
+          newValue = "This is a new cell",
+          amendedBy = "user1",
+          amendedDate = LocalDateTime.now(clock).minusYears(1),
+        ),
+      ),
+    )
+    return migrateRequest
+  }
+
   @BeforeEach
   fun setUp() {
     locationHistoryRepository.deleteAll()
@@ -668,38 +704,7 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
   @DisplayName("POST /migrate/location")
   @Nested
   inner class MigrateLocationTest {
-    var migrateRequest = NomisMigrateLocationRequest(
-      prisonId = "ZZGHI",
-      code = "002",
-      locationType = LocationType.CELL,
-      residentialHousingType = ResidentialHousingType.NORMAL_ACCOMMODATION,
-      comments = "This is a new cell",
-      orderWithinParentLocation = 1,
-      lastUpdatedBy = "user",
-      parentLocationPath = "B-1",
-      deactivationReason = NomisDeactivatedReason.DAMAGED,
-      proposedReactivationDate = LocalDateTime.now(clock).plusMonths(1).toLocalDate(),
-      lastModifiedDate = LocalDateTime.now(clock).minusYears(2),
-      capacity = CapacityDTO(1, 1),
-      certification = CertificationDTO(true, 1),
-      attributes = setOf(ResidentialAttributeValue.CAT_B),
-      history = listOf(
-        ChangeHistory(
-          attribute = LocationAttribute.DESCRIPTION.name,
-          oldValue = null,
-          newValue = "A New Cell",
-          amendedBy = "user2",
-          amendedDate = LocalDateTime.now(clock).minusYears(2),
-        ),
-        ChangeHistory(
-          attribute = LocationAttribute.COMMENTS.name,
-          oldValue = "Old comment",
-          newValue = "This is a new cell",
-          amendedBy = "user1",
-          amendedDate = LocalDateTime.now(clock).minusYears(1),
-        ),
-      ),
-    )
+    var migrateRequest = migrateRequestGeneration(NomisDeactivatedReason.DAMAGED)
 
     @Nested
     inner class Security {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -783,15 +783,12 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
         assertThat(result.getKey()).isEqualTo("ZZGHI-B-1-002")
         assertThat(result.comments).isEqualTo("This is a new cell")
         assertThat(result.orderWithinParentLocation).isEqualTo(1)
-
         assertThat(result.capacity).isNotNull
         assertThat(result.capacity?.maxCapacity).isEqualTo(1)
         assertThat(result.capacity?.workingCapacity).isEqualTo(1)
-
         assertThat(result.attributes).isNotEmpty
         assertThat(result.attributes).contains(ResidentialAttributeValue.CAT_B)
-
-        assertThat(result.deactivatedReason).isEqualTo(DeactivatedReason.DAMAGED)
+        assertThat(result.deactivatedReason).isEqualTo(DeactivatedReason.valueOf(migrateRequest.deactivationReason.toString()))
         assertThat(result.proposedReactivationDate).isEqualTo(migrateRequest.proposedReactivationDate)
 
         webTestClient.get().uri("/locations/key/ZZGHI-B-1-002?includeHistory=true")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -941,6 +941,70 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
             false,
           )
       }
+
+      @Test
+      fun `can migrate a location different deactivationReason REFURBISHMENT`() {
+        migrateRequest = migrateRequestGeneration(NomisDeactivatedReason.REFURBISHMENT)
+
+        val result = webTestClient.post().uri("/migrate/location")
+          .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(migrateRequest))
+          .exchange()
+          .expectStatus().isCreated
+          .expectBody(LegacyLocation::class.java)
+          .returnResult().responseBody!!
+
+        assertThat(result.deactivatedReason).isEqualTo(DeactivatedReason.valueOf(migrateRequest.deactivationReason.toString()))
+      }
+
+      @Test
+      fun `can migrate a location different deactivationReason Refurbishment`() {
+        migrateRequest = migrateRequestGeneration(NomisDeactivatedReason.REFURBISHMENT)
+
+        val result = webTestClient.post().uri("/migrate/location")
+          .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(migrateRequest))
+          .exchange()
+          .expectStatus().isCreated
+          .expectBody(LegacyLocation::class.java)
+          .returnResult().responseBody!!
+
+        assertThat(result.deactivatedReason).isEqualTo(DeactivatedReason.valueOf(migrateRequest.deactivationReason.toString()))
+      }
+
+      @Test
+      fun `can migrate a location different deactivationReason Staff shortage`() {
+        migrateRequest = migrateRequestGeneration(NomisDeactivatedReason.STAFF_SHORTAGE)
+
+        val result = webTestClient.post().uri("/migrate/location")
+          .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(migrateRequest))
+          .exchange()
+          .expectStatus().isCreated
+          .expectBody(LegacyLocation::class.java)
+          .returnResult().responseBody!!
+
+        assertThat(result.deactivatedReason).isEqualTo(DeactivatedReason.valueOf(migrateRequest.deactivationReason.toString()))
+      }
+
+      @Test
+      fun `can migrate a location different deactivationReason Mothballed`() {
+        migrateRequest = migrateRequestGeneration(NomisDeactivatedReason.MOTHBALLED)
+
+        val result = webTestClient.post().uri("/migrate/location")
+          .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(migrateRequest))
+          .exchange()
+          .expectStatus().isCreated
+          .expectBody(LegacyLocation::class.java)
+          .returnResult().responseBody!!
+
+        assertThat(result.deactivatedReason).isEqualTo(DeactivatedReason.valueOf(migrateRequest.deactivationReason.toString()))
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -943,8 +943,8 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
       }
 
       @Test
-      fun `can migrate a location different deactivationReason REFURBISHMENT`() {
-        migrateRequest = migrateRequestGeneration(NomisDeactivatedReason.REFURBISHMENT)
+      fun `can migrate a location different deactivationReason Local Work`() {
+        migrateRequest = migrateRequestGeneration(NomisDeactivatedReason.LOCAL_WORK)
 
         val result = webTestClient.post().uri("/migrate/location")
           .headers(setAuthorisation(roles = listOf("ROLE_MIGRATE_LOCATIONS"), scopes = listOf("write")))
@@ -955,7 +955,7 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
           .expectBody(LegacyLocation::class.java)
           .returnResult().responseBody!!
 
-        assertThat(result.deactivatedReason).isEqualTo(DeactivatedReason.valueOf(migrateRequest.deactivationReason.toString()))
+        assertThat(result.deactivatedReason).isEqualTo(DeactivatedReason.MAINTENANCE)
       }
 
       @Test


### PR DESCRIPTION
As developer we need to cover Kover report red line scenarios.
This scenario cover Branch % need to be tested.

I have refactor a request in order to reuse it. I would use lambda in the test and do **much abstract** but it would require bit more time from my side. but It would reduce number of line.

There are fewer DeactivatedReason scenarios still need to be covered which I will send in a new PR.

before
![image](https://github.com/user-attachments/assets/2408883b-b935-4b0a-ba0e-f2089304e462)

after
![image](https://github.com/user-attachments/assets/30bec438-aa01-4643-b60c-d80befcec843)
