### PR TITLE
MAP-2449 `Update queue and DLQ configurations to use random UUIDs`

### DIFF
--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -4,8 +4,8 @@ hmpps.sqs:
     audit:
       queueName: ${random.uuid}
     updatefromexternalsystemevents:
-      queueName: update_from_external_system_events_queue
-      dlqName: update_from_external_system_events_dlq
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/main/resources/application-train.yml
+++ b/src/main/resources/application-train.yml
@@ -3,6 +3,9 @@ hmpps.sqs:
   queues:
     audit:
       queueName: ${random.uuid}
+  updatefromexternalsystemevents:
+    queueName: ${random.uuid}
+    dlqName: ${random.uuid}
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -40,8 +40,8 @@ hmpps.sqs:
       subscribeTopicId: domainevents
       subscribeFilter: '{"eventType":[ {"prefix": "location.inside.prison"} ] }'
     updatefromexternalsystemevents:
-      queueName: update_from_external_system_events_queue
-      dlqName: update_from_external_system_events_dlq
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}


### PR DESCRIPTION
The Pull Request updates multiple configuration YAML files to replace hardcoded queue and DLQ names with dynamically generated UUIDs. These changes likely aim to enhance configurability and reduce hardcoding.
### Main Changes
- In application-localstack.yml, replaced hardcoded queueName and dlqName values for updatefromexternalsystemevents with random UUIDs.
- In application-train.yml, added new configuration entries for updatefromexternalsystemevents with dynamically generated queueName and dlqName.
- In application-test.yml, updated queueName and dlqName values for updatefromexternalsystemevents to use random UUIDs instead of hardcoded names.