### PR TITLE
MAP-2476 Enhance cell certificate handling and validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -66,7 +66,7 @@ open class CellCertificateLocation(
   val id: UUID? = null,
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "cell_certificate_id", nullable = true)
+  @JoinColumn(name = "cell_certificate_id", nullable = false)
   val cellCertificate: CellCertificate? = null,
 
   @Column(nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -67,7 +67,7 @@ open class CellCertificateLocation(
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "cell_certificate_id", nullable = false)
-  val cellCertificate: CellCertificate? = null,
+  val cellCertificate: CellCertificate,
 
   @Column(nullable = false)
   val locationCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -54,7 +54,9 @@ open class CellCertificate(
   @SortNatural
   @OneToMany(mappedBy = "cellCertificate", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   var locations: SortedSet<CellCertificateLocation> = sortedSetOf(),
-)
+) {
+  override fun toString(): String = "CellCertificate(prisonId='$prisonId', certificationApprovalRequest=$certificationApprovalRequest, current=$current)"
+}
 
 @Entity
 open class CellCertificateLocation(
@@ -64,8 +66,8 @@ open class CellCertificateLocation(
   val id: UUID? = null,
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "cell_certificate_id")
-  val cellCertificate: CellCertificate,
+  @JoinColumn(name = "cell_certificate_id", nullable = true)
+  val cellCertificate: CellCertificate? = null,
 
   @Column(nullable = false)
   val locationCode: String,
@@ -104,6 +106,10 @@ open class CellCertificateLocation(
 
   @Column(name = "specialist_cell_types", nullable = true)
   val specialistCellTypes: String? = null,
+
+  @Column(nullable = true)
+  @Enumerated(EnumType.STRING)
+  val convertedCellType: ConvertedCellType? = null,
 
   @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinColumn(name = "parent_location_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -448,6 +448,18 @@ abstract class Location(
 
   private fun isLeafLevel() = findSubLocations().isEmpty() && !isStructural() && !isArea()
 
+  protected fun isInHierarchy(locationToFind: Location): Boolean {
+    // Walk up the hierarchy of the location to find
+    var current: Location? = locationToFind
+    while (current != null) {
+      if (current.id == this.id) {
+        return true
+      }
+      current = current.getParent()
+    }
+    return false
+  }
+
   fun toPrisonHierarchyDto(maxLevel: Int? = null, includeInactive: Boolean = false): PrisonHierarchyDto {
     val subLocations: List<PrisonHierarchyDto> = childLocations
       .filter { (includeInactive || it.isActiveAndAllParentsActive()) && (it.isStructural() || it.isCell()) && (maxLevel == null || it.getLevel() <= maxLevel) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -42,7 +42,7 @@ class CellCertificateService(
         locations = residentialLocationRepository.findAllByPrisonIdAndParentIsNull(location.prisonId)
           .filter { !it.isPermanentlyDeactivated() && !it.isDraft() && it.isStructural() }
           .map {
-            it.toCellCertificateLocation(this)
+            it.toCellCertificateLocation(this, location)
           }.toSortedSet()
 
         totalWorkingCapacity = locations.sumOf { it.workingCapacity ?: 0 }

--- a/src/main/resources/db/migration/V1_57__new_columns_on_cell_cert.sql
+++ b/src/main/resources/db/migration/V1_57__new_columns_on_cell_cert.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cell_certificate_location add column if not exists converted_cell_type varchar(60);


### PR DESCRIPTION
This Pull Request introduces changes to extend cell certification functionality in the system. It enhances the data model, modifies logic to include hierarchical location structures, adds new fields to accommodate converted cell types, and enriches test coverage.
### Main changes:
- Enhanced DTO and JPA Models:
  - Updated CellCertificateDto and CellCertificateLocationDto to add fields for localName, level, status, convertedCellType, and subLocations.
  - Adjusted serialization/deserialization logic and filtering criteria.
  - Modified CellCertificate and CellCertificateLocation JPA classes to  introduce new fields (convertedCellType, hierarchical sub-locations).
- Service and Helper Logic:
  - Enhanced methods like toCellCertificateLocation to determine hierarchical relationships and support inactive statuses for specific capacities.
- Database Schema Update:
  - Added a new column converted_cell_type to the cell_certificate_location table via a migration script.
- Testing Enhancements:
  - Improved test cases in CellCertificateResourceTest to cover scenarios for approval workflows, hierarchical locations, and converted cell types.
  - Implemented specific scenarios validating cell changes without affecting existing data.