### PR TITLE
MAP-2504 Add `updatedBy` field to support user context in location deactivation requests and transactions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateFromExternalSystemEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateFromExternalSystemEvent.kt
@@ -26,4 +26,5 @@ data class UpdateFromExternalSystemDeactivateEvent(
   val deactivationReasonDescription: String? = null,
   val proposedReactivationDate: LocalDate? = null,
   val planetFmReference: String? = null,
+  val updatedBy: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/BulkUpdateResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/BulkUpdateResource.kt
@@ -218,6 +218,9 @@ data class BulkPermanentDeactivationRequest(
 data class DeactivateLocationsRequest(
   @Schema(description = "List of locations to deactivate", example = "{ \"de91dfa7-821f-4552-a427-bf2f32eafeb0\": { \"deactivationReason\": \"DAMAGED\" } }")
   val locations: Map<UUID, TemporaryDeactivationLocationRequest>,
+  @Schema(description = "Username of the user requesting to deactivate the locations, if not provided the token username or client id will be used", example = "TESTUSER", required = false)
+  @field:Size(max = 80, message = "The updatedBy field cannot be more than 80 characters")
+  val updatedBy: String? = null,
 )
 
 @Schema(description = "Reactivate Locations Request")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/UpdateFromExternalSystemListenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/UpdateFromExternalSystemListenerService.kt
@@ -46,7 +46,7 @@ class UpdateFromExternalSystemListenerService(
         if (location.locationType != LocationType.CELL) {
           throw LocationIsNotACellException(location.getKey())
         }
-        val deactivateLocationsRequest = DeactivateLocationsRequest(mapOf(event.id to temporaryDeactivationLocationRequest))
+        val deactivateLocationsRequest = DeactivateLocationsRequest(updatedBy = event.updatedBy, locations = mapOf(event.id to temporaryDeactivationLocationRequest))
         deactivate(locationService.deactivateLocations(deactivateLocationsRequest))
       }
       else -> throw Exception("Cannot process event of type ${sqsMessage.eventType}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/UpdateFromExternalSystemEventsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/UpdateFromExternalSystemEventsTest.kt
@@ -88,6 +88,7 @@ class UpdateFromExternalSystemEventsTest : CommonDataTestBase() {
           "deactivationReasonDescription" to "Window broken",
           "proposedReactivationDate" to "2025-01-05",
           "planetFmReference" to "23423TH/5",
+          "updatedBy" to "EXTERNAL_USER_1",
         ),
       )
       val message = objectMapper.writeValueAsString(updateFromExternalSystemEvent)
@@ -130,6 +131,7 @@ class UpdateFromExternalSystemEventsTest : CommonDataTestBase() {
           "deactivationReasonDescription" to "Window broken",
           "proposedReactivationDate" to "2025-01-05",
           "planetFmReference" to "23423TH/5",
+          "updatedBy" to "EXTERNAL_USER_2",
         ),
       )
       val message = objectMapper.writeValueAsString(updateFromExternalSystemEvent)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -1813,7 +1813,8 @@ class LocationResourceIntTest : CommonDataTestBase() {
           .bodyValue(
             jsonString(
               DeactivateLocationsRequest(
-                mapOf(
+                updatedBy = "DEACTIVATING_USER",
+                locations = mapOf(
                   cell1.id!! to TemporaryDeactivationLocationRequest(deactivationReason = DeactivatedReason.DAMAGED, deactivationReasonDescription = "Window smashed", proposedReactivationDate = proposedReactivationDate),
                   cell2.id!! to TemporaryDeactivationLocationRequest(deactivationReason = DeactivatedReason.REFURBISHMENT, deactivationReasonDescription = "Fire", planetFmReference = "XXX122"),
                 ),
@@ -1848,6 +1849,8 @@ class LocationResourceIntTest : CommonDataTestBase() {
                   "usedFor": [
                     "STANDARD_ACCOMMODATION"
                   ],
+                  "deactivatedBy": "DEACTIVATING_USER",
+                  "lastModifiedBy": "DEACTIVATING_USER",
                   "status": "INACTIVE",
                   "active": false,
                   "deactivatedByParent": false,
@@ -1889,6 +1892,8 @@ class LocationResourceIntTest : CommonDataTestBase() {
                   ],
                   "status": "INACTIVE",
                   "active": false,
+                  "deactivatedBy": "DEACTIVATING_USER",
+                  "lastModifiedBy": "DEACTIVATING_USER",
                   "deactivatedByParent": false,
                   "deactivatedDate": "$now",
                   "deactivatedReason": "REFURBISHMENT",


### PR DESCRIPTION

This Pull Request introduces changes to capture and utilize the updatedBy field to track users initiating deactivations or updates in the system. The changes span multiple service layers, DTOs, and tests to ensure consistency and coverage.
- Added a new updatedBy field to relevant DTOs (UpdateFromExternalSystemEvent, DeactivateLocationsRequest) for tracking user information.
- Updated service logic (LocationService, UpdateFromExternalSystemListenerService) to make use of the new updatedBy field.
- Adjusted function signatures and integrations to allow passing of the updatedBy details through the system.
- Enhanced test cases to include scenarios where updatedBy is utilized in requests and responses.