### PR TITLE
MAP-2401 Creation of cells on new or existing level, create any level with or without cells, validate no location clashes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResource.kt
@@ -150,11 +150,7 @@ class LocationResidentialResource(
     @RequestBody
     @Validated
     wingAndStructureRequest: CreateWingAndStructureRequest,
-  ): Location = eventPublishAndAudit(
-    InternalLocationDomainEventType.LOCATION_CREATED,
-  ) {
-    locationService.createWing(wingAndStructureRequest)
-  }
+  ): Location = locationService.createWing(wingAndStructureRequest)
 
   @PostMapping("/create-entire-wing", produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasRole('ROLE_MAINTAIN_LOCATIONS') and hasAuthority('SCOPE_write')")
@@ -236,11 +232,7 @@ class LocationResidentialResource(
     @RequestBody
     @Validated
     createCellsRequest: CellInitialisationRequest,
-  ): Location = eventPublishAndAudit(
-    InternalLocationDomainEventType.LOCATION_CREATED,
-  ) {
-    locationService.createCells(createCellsRequest)
-  }
+  ): Location = locationService.createCells(createCellsRequest)
 
   @PostMapping("/residential", produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasRole('ROLE_MAINTAIN_LOCATIONS') and hasAuthority('SCOPE_write')")


### PR DESCRIPTION
### Summary

This pull request introduces enhancements to support the creation of cells on higher hierarchical levels. The changes include:

- Adding an optional `newLevelAboveCells` field in the `CellInitialisationRequest`.
- Updating service logic to handle requests with or without parent-level structures.
- Implementing validations to prevent location code clashes.
- Simplifying related DTOs and test implementations for better maintainability.

### Main Changes:
- Refactored CellInitialisationRequest:
  - Removed redundant fields (newLevelCode, newLevelDescription, etc.).
  - Added the newLevelAboveCells data class for handling structural locations more robustly.
  - Enhanced validation rules to ensure either a parentLocation or newLevelAboveCells is mandatory.
  - Removed the internal createLocation function and incorporated its functionality into LevelAboveCells.
- API Updates in LocationResidentialResource:
  - Removed calls to eventPublishAndAudit for simplified location and cell creation endpoints.
Adjusted endpoints to align with the refactored data structure.
- Service Layer Improvements in LocationService:
  - Replaced direct calls to locationRepository with residentialLocationRepository.
  - Redesigned the cell creation logic to support hierarchical structures using newLevelAboveCells.
- Unit Test Updates:
  - Enhanced and added test cases to cover edge scenarios, including requests with missing parentLocation or newLevelAboveCells, and duplicate cell location validation.
- General Cleanup:
  - Removed legacy or unused attributes and methods.
  - Updated documentation within annotations to reflect the new structure.