### PR TITLE
Reset the value for OTHER when changing to another type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -169,6 +169,8 @@ class Cell(
     this.convertedCellType = convertedCellType
     if (convertedCellType == ConvertedCellType.OTHER) {
       this.otherConvertedCellType = otherConvertedCellType
+    } else {
+      this.otherConvertedCellType = null
     }
 
     this.updatedBy = userOrSystemInContext

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResourceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -1957,6 +1958,7 @@ class LocationResidentialResourceTest : CommonDataTestBase() {
           .returnResult().responseBody!!
 
         assertThat(result.findByPathHierarchy("Z-1-001")!!.convertedCellType == ConvertedCellType.OFFICE)
+        Assertions.assertNull(result.findByPathHierarchy("Z-1-001")!!.otherConvertedCellType)
 
         getDomainEvents(1).let {
           assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(


### PR DESCRIPTION
for non resi

Fortunately, there is an existing test which does the change from OTHER to another type, I just added a check that the value was reset to null and implemented the logic.

The issue is described in https://dsdmoj.atlassian.net/browse/MAP-1669