### PR TITLE
MAP-2762 Remove ampersand from EYI_Care & Separation Unit property key

### DIFF
--- a/src/main/resources/locations/patterns/EYI.properties
+++ b/src/main/resources/locations/patterns/EYI.properties
@@ -70,4 +70,4 @@ EYI_Houseblock\ 6_B-Spur\ Landing\ 2=EYI-HB6-2-0(2[5-9]|3[0-9]|4[0-8])
 EYI_Houseblock\ 6_B-Spur\ Landing\ 3=EYI-HB6-3-0(2[5-9]|3[0-9]|4[0-8])
 EYI_Houseblock\ 6_B-Spur\ Landing\ 4=EYI-HB6-4-0(2[5-9]|3[0-9]|4[0-8])
 EYI_Healthcare=EYI-H-.+
-EYI_Care\ &\ Separation\ Unit=EYI-S-.+
+EYI_Care\ and\ Separation\ Unit=EYI-S-.+


### PR DESCRIPTION
The pull request corrects a typo in the `EYI_Care & Separation Unit` property key. The horrible config files DO NOT WORK with ampersands.  - Lets get rid of them!