### PR TITLE
MAP-2596 Validate location type against wing structure and include wing structure in creation requests"

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CreateEntireWingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CreateEntireWingRequest.kt
@@ -57,6 +57,9 @@ data class CreateEntireWingRequest(
   @Schema(description = "Default CNA", example = "1", required = false, defaultValue = "1")
   @field:Max(value = 4, message = "Max of 4")
   val defaultCNA: Int = 1,
+
+  @Schema(description = "The structure of the wing", required = false)
+  val wingStructure: List<ResidentialStructuralType>? = null,
 ) {
 
   companion object {
@@ -77,6 +80,7 @@ data class CreateEntireWingRequest(
       whenCreated = LocalDateTime.now(clock),
       childLocations = mutableListOf(),
     ).apply {
+      wingStructure?.let { setStructure(it) }
       addHistory(
         attributeName = LocationAttribute.LOCATION_CREATED,
         oldValue = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -95,6 +95,8 @@ open class ResidentialLocation(
     }
   }
 
+  private fun findTopLevelResidentialLocation(): ResidentialLocation = (getParent() as? ResidentialLocation)?.findTopLevelResidentialLocation() ?: this
+
   override fun isResidentialRoomOrConvertedCell() = isNonResType() || isConvertedCell()
 
   override fun hasDeactivatedParent() = if (!isResidentialRoomOrConvertedCell()) {
@@ -170,7 +172,12 @@ open class ResidentialLocation(
     this.residentialStructure = wingStructure.joinToString(separator = ",") { it.name }
   }
 
-  fun getStructure(): List<ResidentialStructuralType>? = this.residentialStructure?.split(",")?.map { ResidentialStructuralType.valueOf(it.trim()) }
+  private fun getStructure(): List<ResidentialStructuralType>? = this.residentialStructure?.split(",")?.map { ResidentialStructuralType.valueOf(it.trim()) }
+
+  fun getNextLevelTypeWithinStructure() = findTopLevelResidentialLocation().getStructure()?.let { structure ->
+    val pos = structure.indexOfFirst { it.locationType == locationType } + 1
+    if (pos < structure.size) structure[pos] else null
+  }
 
   fun requestApproval(requestedDate: LocalDateTime, requestedBy: String, linkedTransaction: LinkedTransaction): CertificationApprovalRequest {
     fun traverseAndLock(location: ResidentialLocation) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/CommonDataTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/CommonDataTestBase.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.locationsinsideprison.SYSTEM_USERNAME
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateEntireWingRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ResidentialStructuralType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.AccommodationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Capacity
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
@@ -120,6 +121,7 @@ class CommonDataTestBase : SqsIntegrationTestBase() {
         defaultMaxCapacity = 2,
         defaultCNA = 1,
         wingDescription = "Wing A",
+        wingStructure = listOf(ResidentialStructuralType.WING, ResidentialStructuralType.LANDING, ResidentialStructuralType.CELL),
       ).toEntity(
         createInDraft = false,
         createdBy = "TEST_USER",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
@@ -109,6 +109,24 @@ class DraftLocationResourceTest : CommonDataTestBase() {
       }
 
       @Test
+      fun `location created that does not fit wing structure`() {
+        webTestClient.post().uri(url)
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              createCellInitialisationRequest(
+                aboveLevelCode = "TEST",
+                parentLocation = leedsWing.id,
+                locationType = ResidentialStructuralType.SPUR,
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().is4xxClientError
+      }
+
+      @Test
       fun `request without a parent location or a new location is rejected`() {
         webTestClient.post().uri(url)
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))


### PR DESCRIPTION
This Pull Request introduces updates to handle and validate the hierarchical structure of prison wing levels. It ensures alignment of newly added locations with predefined structures, improves structure-related logic, and enhances testing for edge cases.
### Main Changes:
- DTO Updates:
  - Added a field wingStructure to represent the structure of a wing in CreateEntireWingRequest.
  - Included logic to apply wing structures during creation.
- JPA Entity Enhancements:
  - Added the function getNextLevelTypeWithinStructure to validate the structure hierarchy.
  - Updated getStructure to private for better encapsulation.
- Service Layer:
  - Enhanced validation to ensure new levels adhere to the agreed wing structure.
  - Refactored sub-location type determination to use getNextLevelTypeWithinStructure.
- Tests:
  - Added tests to ensure validation logic prevents creation of invalid location structures.
  - Extended test data to include wingStructure and edge cases for invalid hierarchies.