### PR TITLE
MAP-2442 Add pending capacity handling for draft locations and update capacity calculations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -80,6 +80,9 @@ data class Location(
   @Schema(description = "Capacity details of the location", required = false)
   val capacity: Capacity? = null,
 
+  @Schema(description = "Pending capacity details of draft or pending approval locations", required = false)
+  val pendingCapacity: Capacity? = null,
+
   @Schema(description = "When a cell is inactive, show the active working capacity value", required = false)
   val oldWorkingCapacity: Int? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -532,7 +532,6 @@ class Cell(
     useHistoryForUpdate: Boolean,
     countCells: Boolean,
     formatLocalName: Boolean,
-    includePendingChange: Boolean,
   ): LocationDto = super.toDto(
     includeChildren = includeChildren,
     includeParent = includeParent,
@@ -542,7 +541,6 @@ class Cell(
     useHistoryForUpdate = useHistoryForUpdate,
     countCells = countCells,
     formatLocalName = formatLocalName,
-    includePendingChange = includePendingChange,
   ).copy(
     oldWorkingCapacity = if (isTemporarilyDeactivated()) {
       getWorkingCapacity()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -180,7 +180,7 @@ abstract class Location(
   open fun isActiveAndAllParentsActive() = isActive() && !hasDeactivatedParent()
 
   open fun isDeactivatedByParent() = isActive() && hasDeactivatedParent()
-  open fun isTemporarilyDeactivated() = !isActiveAndAllParentsActive() && !isPermanentlyDeactivated()
+  open fun isTemporarilyDeactivated() = !isActiveAndAllParentsActive() && !isPermanentlyDeactivated() && !isDraft()
   open fun isPermanentlyDeactivated() = findArchivedLocationInHierarchy()?.status == LocationStatus.ARCHIVED
   fun addChildLocation(childLocation: Location): Location {
     childLocation.parent = this
@@ -345,7 +345,6 @@ abstract class Location(
     useHistoryForUpdate: Boolean = false,
     countCells: Boolean = false,
     formatLocalName: Boolean = false,
-    includePendingChange: Boolean = false,
   ): LocationDto {
     val topHistoryEntry = if (useHistoryForUpdate) {
       history.maxByOrNull { it.amendedDate }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -92,7 +92,6 @@ class NonResidentialLocation(
     useHistoryForUpdate: Boolean,
     countCells: Boolean,
     formatLocalName: Boolean,
-    includePendingChange: Boolean,
   ): LocationDto = super.toDto(
     includeChildren = includeChildren,
     includeParent = includeParent,
@@ -102,7 +101,6 @@ class NonResidentialLocation(
     useHistoryForUpdate = useHistoryForUpdate,
     countCells = countCells,
     formatLocalName = formatLocalName,
-    includePendingChange = includePendingChange,
   ).copy(
     usage = nonResidentialUsages.map { it.toDto() }.sortedBy { it.usageType.sequence },
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/VirtualResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/VirtualResidentialLocation.kt
@@ -80,7 +80,6 @@ open class VirtualResidentialLocation(
     useHistoryForUpdate: Boolean,
     countCells: Boolean,
     formatLocalName: Boolean,
-    includePendingChange: Boolean,
   ): LocationDto = super.toDto(
     includeChildren = includeChildren,
     includeParent = includeParent,
@@ -90,7 +89,6 @@ open class VirtualResidentialLocation(
     useHistoryForUpdate = useHistoryForUpdate,
     countCells = false,
     formatLocalName = formatLocalName,
-    includePendingChange = includePendingChange,
   ).copy(
     capacity = CapacityDto(
       maxCapacity = getMaxCapacity(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
@@ -171,8 +171,12 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                 "STANDARD_ACCOMMODATION"
               ],
               "capacity": {
-                "maxCapacity": 1,
+                "maxCapacity": 0,
                 "workingCapacity": 0
+              },
+              "pendingCapacity": {
+                "maxCapacity": 1,
+                "workingCapacity": 1
               },
               "certification": {
                 "certified": false,
@@ -184,10 +188,13 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                   "cellMark": "J-001",
                   "locationType": "CELL",
                   "capacity": {
-                    "maxCapacity": 1,
+                    "maxCapacity": 0,
                     "workingCapacity": 0
                   },
-                  "oldWorkingCapacity": 1,
+                  "pendingCapacity": {
+                    "maxCapacity": 1,
+                    "workingCapacity": 1
+                  },
                   "certification": {
                     "certified": false,
                     "capacityOfCertifiedCell": 1
@@ -245,8 +252,12 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                 "STANDARD_ACCOMMODATION"
               ],
               "capacity": {
-                "maxCapacity": 1,
+                "maxCapacity": 0,
                 "workingCapacity": 0
+              },
+              "pendingCapacity": {
+                "maxCapacity": 1,
+                "workingCapacity": 1
               },
               "certification": {
                 "certified": false,
@@ -258,10 +269,13 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                   "cellMark": "J-001",
                   "locationType": "CELL",
                   "capacity": {
-                    "maxCapacity": 1,
+                    "maxCapacity": 0,
                     "workingCapacity": 0
                   },
-                  "oldWorkingCapacity": 1,
+                  "pendingCapacity": {
+                    "maxCapacity": 1,
+                    "workingCapacity": 1
+                  },
                   "certification": {
                     "certified": false,
                     "capacityOfCertifiedCell": 1
@@ -320,8 +334,12 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                 "STANDARD_ACCOMMODATION"
               ],
               "capacity": {
-                "maxCapacity": 5,
+                "maxCapacity": 4,
                 "workingCapacity": 4
+              },
+              "pendingCapacity": {
+                "maxCapacity": 5,
+                "workingCapacity": 5
               },
               "certification": {
                 "certified": true,
@@ -343,7 +361,15 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                 {
                   "key": "MDI-Z-1-010",
                   "status": "DRAFT",
-                  "inCellSanitation": true
+                  "inCellSanitation": true,
+                  "capacity": {
+                    "maxCapacity": 0,
+                    "workingCapacity": 0
+                  },
+                  "pendingCapacity": {
+                    "maxCapacity": 1,
+                    "workingCapacity": 1
+                  }
                 }  
               ]
             }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResourceTest.kt
@@ -648,8 +648,12 @@ class LocationResidentialResourceTest : CommonDataTestBase() {
               "key": "LEI-A-1-010",
               "inCellSanitation": true,
               "capacity": {
-                "maxCapacity": 2,
+                "maxCapacity": 0,
                 "workingCapacity": 0
+              },
+              "pendingCapacity": {
+                "maxCapacity": 2,
+                "workingCapacity": 2
               },
               "certification": {
                 "certified": false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationTransformResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationTransformResourceTest.kt
@@ -965,6 +965,10 @@ class LocationTransformResourceTest : CommonDataTestBase() {
                 "code": "${aCell.getCode()}",
                 "pathHierarchy": "${aCell.getPathHierarchy()}",
                 "capacity": {
+                  "maxCapacity": ${aCell.getMaxCapacity()},
+                  "workingCapacity": ${aCell.getWorkingCapacity()}
+                },
+                "pendingCapacity": {
                   "maxCapacity": $incMaxCap,
                   "workingCapacity": ${aCell.getWorkingCapacity()}
                 },

--- a/src/test/resources/repository/insert-dummy-locations.sql
+++ b/src/test/resources/repository/insert-dummy-locations.sql
@@ -1,11 +1,11 @@
 DELETE FROM location;
 
-INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, local_name, residential_housing_type, when_created, when_updated, updated_by)
-values ('MDI', 'A', 'A', 'WING', 'RESIDENTIAL', null, 'Wing A', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO');
-INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, local_name, residential_housing_type, when_created, when_updated, updated_by)
-values ('MDI', 'A-1', '1', 'LANDING', 'RESIDENTIAL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A'), 'Landing 1', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO');
-INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, accommodation_type, residential_housing_type, when_created, when_updated, updated_by)
-values ('MDI', 'A-1-001', '001', 'CELL', 'CELL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A-1'), 'NORMAL_ACCOMMODATION', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO');
+INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, local_name, residential_housing_type, when_created, when_updated, updated_by, status)
+values ('MDI', 'A', 'A', 'WING', 'RESIDENTIAL', null, 'Wing A', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO', 'ACTIVE');
+INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, local_name, residential_housing_type, when_created, when_updated, updated_by, status)
+values ('MDI', 'A-1', '1', 'LANDING', 'RESIDENTIAL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A'), 'Landing 1', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO', 'ACTIVE');
+INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, accommodation_type, residential_housing_type, when_created, when_updated, updated_by, status)
+values ('MDI', 'A-1-001', '001', 'CELL', 'CELL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A-1'), 'NORMAL_ACCOMMODATION', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO', 'ACTIVE');
 INSERT INTO capacity (max_capacity, working_capacity) VALUES (1,1);
 INSERT INTO certification (certified, capacity_of_certified_cell) VALUES (true, 1);
 UPDATE location set capacity_id = currval('capacity_id_seq'), certification_id = currval('certification_id_seq') WHERE prison_id = 'MDI' and path_hierarchy = 'A-1-001';
@@ -31,21 +31,21 @@ INSERT INTO certification (certified, capacity_of_certified_cell) VALUES (true, 
 UPDATE location set capacity_id = currval('capacity_id_seq'), certification_id = currval('certification_id_seq') WHERE prison_id = 'MDI' and path_hierarchy = 'A-2-003';
 
 
-INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, local_name, residential_housing_type, when_created, when_updated, updated_by)
-values ('MDI', 'A-3', '3', 'LANDING', 'RESIDENTIAL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A'), 'Landing 3', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO');
+INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, local_name, residential_housing_type, when_created, when_updated, updated_by, status)
+values ('MDI', 'A-3', '3', 'LANDING', 'RESIDENTIAL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A'), 'Landing 3', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO', 'ACTIVE');
 
-INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, accommodation_type, residential_housing_type, when_created, when_updated, updated_by)
-values ('MDI', 'A-3-001', '001', 'CELL', 'CELL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A-3'), 'NORMAL_ACCOMMODATION', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO');
+INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, accommodation_type, residential_housing_type, when_created, when_updated, updated_by, status)
+values ('MDI', 'A-3-001', '001', 'CELL', 'CELL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A-3'), 'NORMAL_ACCOMMODATION', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO', 'ACTIVE');
 INSERT INTO capacity (max_capacity, working_capacity) VALUES (2,1);
 INSERT INTO certification (certified, capacity_of_certified_cell) VALUES (true, 1);
 UPDATE location set capacity_id = currval('capacity_id_seq'), certification_id = currval('certification_id_seq') WHERE prison_id = 'MDI' and path_hierarchy = 'A-3-001';
 
 
-INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, local_name, residential_housing_type, when_created, when_updated, updated_by)
-values ('MDI', 'A-4', '4', 'LANDING', 'RESIDENTIAL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A'), 'Landing 4', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO');
+INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, local_name, residential_housing_type, when_created, when_updated, updated_by, status)
+values ('MDI', 'A-4', '4', 'LANDING', 'RESIDENTIAL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A'), 'Landing 4', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO', 'ACTIVE');
 
-INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, accommodation_type, residential_housing_type, when_created, when_updated, updated_by)
-values ('MDI', 'A-4-001', '001', 'CELL', 'CELL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A-4'), 'NORMAL_ACCOMMODATION', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO');
+INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, accommodation_type, residential_housing_type, when_created, when_updated, updated_by, status)
+values ('MDI', 'A-4-001', '001', 'CELL', 'CELL', (select id from location where prison_id = 'MDI' and path_hierarchy = 'A-4'), 'NORMAL_ACCOMMODATION', 'NORMAL_ACCOMMODATION', now(), now(), 'LOCATION_RO', 'ACTIVE');
 INSERT INTO capacity (max_capacity, working_capacity) VALUES (2,1);
 INSERT INTO certification (certified, capacity_of_certified_cell) VALUES (true, 1);
 UPDATE location set capacity_id = currval('capacity_id_seq'), certification_id = currval('certification_id_seq') WHERE prison_id = 'MDI' and path_hierarchy = 'A-4-001';


### PR DESCRIPTION
This Pull Request introduces changes to support tracking "pending capacity" details for locations, such as draft or pending approval statuses.

### Main Changes:
- **Addition of pendingCapacity Field**: Added `pendingCapacity` to `LocationDto` to capture capacity details for draft or pending approval locations.
- **Refactoring**:
  - Replaced and simplified capacity handling methods (e.g., `getDerivedMaxCapacity` was refactored to `calcMaxCapacity`).
  - Removed unused `includePendingChange` parameter and its associated logic across DTO and service files.
- **Logic Update for isTemporarilyDeactivated**: Now considers draft status in its check.
- **Test Updates**:
  - Adjusted tests to incorporate `pendingCapacity` changes.
  - Added new test data to validate updated capacity logic.
- **SQL Updates**: Added a `status` field to location insert statements to fix test as default is now `DRAFT` on insert