### PR TITLE
MAP-2437 Update dependencies to latest versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,9 @@ import uk.gov.justice.digital.hmpps.gradle.PortForwardRedisTask
 import uk.gov.justice.digital.hmpps.gradle.RevealSecretsTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.4"
-  kotlin("plugin.spring") version "2.1.10"
-  kotlin("plugin.jpa") version "2.1.10"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.1.0"
+  kotlin("plugin.spring") version "2.1.21"
+  kotlin("plugin.jpa") version "2.1.21"
   id("org.jetbrains.kotlinx.kover") version "0.9.1"
   idea
 }
@@ -16,34 +16,34 @@ configurations {
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.4.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.4.3")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-validation")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:8.0.1")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.3.2")
-  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.13.3")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:8.1.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.4")
+  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.16.0")
 
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
-  implementation("com.zaxxer:HikariCP:6.2.1")
+  implementation("com.zaxxer:HikariCP:6.3.0")
   runtimeOnly("org.postgresql:postgresql")
   implementation("com.fasterxml.uuid:java-uuid-generator:5.1.0")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
-  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.3")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.19.0")
 
   developmentOnly("org.springframework.boot:spring-boot-devtools")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.4.0")
-  testImplementation("org.wiremock:wiremock-standalone:3.12.1")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.4.3")
+  testImplementation("org.wiremock:wiremock-standalone:3.13.0")
 
   testImplementation("com.pauldijou:jwt-core_2.11:5.0.0")
   testImplementation("org.awaitility:awaitility-kotlin:4.3.0")
   testImplementation("org.mockito:mockito-inline:5.2.0")
-  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.25")
+  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.28")
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-  testImplementation("org.testcontainers:localstack:1.20.6")
-  testImplementation("org.testcontainers:postgresql:1.20.6")
+  testImplementation("org.testcontainers:localstack:1.21.0")
+  testImplementation("org.testcontainers:postgresql:1.21.0")
 }
 
 kotlin {


### PR DESCRIPTION
This Pull Request updates the project dependencies and plugin versions to their latest compatible releases. No functional changes to the code are introduced; the updates aim at maintaining compatibility, bug fixes, and improved features from the library developers.
### Main Changes:
- Updated the version of the uk.gov.justice.hmpps.gradle-spring-boot plugin from 7.1.4 to 8.1.0.
- Upgraded Kotlin plugin versions (plugin.spring and plugin.jpa) from 2.1.10 to 2.1.21.
- Incremented versions for multiple dependencies, such as:
  - hmpps-kotlin-spring-boot-starter from 1.4.0 to 1.4.3.
  - hmpps-digital-prison-reporting-lib from 8.0.1 to 8.1.0.
  - hmpps-sqs-spring-boot-starter from 5.3.2 to 5.4.4.
  - opentelemetry-instrumentation-annotations from 2.13.3 to 2.16.0.
  - Others listed include libraries for HikariCP, Jackson, OpenAPI, testing frameworks, etc.
- Updated test dependencies like wiremock-standalone, testcontainers, and swagger-parser to newer versions.

This is a maintenance-focused PR to keep the project dependencies up-to-date with the latest stable releases, ensuring better stability and access to new features.