### PR TITLE
MAP-2472 Add handling for locked locations, preventing updates and conversions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-validation")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:8.3.3")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:8.3.4")
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.5")
   implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.16.0")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -109,6 +109,9 @@ class Cell(
   fun getCapacityOfCertifiedCell() = certification?.capacityOfCertifiedCell
 
   fun setCapacityOfCertifiedCell(capacityOfCertifiedCell: Int, userOrSystemInContext: String, clock: Clock, linkedTransaction: LinkedTransaction): Boolean {
+    if (isLocationLocked()) {
+      throw LockedLocationCannotBeUpdatedException(getKey())
+    }
     addHistory(
       LocationAttribute.CERTIFIED_CAPACITY,
       certification?.capacityOfCertifiedCell?.toString(),
@@ -140,6 +143,10 @@ class Cell(
   private fun getConvertedCellTypeSummary() = listOfNotBlank(convertedCellType?.description, otherConvertedCellType).joinToString(" - ")
 
   fun convertToNonResidentialCell(convertedCellType: ConvertedCellType, otherConvertedCellType: String? = null, userOrSystemInContext: String, clock: Clock, linkedTransaction: LinkedTransaction) {
+    if (isLocationLocked()) {
+      throw LockedLocationCannotBeUpdatedException(getKey())
+    }
+
     addHistory(
       LocationAttribute.STATUS,
       this.getDerivedStatus().description,
@@ -193,6 +200,9 @@ class Cell(
   override fun getUsedForValues() = this.usedFor
 
   fun updateNonResidentialCellType(convertedCellType: ConvertedCellType, otherConvertedCellType: String? = null, userOrSystemInContext: String, clock: Clock, linkedTransaction: LinkedTransaction) {
+    if (isLocationLocked()) {
+      throw LockedLocationCannotBeUpdatedException(getKey())
+    }
     addHistory(
       LocationAttribute.CONVERTED_CELL_TYPE,
       this.getConvertedCellTypeSummary(),
@@ -221,6 +231,10 @@ class Cell(
   }
 
   fun convertToCell(accommodationType: AllowedAccommodationTypeForConversion, usedForTypes: List<UsedForType>? = null, specialistCellTypes: Set<SpecialistCellType>? = null, maxCapacity: Int = 0, workingCapacity: Int = 0, userOrSystemInContext: String, clock: Clock, linkedTransaction: LinkedTransaction) {
+    if (isLocationLocked()) {
+      throw LockedLocationCannotBeUpdatedException(getKey())
+    }
+
     val amendedDate = LocalDateTime.now(clock)
     addHistory(
       LocationAttribute.STATUS,
@@ -381,6 +395,9 @@ class Cell(
     clock: Clock,
     linkedTransaction: LinkedTransaction,
   ) {
+    if (isLocationLocked()) {
+      throw LockedLocationCannotBeUpdatedException(getKey())
+    }
     recordRemovedSpecialistCellTypes(specialistCellTypes, userOrSystemInContext, clock, linkedTransaction)
     this.specialistCellTypes.retainAll(
       specialistCellTypes.map {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -66,6 +66,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationConta
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationPrefixNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationResidentialResource.AllowedAccommodationTypeForConversion
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LockedLocationCannotBeUpdatedException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PermanentlyDeactivatedUpdateNotAllowedException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PrisonNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ReactivateLocationsRequest
@@ -564,6 +565,10 @@ class LocationService(
     patchLocationRequest: PatchLocationRequest,
     linkedTransaction: LinkedTransaction,
   ): UpdateLocationResult {
+    if (location.isLocationLocked()) {
+      throw LockedLocationCannotBeUpdatedException(location.getKey())
+    }
+
     val (codeChanged, oldParent, parentChanged) = updateCoreLocationDetails(location, patchLocationRequest, linkedTransaction)
 
     location.update(patchLocationRequest, getUsername(), clock, linkedTransaction)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/CommonDataTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/CommonDataTestBase.kt
@@ -94,6 +94,8 @@ class CommonDataTestBase : SqsIntegrationTestBase() {
         PrisonConfiguration(
           prisonId = "NMI",
           signedOperationCapacity = 10,
+          resiLocationServiceActive = true,
+          certificationApprovalRequired = true,
           whenUpdated = LocalDateTime.now(clock),
           updatedBy = SYSTEM_USERNAME,
         ),
@@ -154,6 +156,10 @@ class CommonDataTestBase : SqsIntegrationTestBase() {
         linkedTransaction = linkedTransaction,
       ),
     )
+    cell1N.setCapacity(maxCapacity = 3, workingCapacity = 2, userOrSystemInContext = EXPECTED_USERNAME, amendedDate = LocalDateTime.now(clock), linkedTransaction = linkedTransaction)
+    cell1N.requestApproval(requestedBy = EXPECTED_USERNAME, requestedDate = LocalDateTime.now(clock), linkedTransaction = linkedTransaction)
+    cell1N = repository.saveAndFlush(cell1N)
+
     landingN1 = repository.save(
       buildResidentialLocation(
         prisonId = "NMI",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
@@ -304,11 +304,15 @@ class CellCertificateResourceTest : CommonDataTestBase() {
         .jsonPath("$.totalCapacityOfCertifiedCell").isEqualTo(12)
         // Verify that there are locations in the response
         .jsonPath("$.locations.length()").isEqualTo(2)
+        .jsonPath("$.locations[0].workingCapacity").isEqualTo(6)
         .jsonPath("$.locations[0].subLocations.length()").isEqualTo(2)
         .jsonPath("$.locations[0].subLocations[0].subLocations.length()").isEqualTo(3)
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].workingCapacity").isEqualTo(1)
         .jsonPath("$.locations[0].subLocations[1].subLocations.length()").isEqualTo(3)
+        .jsonPath("$.locations[1].workingCapacity").isEqualTo(6)
         .jsonPath("$.locations[1].subLocations.length()").isEqualTo(2)
         .jsonPath("$.locations[1].subLocations[0].subLocations.length()").isEqualTo(3)
+        .jsonPath("$.locations[1].subLocations[0].subLocations[0].workingCapacity").isEqualTo(1)
         .jsonPath("$.locations[1].subLocations[1].subLocations.length()").isEqualTo(3)
     }
 
@@ -327,7 +331,7 @@ class CellCertificateResourceTest : CommonDataTestBase() {
         .jsonPath("$.current").isEqualTo(true)
         .jsonPath("$.locations").isArray()
         .jsonPath("$.totalMaxCapacity").isEqualTo(14)
-        .jsonPath("$.totalWorkingCapacity").isEqualTo(12)
+        .jsonPath("$.totalWorkingCapacity").isEqualTo(6)
         .jsonPath("$.totalCapacityOfCertifiedCell").isEqualTo(12)
         // Verify that there are locations in the response
         .jsonPath("$.locations.length()").isEqualTo(2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -2658,15 +2658,12 @@ class LocationResourceIntTest : CommonDataTestBase() {
             JsonCompareMode.LENIENT,
           )
 
-        getDomainEvents(9).let {
+        getDomainEvents(6).let {
           assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
             "location.inside.prison.amended" to "MDI-Z-1-001",
-            "location.inside.prison.amended" to "NMI-A-1-001",
             "location.inside.prison.amended" to "MDI-B-A-001",
             "location.inside.prison.amended" to "MDI-Z-1",
             "location.inside.prison.amended" to "MDI-Z",
-            "location.inside.prison.amended" to "NMI-A-1",
-            "location.inside.prison.amended" to "NMI-A",
             "location.inside.prison.amended" to "MDI-B-A",
             "location.inside.prison.amended" to "MDI-B",
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -2619,20 +2619,10 @@ class LocationResourceIntTest : CommonDataTestBase() {
                     "message": "Update failed: Max capacity (0) cannot be decreased below current cell occupancy (1)"
                   }
                 ],
-                "NMI-A-1-001": [
+                "NMI-A-1-001":[
                   {
-                    "key": "NMI-A-1-001",
-                    "message": "Max capacity from 2 ==> 4",
-                    "type": "maxCapacity",
-                    "previousValue": 2,
-                    "newValue": 4
-                  },
-                  {
-                    "key": "NMI-A-1-001",
-                    "message": "Working capacity from 2 ==> 1",
-                    "type": "workingCapacity",
-                    "previousValue": 2,
-                    "newValue": 1
+                    "key":"NMI-A-1-001",
+                    "message":"Update failed: Location NMI-A-1-001 cannot be updated as it is locked"
                   }
                 ],
                 "MDI-1-2-008": [

--- a/src/test/resources/repository/insert-dummy-locations.sql
+++ b/src/test/resources/repository/insert-dummy-locations.sql
@@ -1,3 +1,5 @@
+DELETE FROM cell_certificate cascade;
+DELETE FROM certification_approval_request;
 DELETE FROM location;
 
 INSERT INTO location (prison_id, path_hierarchy, code, location_type, location_type_discriminator, parent_id, local_name, residential_housing_type, when_created, when_updated, updated_by, status)


### PR DESCRIPTION
This pull request addresses updates to location management in the prison system, enforcing restrictions when locations are locked and improving test coverage for these scenarios. Minor library updates are also included.
- Library Update: Bumps the version of hmpps-digital-prison-reporting-lib from 8.3.3 to 8.3.4.
- Core Updates:
  - Introduces a new validation to prevent updates to locked locations across various operations (Cell and Location).
  - Adds a custom exception for locked locations: LockedLocationCannotBeUpdatedException.
- Testing Enhancements:
  - Updates integration tests to validate behavior for locked locations.
  - Introduces new test cases to verify restrictions on updating, converting, or renaming locked locations.
- SQL Adjustments: Modifies the test data cleanup in insert-dummy-locations.sql with additional delete statements to handle certificates and approvals.
This aims to enhance data consistency and integrity by disallowing modifications to locked entities.