### PR TITLE
MAP-2761 Add `internalMovementAllowed` attribute to location entities and update related DTOs, migrations, and tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LegacyLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LegacyLocation.kt
@@ -52,6 +52,9 @@ data class LegacyLocation(
   @param:Schema(description = "Location Usage", required = false)
   val usage: List<NonResidentialUsageDto>? = null,
 
+  @param:Schema(description = "Indicates that this location can used for internal movements", required = false)
+  val internalMovementAllowed: Boolean? = null,
+
   @param:Schema(description = "Sequence of locations within the current parent location", example = "1", required = false)
   val orderWithinParentLocation: Int? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -92,6 +92,9 @@ data class Location(
   @param:Schema(description = "Location Usage", required = false)
   val usage: List<NonResidentialUsageDto>? = null,
 
+  @param:Schema(description = "Indicates that this location can used for internal movements", required = false)
+  val internalMovementAllowed: Boolean? = null,
+
   @param:Schema(description = "Accommodation Types", required = false)
   val accommodationTypes: List<AccommodationType>? = null,
 
@@ -636,6 +639,9 @@ data class CreateNonResidentialLocationRequest(
 
   @param:Schema(description = "Location Usage", required = false)
   val usage: Set<NonResidentialUsageDto>? = null,
+
+  @param:Schema(description = "Indicates that this location can used for internal movements", required = false)
+  val internalMovementAllowed: Boolean? = null,
 ) {
 
   fun toNewEntity(createdBy: String, clock: Clock, linkedTransaction: LinkedTransaction, parentLocation: uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location? = null) = NonResidentialLocationJPA(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/NomisSyncLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/NomisSyncLocationRequest.kt
@@ -89,6 +89,9 @@ data class NomisSyncLocationRequest(
   @param:Schema(description = "Location Usage", required = false)
   val usage: Set<NonResidentialUsageDto>? = null,
 
+  @param:Schema(description = "Indicates that this location can used for internal movements", required = false)
+  val internalMovementAllowed: Boolean? = null,
+
   @param:Schema(description = "Date location was created, if not provided then the current time will be used for a new location", required = false)
   val createDate: LocalDateTime? = null,
 
@@ -193,6 +196,7 @@ data class NomisSyncLocationRequest(
         localName = localName,
         comments = comments,
         orderWithinParentLocation = orderWithinParentLocation,
+        internalMovementAllowed = internalMovementAllowed,
         createdBy = lastUpdatedBy,
         whenCreated = createDate ?: LocalDateTime.now(clock),
         childLocations = mutableListOf(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PatchLocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PatchLocationRequest.kt
@@ -82,6 +82,9 @@ data class PatchNonResidentialLocationRequest(
   @param:Schema(description = "Non-residential usage", required = false)
   val usage: Set<NonResidentialUsageDto>? = null,
 
+  @param:Schema(description = "Indicates that this location can used for internal movements", required = false)
+  val internalMovementAllowed: Boolean? = null,
+
   @param:Schema(description = "Alternative description to display for location", example = "Wing A", required = false)
   @field:Size(max = 30, message = "Description must be less than 31 characters")
   override val localName: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationHistory.kt
@@ -104,6 +104,7 @@ enum class LocationAttribute(
   // non res only
   USAGE(description = "Usage", display = true),
   NON_RESIDENTIAL_CAPACITY(description = "Non residential capacity", display = true),
+  INTERNAL_MOVEMENT_ALLOWED(description = "Internal movement allowed", display = true),
 
   // These are recorded but not returned as history changes
   CODE(description = "Code"),

--- a/src/main/resources/db/migration/V1_66__internal_movement_alllowed.sql
+++ b/src/main/resources/db/migration/V1_66__internal_movement_alllowed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE location add column internal_movement_allowed boolean;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/LocationBuilder.kt
@@ -128,6 +128,7 @@ fun buildNonResidentialLocation(
     status = status,
     createdBy = "DIFFERENT_USER",
     whenCreated = LocalDateTime.now(clock).minusDays(1),
+    internalMovementAllowed = false,
     childLocations = mutableListOf(),
     orderWithinParentLocation = 99,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
@@ -25,6 +25,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
       code = "ADJ",
       locationType = NonResidentialLocationType.ADJUDICATION_ROOM,
       localName = "Adjudication Room",
+      internalMovementAllowed = true,
       usage = setOf(
         NonResidentialUsageDto(usageType = NonResidentialUsageType.ADJUDICATION_HEARING, capacity = 15, sequence = 1),
       ),
@@ -113,6 +114,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "locationType": "${createNonResidentialLocationRequest.locationType}",
               "active": true,
               "key": "MDI-Z-ADJ",
+              "internalMovementAllowed": false,
               "localName": "${createNonResidentialLocationRequest.localName}",
               "usage": [
                 {
@@ -154,6 +156,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
 
     val removeUsage = PatchNonResidentialLocationRequest(
       usage = emptySet(),
+      internalMovementAllowed = true,
     )
 
     @Nested
@@ -335,7 +338,8 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "locationType": "VISITS",
               "active": true,
               "key": "MDI-Z-VISIT",
-              "usage": []
+              "usage": [],
+              "internalMovementAllowed": true
             }
           """,
             JsonCompareMode.LENIENT,
@@ -357,10 +361,16 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "active": true,
               "key": "MDI-Z-VISIT",
               "usage": [],
+              "internalMovementAllowed":true,
               "changeHistory": [
                 {
                   "attribute": "Usage",
                   "oldValues": ["Visit"]
+                },
+                 {
+                  "attribute": "Internal movement allowed",
+                  "oldValues": ["false"],
+                  "newValues": ["true"]
                 }
               ]
             }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -176,6 +176,7 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
       locationType = LocationType.VISITS,
       localName = "Visit Hall",
       comments = "This is a visit room",
+      internalMovementAllowed = true,
       orderWithinParentLocation = 1,
       lastUpdatedBy = "user",
       usage = setOf(NonResidentialUsageDto(NonResidentialUsageType.VISIT, 10, 1)),
@@ -668,6 +669,7 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
               "active": true,
               "key": "ZZGHI-VISIT",
               "comments": "This is a visit room",
+              "internalMovementAllowed": true,
               "localName": "Visit Hall",
               "orderWithinParentLocation": 1,
               "usage": [
@@ -678,6 +680,50 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
                 }
               ]
             }
+          """,
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `can sync an existing non res location and update it`() {
+        webTestClient.post().uri("/sync/upsert")
+          .headers(setAuthorisation(roles = listOf("ROLE_SYNC_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              syncNonResRequest.copy(
+                id = nonRes.id,
+                internalMovementAllowed = true,
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """ 
+           {
+            "key": "ZZGHI-B-1-VISIT",
+            "prisonId": "ZZGHI",
+            "code": "VISIT",
+            "pathHierarchy": "B-1-VISIT",
+            "locationType": "VISITS",
+            "localName": "Visit Hall",
+            "comments": "This is a visit room",
+            "ignoreWorkingCapacity": false,
+            "usage": [
+              {
+                "usageType": "VISIT",
+                "capacity": 10,
+                "sequence": 1
+              }
+            ],
+            "internalMovementAllowed": true,
+            "orderWithinParentLocation": 1,
+            "active": true,
+            "permanentlyDeactivated": false
+          }
           """,
             JsonCompareMode.LENIENT,
           )


### PR DESCRIPTION
### Summary of Changes
- Introduced `internalMovementAllowed` attribute to location entities.
- Updated related Data Transfer Objects (DTOs), migrations, and tests.
