### PR TITLE
MAP-2412 Refactor cell creation logic and add specialist cell validations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellInitialisationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellInitialisationRequest.kt
@@ -54,8 +54,13 @@ data class CellInitialisationRequest(
   @Schema(description = "Used For Types for all cells", required = false)
   val cellsUsedFor: Set<UsedForType>? = null,
 
-  @Schema(description = "In-cell sanitation for all cells", required = false, defaultValue = "true")
-  val inCellSanitation: Boolean = true,
+  @Schema(
+    description = "Accommodation Type for all cells",
+    required = false,
+    defaultValue = "NORMAL_ACCOMMODATION",
+    example = "NORMAL_ACCOMMODATION",
+  )
+  val accommodationType: AccommodationType = AccommodationType.NORMAL_ACCOMMODATION,
 
   val cells: Set<NewCellRequest>,
 ) {
@@ -64,19 +69,19 @@ data class CellInitialisationRequest(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun creatCells(
+  fun createCells(
     createdBy: String,
     clock: Clock,
     linkedTransaction: LinkedTransaction,
     location: ResidentialLocation,
-  ): List<Cell> = cells.map { cell ->
+  ) = cells.map { cell ->
     Cell(
       prisonId = prisonId,
       code = cell.code,
       cellMark = cell.cellMark,
       pathHierarchy = "${location.getPathHierarchy()}-${cell.code}",
       status = LocationStatus.DRAFT,
-      accommodationType = cell.accommodationType,
+      accommodationType = accommodationType,
       createdBy = createdBy,
       whenCreated = LocalDateTime.now(clock),
       childLocations = mutableListOf(),
@@ -85,7 +90,7 @@ data class CellInitialisationRequest(
         workingCapacity = cell.workingCapacity,
       ),
       certification = Certification(capacityOfCertifiedCell = cell.capacityNormalAccommodation),
-      inCellSanitation = inCellSanitation,
+      inCellSanitation = cell.inCellSanitation,
     ).apply {
       cell.specialistCellTypes?.forEach {
         addSpecialistCellType(
@@ -162,14 +167,6 @@ data class NewCellRequest(
   @field:Size(max = 12, message = "Mark must be up to 12 characters")
   val cellMark: String? = null,
 
-  @Schema(
-    description = "Accommodation Type",
-    required = false,
-    defaultValue = "NORMAL_ACCOMMODATION",
-    example = "NORMAL_ACCOMMODATION",
-  )
-  val accommodationType: AccommodationType = AccommodationType.NORMAL_ACCOMMODATION,
-
   @Schema(description = "CNA value", required = false, defaultValue = "0")
   @field:Max(value = 99, message = "CNA cannot be greater than 99")
   @field:PositiveOrZero(message = "CNA cannot be less than 0")
@@ -187,6 +184,9 @@ data class NewCellRequest(
 
   @Schema(description = "Specialist Cell Types", required = false)
   val specialistCellTypes: Set<SpecialistCellType>? = null,
+
+  @Schema(description = "In-cell sanitation for cell", required = false, defaultValue = "true")
+  val inCellSanitation: Boolean = true,
 )
 
 enum class ResidentialStructuralType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/SpecialistCellType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/SpecialistCellType.kt
@@ -7,15 +7,21 @@ import io.swagger.v3.oas.annotations.media.Schema
 @JsonInclude(JsonInclude.Include.NON_NULL)
 enum class SpecialistCellType(
   val description: String,
+  val affectsCapacity: Boolean = false,
   val additionalInformation: String? = null,
   val sequence: Int = 99,
 ) {
-  ACCESSIBLE_CELL("Accessible cell", "Also known as wheelchair accessible or Disability and Discrimination Act (DDA) compliant", 1),
-  BIOHAZARD_DIRTY_PROTEST("Biohazard / dirty protest cell", "Previously known as a dirty protest cell", 2),
-  CSU("Care and separation cell", sequence = 3),
+  ACCESSIBLE_CELL("Accessible cell", additionalInformation = "Also known as wheelchair accessible or Disability and Discrimination Act (DDA) compliant", sequence = 1),
+  BIOHAZARD_DIRTY_PROTEST(
+    "Biohazard / dirty protest cell",
+    additionalInformation = "Previously known as a dirty protest cell",
+    sequence = 2,
+    affectsCapacity = true,
+  ),
+  CSU("Care and separation cell", sequence = 3, affectsCapacity = true),
   CAT_A("Cat A cell", sequence = 4),
   CONSTANT_SUPERVISION("Constant supervision cell", sequence = 5),
-  DRY("Dry cell", sequence = 6),
+  DRY("Dry cell", sequence = 6, affectsCapacity = true),
   ESCAPE_LIST("Escape list cell", sequence = 7),
   ISOLATION_DISEASES("Isolation cell for communicable diseases", sequence = 8),
   LISTENER_CRISIS("Listener / crisis cell", sequence = 9),


### PR DESCRIPTION
### Description of changes

- Refactored `createLandingRequest` to a Kotlin function for improved test readability and maintainability.
- Added validation for specialist cell types that affect capacity when CNA or working capacity are not zero.
- Updated schema and DTOs to support related field changes for better input handling.

This Pull Request introduces significant updates to the cell creation logic and related files. The changes primarily affect the handling of CellInitialisationRequest, inclusion of additional constraints and properties to cells, amendments to the SpecialistCellType behavior, as well as corresponding updates to services and tests.

### Main Changes:
- Updated CellInitialisationRequest DTO:
  - Added a new field accommodationType with default value NORMAL_ACCOMMODATION.
  - Refactored inCellSanitation to be specific to individual cells instead of applying globally.
  - Minor typo correction: renamed method creatCells to createCells.
- Modified cell creation logic:
  - Adjusted to use accommodationType globally for cells instead of per cell.
  - Added validation to prevent specialist cell types (affectsCapacity) from being set alongside non-zero CNA or working capacity.
- Updated SpecialistCellType enum:
  - Introduced a new property, affectsCapacity, to indicate if certain types impact capacity and included it for specific cell types.
- Refactored Tests:
  - Enhanced test coverage for validation (e.g., rejecting specialist cells with improper capacity settings).
  - Refactored test logic to utilize a newly parameterized createLandingRequest.
  - Simplified request construction logic for better readability and reuse.
This update enhances the flexibility, validation, and clarity of cell creation and configuration workflows.

### Checklist

- [x] Tests have been added or updated where necessary.
- [x] Documentation has been updated (if applicable).
- [x] All code passes linting and formatting checks.
- [x] Commits follow the project's code style guidelines.
- [ ] Changes have been reviewed and approved by at least one other contributor.