### PR TITLE
MAP-2510 Refactor location-to-entity mapping methods for approval requests and certifications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -186,8 +186,8 @@ open class ResidentialLocation(
       maxCapacityChange = calcMaxCapacity(true) - calcMaxCapacity(),
       workingCapacityChange = calcWorkingCapacity(true) - calcWorkingCapacity(),
       certifiedNormalAccommodationChange = calcCertifiedNormalAccommodation(true) - calcCertifiedNormalAccommodation(),
+      locations = sortedSetOf(toCertificationApprovalRequestLocation()),
     ).apply {
-      locations = sortedSetOf(toCertificationApprovalRequestLocation(this))
       linkPendingChangesToApprovalRequest(approvalRequest = this)
     }
 
@@ -420,11 +420,11 @@ open class ResidentialLocation(
     return this
   }
 
-  fun toCellCertificateLocation(cellCertificate: CellCertificate, approvedLocation: ResidentialLocation): CellCertificateLocation {
+  fun toCellCertificateLocation(approvedLocation: ResidentialLocation): CellCertificateLocation {
     val subLocations: List<CellCertificateLocation> = childLocations
       .filterIsInstance<ResidentialLocation>()
       .filter { !it.isDraft() && (it.isStructural() || it.isCell() || it.isConvertedCell()) }
-      .map { it.toCellCertificateLocation(cellCertificate, approvedLocation) }
+      .map { it.toCellCertificateLocation(approvedLocation) }
 
     val approvedLocationIsPartOfHierarchy = isInHierarchy(approvedLocation)
     return CellCertificateLocation(
@@ -460,11 +460,11 @@ open class ResidentialLocation(
     )
   }
 
-  private fun toCertificationApprovalRequestLocation(certificationApprovalRequest: CertificationApprovalRequest): CertificationApprovalRequestLocation {
+  private fun toCertificationApprovalRequestLocation(): CertificationApprovalRequestLocation {
     val subLocations: List<CertificationApprovalRequestLocation> = childLocations
       .filterIsInstance<ResidentialLocation>()
       .filter { (it.isStructural() || it.isCell() || it.isConvertedCell()) }
-      .map { it.toCertificationApprovalRequestLocation(certificationApprovalRequest) }
+      .map { it.toCertificationApprovalRequestLocation() }
 
     return CertificationApprovalRequestLocation(
       locationType = locationType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -36,13 +36,12 @@ class CellCertificateService(
         approvedBy = approvedBy,
         approvedDate = approvedDate,
         certificationApprovalRequest = approvalRequest,
-      ).apply {
         locations = residentialLocationRepository.findAllByPrisonIdAndParentIsNull(location.prisonId)
           .filter { !it.isPermanentlyDeactivated() && !it.isDraft() && it.isStructural() }
           .map {
-            it.toCellCertificateLocation(this, location)
-          }.toSortedSet()
-
+            it.toCellCertificateLocation(location)
+          }.toSortedSet(),
+      ).apply {
         totalWorkingCapacity = locations.sumOf { it.workingCapacity ?: 0 }
         totalMaxCapacity = locations.sumOf { it.maxCapacity ?: 0 }
         totalCertifiedNormalAccommodation = locations.sumOf { it.certifiedNormalAccommodation ?: 0 }


### PR DESCRIPTION
This Pull Request simplifies several method signatures and cleanses unnecessary parameters. It removes redundant arguments and streamlines calls to certain methods within the ResidentialLocation and CellCertificateService classes.
### Main Changes:
- Updated method definitions in ResidentialLocation to remove unnecessary parameters (certificationApprovalRequest or cellCertificate), ensuring cleaner function calls.
- Adjusted map operations to better align with the streamlined method signatures.
- Moved certain variable assignments and call chains for clearer and more readable flow, especially in CellCertificateService.

This PR primarily improves code readability and eliminates unused or redundant method arguments, aligning with principles of clean code.