### PR TITLE
MAP-2358 Remove old status columns from location table

### DIFF
--- a/src/main/resources/db/migration/V1_50__remove_old_status_columns.sql
+++ b/src/main/resources/db/migration/V1_50__remove_old_status_columns.sql
@@ -1,0 +1,6 @@
+alter table location
+    drop column if exists active;
+
+alter table location
+    drop column if exists archived;
+


### PR DESCRIPTION
## Summary
This Pull Request removes unused status columns (active and archived) from the location table in the database schema.

###  Main Changes
Added a migration script (V1_50__remove_old_status_columns.sql) to:
- Drop the active column from the location table, if it exists.
- Drop the archived column from the location table, if it exists.