### PR TITLE
MAP-2449 Fix indentation in train YAML queue configuration

### DIFF
--- a/src/main/resources/application-train.yml
+++ b/src/main/resources/application-train.yml
@@ -3,9 +3,9 @@ hmpps.sqs:
   queues:
     audit:
       queueName: ${random.uuid}
-  updatefromexternalsystemevents:
-    queueName: ${random.uuid}
-    dlqName: ${random.uuid}
+    updatefromexternalsystemevents:
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
   topics:
     domainevents:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}


### PR DESCRIPTION
Corrected the indentation of `updatefromexternalsystemevents` queue and DLQ configuration in `application-train.yml`. This ensures proper YAML parsing and adherence to structure expectations