### PR TITLE
MAP-2504 Add support for propagating `updatedBy` field in deactivation event transformation.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateFromExternalSystemEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/UpdateFromExternalSystemEvent.kt
@@ -16,7 +16,7 @@ data class UpdateFromExternalSystemEvent(
 ) {
   fun toUpdateFromExternalSystemDeactivateEvent(): UpdateFromExternalSystemDeactivateEvent {
     val mapper = ObjectMapper().registerModule(KotlinModule.Builder().build()).registerModule(JavaTimeModule())
-    return mapper.convertValue(this.messageAttributes, UpdateFromExternalSystemDeactivateEvent::class.java)
+    return mapper.convertValue(this.messageAttributes, UpdateFromExternalSystemDeactivateEvent::class.java).copy(updatedBy = who)
   }
 }
 


### PR DESCRIPTION
Updated the method toUpdateFromExternalSystemDeactivateEvent to call .copy(updatedBy = who) after converting the object, likely to ensure the updatedBy field is explicitly set.
No other changes appear to be in this file; the modification is focused on improving how data is handled/transferred while using ObjectMapper.