### PR TITLE
MAP-1808 enable sorting and formatting for some endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationPrisonIdResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationPrisonIdResource.kt
@@ -26,7 +26,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PrisonHierarchyDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationService
-import java.util.*
+import java.util.UUID
 
 @RestController
 @Validated
@@ -353,7 +353,10 @@ class LocationPrisonIdResource(
     @Schema(description = "Usage type", example = "APPOINTMENTS", required = true)
     @PathVariable
     usageType: NonResidentialUsageType,
-  ): List<Location> = locationService.getLocationsByPrisonAndNonResidentialUsageType(prisonId, usageType)
+    @RequestParam(name = "sortByLocalName", required = false, defaultValue = "false") sortByLocalName: Boolean = false,
+    @RequestParam(name = "formatLocalName", required = false, defaultValue = "false") formatLocalName: Boolean = false,
+
+    ): List<Location> = locationService.getLocationsByPrisonAndNonResidentialUsageType(prisonId, usageType, sortByLocalName, formatLocalName)
 
   @GetMapping("/prison/{prisonId}/location-type/{locationType}")
   @ResponseStatus(HttpStatus.OK)
@@ -394,5 +397,7 @@ class LocationPrisonIdResource(
     @Schema(description = "Location type", example = "CELL", required = true)
     @PathVariable
     locationType: LocationType,
-  ): List<Location> = locationService.getLocationByPrisonAndLocationType(prisonId, locationType)
+    @RequestParam(name = "sortByLocalName", required = false, defaultValue = "false") sortByLocalName: Boolean = false,
+    @RequestParam(name = "formatLocalName", required = false, defaultValue = "false") formatLocalName: Boolean = false,
+    ): List<Location> = locationService.getLocationByPrisonAndLocationType(prisonId, locationType, sortByLocalName, formatLocalName)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationPrisonIdResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationPrisonIdResource.kt
@@ -355,8 +355,7 @@ class LocationPrisonIdResource(
     usageType: NonResidentialUsageType,
     @RequestParam(name = "sortByLocalName", required = false, defaultValue = "false") sortByLocalName: Boolean = false,
     @RequestParam(name = "formatLocalName", required = false, defaultValue = "false") formatLocalName: Boolean = false,
-
-    ): List<Location> = locationService.getLocationsByPrisonAndNonResidentialUsageType(prisonId, usageType, sortByLocalName, formatLocalName)
+  ): List<Location> = locationService.getLocationsByPrisonAndNonResidentialUsageType(prisonId, usageType, sortByLocalName, formatLocalName)
 
   @GetMapping("/prison/{prisonId}/location-type/{locationType}")
   @ResponseStatus(HttpStatus.OK)
@@ -399,5 +398,5 @@ class LocationPrisonIdResource(
     locationType: LocationType,
     @RequestParam(name = "sortByLocalName", required = false, defaultValue = "false") sortByLocalName: Boolean = false,
     @RequestParam(name = "formatLocalName", required = false, defaultValue = "false") formatLocalName: Boolean = false,
-    ): List<Location> = locationService.getLocationByPrisonAndLocationType(prisonId, locationType, sortByLocalName, formatLocalName)
+  ): List<Location> = locationService.getLocationByPrisonAndLocationType(prisonId, locationType, sortByLocalName, formatLocalName)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
@@ -79,8 +79,8 @@ class LocationResource(
     id: UUID,
     @RequestParam(name = "includeChildren", required = false, defaultValue = "false") includeChildren: Boolean = false,
     @RequestParam(name = "includeHistory", required = false, defaultValue = "false") includeHistory: Boolean = false,
-  ) =
-    locationService.getLocationById(id = id, includeChildren = includeChildren, includeHistory = includeHistory)
+    @RequestParam(name = "formatLocalName", required = false, defaultValue = "false") formatLocalName: Boolean = false,
+  ) = locationService.getLocationById(id = id, includeChildren = includeChildren, includeHistory = includeHistory, formatLocalName = formatLocalName)
       ?: throw LocationNotFoundException(id.toString())
 
   @GetMapping("")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
@@ -81,7 +81,7 @@ class LocationResource(
     @RequestParam(name = "includeHistory", required = false, defaultValue = "false") includeHistory: Boolean = false,
     @RequestParam(name = "formatLocalName", required = false, defaultValue = "false") formatLocalName: Boolean = false,
   ) = locationService.getLocationById(id = id, includeChildren = includeChildren, includeHistory = includeHistory, formatLocalName = formatLocalName)
-      ?: throw LocationNotFoundException(id.toString())
+    ?: throw LocationNotFoundException(id.toString())
 
   @GetMapping("")
   @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -100,10 +100,10 @@ class LocationService(
     includeHistory: Boolean = false,
     formatLocalName: Boolean = false,
   ): LocationDTO? = locationRepository.findById(id).getOrNull()?.toDto(
-      includeChildren = includeChildren,
-      includeHistory = includeHistory,
-      formatLocalName = formatLocalName,
-    )
+    includeChildren = includeChildren,
+    includeHistory = includeHistory,
+    formatLocalName = formatLocalName,
+  )
 
   fun getLocationByPrison(prisonId: String): List<LocationDTO> =
     locationRepository.findAllByPrisonIdOrderByPathHierarchy(prisonId)
@@ -187,10 +187,11 @@ class LocationService(
     val rawResult = nonResidentialLocationRepository.findAllByPrisonIdAndNonResidentialUsages(prisonId, usageType)
       .map { it.toDto(formatLocalName = formatLocalName) }
 
-    return if (sortByLocalName)
+    return if (sortByLocalName) {
       rawResult.sortedBy { it.localName }
-    else
+    } else {
       rawResult
+    }
   }
 
   fun getLocationByKey(key: String, includeChildren: Boolean = false, includeHistory: Boolean = false): LocationDTO? {
@@ -209,21 +210,22 @@ class LocationService(
     return locationRepository.findAll(pageable).map(Location::toLegacyDto)
   }
 
-fun getLocationByPrisonAndLocationType(
-  prisonId: String,
-  locationType: LocationType,
-  sortByLocalName: Boolean = false,
-  formatLocalName: Boolean = false,
-): List<LocationDTO> {
-  val rawResult = locationRepository.findAllByPrisonIdAndLocationTypeOrderByPathHierarchy(prisonId, locationType)
+  fun getLocationByPrisonAndLocationType(
+    prisonId: String,
+    locationType: LocationType,
+    sortByLocalName: Boolean = false,
+    formatLocalName: Boolean = false,
+  ): List<LocationDTO> {
+    val rawResult = locationRepository.findAllByPrisonIdAndLocationTypeOrderByPathHierarchy(prisonId, locationType)
       .filter { it.isActive() }
-    .map { it.toDto(formatLocalName = formatLocalName) }
+      .map { it.toDto(formatLocalName = formatLocalName) }
 
-  return if (sortByLocalName)
-    rawResult.sortedBy { it.localName }
-  else
-    rawResult.sortedBy { it.getKey() }
-}
+    return if (sortByLocalName) {
+      rawResult.sortedBy { it.localName }
+    } else {
+      rawResult.sortedBy { it.getKey() }
+    }
+  }
 
   @Transactional
   fun createResidentialLocation(request: CreateResidentialLocationRequest): LocationDTO {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -94,13 +94,16 @@ class LocationService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getLocationById(id: UUID, includeChildren: Boolean = false, includeHistory: Boolean = false): LocationDTO? {
-    val toDto = locationRepository.findById(id).getOrNull()?.toDto(
+  fun getLocationById(
+    id: UUID,
+    includeChildren: Boolean = false,
+    includeHistory: Boolean = false,
+    formatLocalName: Boolean = false,
+  ): LocationDTO? = locationRepository.findById(id).getOrNull()?.toDto(
       includeChildren = includeChildren,
       includeHistory = includeHistory,
+      formatLocalName = formatLocalName,
     )
-    return toDto
-  }
 
   fun getLocationByPrison(prisonId: String): List<LocationDTO> =
     locationRepository.findAllByPrisonIdOrderByPathHierarchy(prisonId)
@@ -178,11 +181,17 @@ class LocationService(
   fun getLocationsByPrisonAndNonResidentialUsageType(
     prisonId: String,
     usageType: NonResidentialUsageType,
-  ): List<LocationDTO> =
-    nonResidentialLocationRepository.findAllByPrisonIdAndNonResidentialUsages(prisonId, usageType)
-      .map {
-        it.toDto()
-      }
+    sortByLocalName: Boolean = false,
+    formatLocalName: Boolean = false,
+  ): List<LocationDTO> {
+    val rawResult = nonResidentialLocationRepository.findAllByPrisonIdAndNonResidentialUsages(prisonId, usageType)
+      .map { it.toDto(formatLocalName = formatLocalName) }
+
+    return if (sortByLocalName)
+      rawResult.sortedBy { it.localName }
+    else
+      rawResult
+  }
 
   fun getLocationByKey(key: String, includeChildren: Boolean = false, includeHistory: Boolean = false): LocationDTO? {
     return locationRepository.findOneByKey(key)?.toDto(
@@ -200,13 +209,21 @@ class LocationService(
     return locationRepository.findAll(pageable).map(Location::toLegacyDto)
   }
 
-  fun getLocationByPrisonAndLocationType(prisonId: String, locationType: LocationType): List<LocationDTO> =
-    locationRepository.findAllByPrisonIdAndLocationTypeOrderByPathHierarchy(prisonId, locationType)
+fun getLocationByPrisonAndLocationType(
+  prisonId: String,
+  locationType: LocationType,
+  sortByLocalName: Boolean = false,
+  formatLocalName: Boolean = false,
+): List<LocationDTO> {
+  val rawResult = locationRepository.findAllByPrisonIdAndLocationTypeOrderByPathHierarchy(prisonId, locationType)
       .filter { it.isActive() }
-      .map {
-        it.toDto()
-      }
-      .sortedBy { it.getKey() }
+    .map { it.toDto(formatLocalName = formatLocalName) }
+
+  return if (sortByLocalName)
+    rawResult.sortedBy { it.localName }
+  else
+    rawResult.sortedBy { it.getKey() }
+}
 
   @Transactional
   fun createResidentialLocation(request: CreateResidentialLocationRequest): LocationDTO {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationServiceTest.kt
@@ -248,7 +248,6 @@ class LocationServiceTest {
     Assertions.assertThat(nonResLoc[2].localName).isEqualTo("Cc")
   }
 
-
   // getLocationByPrisonAndLocationType
   private val adjRoom1 = buildLocation("A-ADJ-1")
   private val adjRoom2 = buildLocation("A-ADJ-2")
@@ -311,7 +310,6 @@ class LocationServiceTest {
     Assertions.assertThat(nonResLoc[2].localName).isEqualTo("A-ADJ-2")
   }
 
-
   // getLocationPrefixFromGroup
   @Test
   fun `should throw correct exception when location prefix not found`() {
@@ -322,7 +320,7 @@ class LocationServiceTest {
     }
   }
 
-  private fun buildLocation(localName: String): NonResidentialLocation{
+  private fun buildLocation(localName: String): NonResidentialLocation {
     return NonResidentialLocation(
       id = UUID.randomUUID(),
       localName = localName,


### PR DESCRIPTION
enabling sorting of response by localName and formatting by localName for 

- /locations/prison/${prisonId}/non-residential-usage-type/{usageType}`
- /locations/{id}
- /locations/prison/{prisonId}/location-type/{locationType}

options for sorting and formatting passed in query params  sortByLocalName and formatLocalName. Defaulted to false.