### PR TITLE
MAP-2411 return all child locations deleted - but don't publish if DRAFT

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -143,7 +143,7 @@ class LocationService(
       null,
     )
     tx.txEndTime = LocalDateTime.now(clock)
-  }?.toDto()
+  }?.toDto(includeChildren = true)
     ?: throw LocationNotFoundException(id.toString())
 
   fun getLocationByPrison(prisonId: String): List<LocationDTO> = locationRepository.findAllByPrisonIdOrderByPathHierarchy(prisonId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
@@ -556,6 +556,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
           .expectStatus().isNoContent
 
         assertThat(repository.findById(cell1.id!!)).isEmpty
+
+        assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero()
       }
 
       @Test
@@ -567,6 +569,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
           .expectStatus().isNoContent
 
         assertThat(repository.findById(landing1.id!!)).isEmpty
+
+        assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero()
       }
 
       @Test
@@ -577,6 +581,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
           .expectStatus().isNoContent
 
         assertThat(repository.findById(draftWing.id!!)).isEmpty
+
+        assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero()
       }
     }
   }


### PR DESCRIPTION
### Summary
This Pull Request introduces changes to the LocationService class to return all the sub location that are affect  by the delete and checks that no events are emitted for draft location that were deleted.
- LocationService.kt:
  - Modified the toDto() method call to include children by passing a new argument includeChildren = true.
  - This change affects how DTOs are generated, potentially adding more detailed data.
- DraftLocationResourceTest.kt:
  - Added assertions in existing tests to check that the number of messages in the queue is zero after certain operations.
  - These assertions enhance the test coverage by validating message queue states.