### PR TITLE
MAP-2679 Introduce client caching for OAuth2 authorized client management

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/ClientCachingOAuth2AuthorizedClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/ClientCachingOAuth2AuthorizedClientService.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.config
+
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientId
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.SYSTEM_USERNAME
+import java.util.concurrent.ConcurrentHashMap
+
+class ClientCachingOAuth2AuthorizedClientService(
+  private val clientRegistrationRepository: ClientRegistrationRepository,
+) : OAuth2AuthorizedClientService {
+  private val authorizedClients: MutableMap<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> = ConcurrentHashMap()
+
+  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
+    clientRegistrationId: String,
+    principalName: String,
+  ): T? = clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.let {
+    @Suppress("UNCHECKED_CAST")
+    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME)] as T
+  }
+
+  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {
+    authorizedClients[
+      OAuth2AuthorizedClientId(authorizedClient.clientRegistration.registrationId, SYSTEM_USERNAME),
+    ] = authorizedClient
+  }
+
+  override fun removeAuthorizedClient(clientRegistrationId: String, principalName: String) {
+    clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.apply {
+      authorizedClients.remove(OAuth2AuthorizedClientId(clientRegistrationId, SYSTEM_USERNAME))
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/OAuth2ClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/OAuth2ClientConfiguration.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+
+@Configuration
+class OAuth2ClientConfiguration {
+
+  @Bean
+  fun authorizedClientManager(
+    clientRegistrationRepository: ClientRegistrationRepository,
+  ): OAuth2AuthorizedClientManager {
+    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
+    val authorizedClientManager =
+      AuthorizedClientServiceOAuth2AuthorizedClientManager(
+        clientRegistrationRepository,
+        ClientCachingOAuth2AuthorizedClientService(clientRegistrationRepository),
+      )
+    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
+    return authorizedClientManager
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/HmppsAuthMockServer.kt
@@ -22,7 +22,8 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
             .withBody(
               """{
                     "token_type": "bearer",
-                    "access_token": "ABCDE"
+                    "access_token": "ABCDE",
+                    "expires_in": 3600
                 }
               """.trimIndent(),
             ),


### PR DESCRIPTION
### Summary

This pull request introduces client caching for OAuth2 authorized client management. It includes the addition of `ClientCachingOAuth2AuthorizedClientService` to optimise client handling. The configuration is updated to utilize the client credentials grant flow, and mock server responses are enhanced to include token expiry details. 

### Additional Notes

N/A

### Checklist

- [ ] All acceptance criteria are met
- [ ] Code reviewed and approved