### PR TITLE
MAP-2405 Fix datetime in transaction report and add tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/EventBaseResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/EventBaseResource.kt
@@ -16,11 +16,10 @@ abstract class EventBaseResource {
   private lateinit var eventPublishAndAuditService: EventPublishAndAuditService
 
   protected fun publishSignedOpCapChange(
-    event: InternalLocationDomainEventType,
     function: () -> SignedOperationCapacityDto,
   ) = function().also { signedOpCap ->
     eventPublishAndAuditService.signedOpCapEvent(
-      eventType = event,
+      eventType = InternalLocationDomainEventType.SIGNED_OP_CAP_AMENDED,
       signedOperationCapacity = signedOpCap,
       auditData = signedOpCap,
     )
@@ -75,7 +74,7 @@ abstract class EventBaseResource {
 
   protected fun update(updatedLocations: Map<InternalLocationDomainEventType, List<LocationDTO>>): List<Location> = auditAndEmit(InternalLocationDomainEventType.LOCATION_AMENDED, updatedLocations)
 
-  protected fun auditAndEmit(eventType: InternalLocationDomainEventType, locations: Map<InternalLocationDomainEventType, List<Location>>): List<Location> {
+  private fun auditAndEmit(eventType: InternalLocationDomainEventType, locations: Map<InternalLocationDomainEventType, List<Location>>): List<Location> {
     eventPublish { locations }
     locations[eventType]?.forEach {
       audit(it.getKey()) { it.copy(childLocations = null, parentLocation = null) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SignedOperationCapacityResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SignedOperationCapacityResource.kt
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.SignedOperationCapacityDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.SignedOperationCapacityValidRequest
-import uk.gov.justice.digital.hmpps.locationsinsideprison.service.InternalLocationDomainEventType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.SignedOperationCapacityService
 
 @RestController
@@ -119,9 +118,7 @@ class SignedOperationCapacityResource(
     signedOperationCapacityValidRequest: SignedOperationCapacityValidRequest,
   ): ResponseEntity<SignedOperationCapacityDto> {
     val saveSignedOperationalCapacity = signedOperationCapacityService.saveSignedOperationalCapacity(signedOperationCapacityValidRequest)
-    val response = publishSignedOpCapChange(
-      InternalLocationDomainEventType.SIGNED_OP_CAP_AMENDED,
-    ) {
+    val response = publishSignedOpCapChange {
       saveSignedOperationalCapacity.signedOperationCapacityDto
     }
 

--- a/src/main/resources/reports/residential-usage.json
+++ b/src/main/resources/reports/residential-usage.json
@@ -151,7 +151,7 @@
             "sortable": true,
             "visible": "true",
             "defaultsort": false,
-            "default": "${activeCaseloadId}",
+
             "filter": {
               "type": "multiselect",
               "mandatory": false,
@@ -181,7 +181,7 @@
           {
             "name": "$ref:tx_start_time",
             "display": "Transaction time",
-            "formula": "format_date(${tx_start_time}, 'dd/MM/yyyy hh:mm')",
+            "formula": "format_date(${tx_start_time}, 'dd/MM/yyyy HH:mm')",
             "sortable": true,
             "visible": "true",
             "defaultsort": true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/ManageUsersApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/ManageUsersApiMockServer.kt
@@ -25,4 +25,49 @@ class ManageUsersApiMockServer : WireMockServer(WIREMOCK_PORT) {
       ),
     )
   }
+
+  fun stubLookupUserCaseload(
+    username: String = "request-user",
+    activeCaseload: String = "LEI",
+    otherCaseloads: List<String> = emptyList(),
+  ) {
+    val otherCaseloadJson: String = otherCaseloads.joinToString { ",{\"id\": \"$it\", \"name\": \"$it\"}" }
+    val payload = """
+        {
+          "username": "$username",
+          "active": true,
+          "accountType": "GENERAL",
+          "activeCaseload": { "id": "$activeCaseload", "name": "$activeCaseload" },
+          "caseloads": [
+            {
+              "id": "$activeCaseload",
+              "name": "$activeCaseload"
+            }
+             $otherCaseloadJson
+          ]
+        }
+    """.trimIndent()
+    stubFor(
+      get("/prisonusers/$username/caseloads")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(payload).withStatus(200),
+        ),
+    )
+  }
+
+  fun stubLookupUsersRoles(username: String = "request-user", roles: List<String> = emptyList()) {
+    stubFor(
+      get("/users/$username/roles")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsBytes(roles.map { RolesResponse(it) })).withStatus(200),
+        ),
+    )
+  }
+  data class RolesResponse(
+    val roleCode: String,
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DprReportingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DprReportingIntegrationTest.kt
@@ -1,0 +1,203 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import org.springframework.beans.factory.annotation.Value
+import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
+
+private const val REQUESTING_USER = "request-user"
+
+@DisplayName("DPR reporting resource tests")
+class DprReportingIntegrationTest : CommonDataTestBase() {
+
+  @Value("\${dpr.lib.system.role}")
+  lateinit var systemRole: String
+
+  @BeforeEach
+  override fun setUp() {
+    super.setUp()
+    manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("MANAGE_RES_LOCATIONS_OP_CAP"))
+    manageUsersApiMockServer.stubLookupUserCaseload(REQUESTING_USER, "LEI", listOf("MDI"))
+  }
+
+  @DisplayName("GET /definitions")
+  @Nested
+  inner class GetDefinitions {
+    private val url = "/definitions"
+
+    @DisplayName("is secured")
+    @Nested
+    inner class Security {
+      @DisplayName("by role and scope")
+      @TestFactory
+      fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+        webTestClient.get().uri(url),
+        systemRole,
+      )
+    }
+
+    @DisplayName("works")
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `returns the definitions of all the reports`() {
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().jsonPath("$.length()").isEqualTo(1)
+          .jsonPath("$[0].authorised").isEqualTo("true")
+      }
+
+      @Test
+      fun `returns the definitions of all the reports but not authorises as no user in context`() {
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = null, roles = listOf(systemRole), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().jsonPath("$.length()").isEqualTo(1)
+          .jsonPath("$[0].authorised").isEqualTo("false")
+      }
+
+      @Test
+      fun `returns the not auth definitions of the reports`() {
+        manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("ANOTHER_USER_ROLE"))
+
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.length()").isEqualTo(1)
+          .jsonPath("$[0].authorised").isEqualTo("false")
+      }
+    }
+  }
+
+  @DisplayName("GET /definitions/transactions/residential")
+  @Nested
+  inner class GetDefinitionDetails {
+    private val url = "/definitions/transactions/residential"
+
+    @DisplayName("is secured")
+    @Nested
+    inner class Security {
+      @DisplayName("by role and scope")
+      @TestFactory
+      fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+        webTestClient.get().uri(url),
+        systemRole,
+      )
+    }
+
+    @Test
+    fun `report definition denied when user has incorrect role`() {
+      manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("ANOTHER_USER_ROLE"))
+
+      webTestClient.get().uri(url)
+        .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @DisplayName("works")
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `returns the definition of the report`() {
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .json(
+            // language=json
+            """
+           {
+              "id": "transactions",
+              "name": "Transactions for locations",
+              "description": "List of transactions in locations",
+              "variant": {
+                "id": "residential",
+                "name": "Transactions for residential locations",
+                "resourceName": "reports/transactions/residential",
+                "description": "Details each transaction that has occurred in a residential location",
+                "printable": true
+              }
+            }
+            """,
+          )
+      }
+    }
+  }
+
+  @DisplayName("GET /reports")
+  @Nested
+  inner class GetReports {
+    @DisplayName("GET /reports/transactions/residential")
+    @Nested
+    inner class RunTransactionReport {
+      private val url = "/reports/transactions/residential"
+
+      @DisplayName("is secured")
+      @Nested
+      inner class Security {
+        @DisplayName("by role and scope")
+        @TestFactory
+        fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+          webTestClient.get().uri(url),
+          systemRole,
+        )
+      }
+
+      @Test
+      fun `returns 403 when user does not have the role`() {
+        manageUsersApiMockServer.stubLookupUsersRoles(REQUESTING_USER, listOf("ANOTHER_USER_ROLE"))
+
+        webTestClient.get().uri(url)
+          .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @DisplayName("works")
+      @Nested
+      inner class HappyPath {
+
+        @Test
+        fun `returns a page of the report`() {
+          webTestClient.get().uri(url)
+            .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+            .header("Content-Type", "application/json")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody().jsonPath("$.length()").isEqualTo(10)
+        }
+
+        @Test
+        fun `returns no data when user does not have the caseload`() {
+          manageUsersApiMockServer.stubLookupUserCaseload(REQUESTING_USER, "BXI", listOf("BXI"))
+
+          webTestClient.get().uri(url)
+            .headers(setAuthorisation(user = REQUESTING_USER, roles = listOf(systemRole), scopes = listOf("read")))
+            .header("Content-Type", "application/json")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.length()").isEqualTo(0)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This Pull Request introduces enhancements and adjustments to the codebase, focusing on event handling, scope/access checks, and security-related functionality. It includes changes to event publishing methods, additional integration tests, improved test data mocking, and minor fixes in a JSON report configuration.
### Main Changes
- DPR Report Fixes:
  - Adjusted date formatting in the residential-usage.json file for consistency (uses 24-hour format).
  - Removed an unused default value field from the configuration.
- Event Methods Updates:
  - Refactoring of publishSignedOpCapChange to default event type SIGNED_OP_CAP_AMENDED.
  - Changed access modifier for auditAndEmit from protected to private.
- Integration Test Improvements:
  - Added new dynamic tests for endpoint authorization in IntegrationTestBase.
  - Comprehensive new tests for DprReportingIntegrationTest to validate security and functionality for reporting endpoints.
- Mocking Enhancements:
  - Extended ManageUsersApiMockServer to include stubbing methods for user caseload and roles to support new tests.
- General Code Cleanup:
  - Removed unused imports and other minor refactoring in existing files for better readability and maintainability.