### PR TITLE
MAP-2702 Add `workingCapacity` to LocationDto and related pending changes handling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -238,8 +238,12 @@ data class PendingChangeDto(
   @param:Schema(description = "Pending max capacity", example = "2", required = false)
   val maxCapacity: Int? = null,
 
+  @param:Schema(description = "Pending working capacity", example = "1", required = false)
+  val workingCapacity: Int? = null,
+
   @param:Schema(description = "Pending CNA", example = "2", required = false)
   val certifiedNormalAccommodation: Int? = null,
+
 )
 
 @Schema(description = "Non Residential Usage")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -533,6 +533,7 @@ open class ResidentialLocation(
     pendingChanges = if (hasPendingChanges() || hasPendingChangesBelowThisLevel()) {
       PendingChangeDto(
         maxCapacity = calcMaxCapacity(true),
+        workingCapacity = calcWorkingCapacity(true),
         certifiedNormalAccommodation = calcCertifiedNormalAccommodation(true),
       )
     } else {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
@@ -193,7 +193,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                 "workingCapacity": 0
               },
               "pendingChanges": {
-                "maxCapacity": 1
+                "maxCapacity": 1,
+                "workingCapacity": 1
               },
               "certification": {
                 "certified": false,
@@ -209,7 +210,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                     "workingCapacity": 0
                   },
                   "pendingChanges": {
-                    "maxCapacity": 1
+                    "maxCapacity": 1,
+                    "workingCapacity": 1
                   },
                   "certification": {
                     "certified": false,
@@ -272,7 +274,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                 "workingCapacity": 0
               },
               "pendingChanges": {
-                "maxCapacity": 1
+                "maxCapacity": 1,
+                "workingCapacity": 1
               },
               "certification": {
                 "certified": false,
@@ -288,7 +291,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                     "workingCapacity": 0
                   },
                   "pendingChanges": {
-                    "maxCapacity": 1
+                    "maxCapacity": 1,
+                    "workingCapacity": 1
                   },
                   "certification": {
                     "certified": false,
@@ -352,7 +356,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                 "workingCapacity": 4
               },
               "pendingChanges": {
-                "maxCapacity": 5
+                "maxCapacity": 5,
+                "workingCapacity": 5
               },
               "certification": {
                 "certified": true,
@@ -380,7 +385,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
                     "workingCapacity": 0
                   },
                   "pendingChanges": {
-                    "maxCapacity": 1
+                    "maxCapacity": 1,
+                    "workingCapacity": 1
                   }
                 }  
               ]


### PR DESCRIPTION


- Introduced `workingCapacity` property in `LocationDto`.
- Updated `PendingChangeDto` to include `workingCapacity` calculations.
- Adjusted unit tests to validate `workingCapacity` in responses.