### PR TITLE
Rename SQS secret key in Helm values files

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,7 +26,7 @@ generic-service:
       HMPPS_SQS_QUEUES_LOCATIONSINSIDEPRISON_QUEUE_NAME: "sqs_queue_name"
     sqs-prisoner-event-queue-dlq-secret:
       HMPPS_SQS_QUEUES_LOCATIONSINSIDEPRISON_DLQ_NAME: "sqs_queue_name"
-    sqs-update-from-external-system-events-secret:
+    sqs-update-from-external-system-events-queue-secret:
       HMPPS_SQS_QUEUES_UPDATEFROMEXTERNALSYSTEMEVENTS_QUEUE_NAME: "sqs_queue_name"
     sqs-update-from-external-system-events-dlq-secret:
       HMPPS_SQS_QUEUES_UPDATEFROMEXTERNALSYSTEMEVENTS_DLQ_NAME: "sqs_queue_name"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -26,7 +26,7 @@ generic-service:
       HMPPS_SQS_QUEUES_LOCATIONSINSIDEPRISON_QUEUE_NAME: "sqs_queue_name"
     sqs-prisoner-event-queue-dlq-secret:
       HMPPS_SQS_QUEUES_LOCATIONSINSIDEPRISON_DLQ_NAME: "sqs_queue_name"
-    sqs-update-from-external-system-events-secret:
+    sqs-update-from-external-system-events-queue-secret:
       HMPPS_SQS_QUEUES_UPDATEFROMEXTERNALSYSTEMEVENTS_QUEUE_NAME: "sqs_queue_name"
     sqs-update-from-external-system-events-dlq-secret:
       HMPPS_SQS_QUEUES_UPDATEFROMEXTERNALSYSTEMEVENTS_DLQ_NAME: "sqs_queue_name"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -25,7 +25,7 @@ generic-service:
       HMPPS_SQS_QUEUES_LOCATIONSINSIDEPRISON_QUEUE_NAME: "sqs_queue_name"
     sqs-prisoner-event-queue-dlq-secret:
       HMPPS_SQS_QUEUES_LOCATIONSINSIDEPRISON_DLQ_NAME: "sqs_queue_name"
-    sqs-update-from-external-system-events-secret:
+    sqs-update-from-external-system-events-queue-secret:
       HMPPS_SQS_QUEUES_UPDATEFROMEXTERNALSYSTEMEVENTS_QUEUE_NAME: "sqs_queue_name"
     sqs-update-from-external-system-events-dlq-secret:
       HMPPS_SQS_QUEUES_UPDATEFROMEXTERNALSYSTEMEVENTS_DLQ_NAME: "sqs_queue_name"


### PR DESCRIPTION
This Pull Request updates configuration values across three Helm deployment files to correct the naming of an SQS queue secret.
###  Main Changes
- Renamed the key sqs-update-from-external-system-events-secret to sqs-update-from-external-system-events-queue-secret in the following files:
  - values-dev.yaml
  - values-preprod.yaml
  - values-prod.yaml
The modification ensures consistent and accurate naming for the corresponding secret in the SQS queue configurations.