### PR TITLE
MAP-2773 Add reason for signed operation capacity change to DTOs, entities, services, migrations, and tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestDto.kt
@@ -55,6 +55,9 @@ data class CertificationApprovalRequestDto(
   @param:Schema(description = "Change signed operational capacity", example = "1", required = true)
   val signedOperationCapacityChange: Int? = null,
 
+  @param:Schema(description = "The reason why the signed op cap was changed", example = "Change in number of cells", required = false)
+  val reasonForSignedOpChange: String? = null,
+
   @param:Schema(description = "Locations affected by the approval", required = false)
   val locations: List<CertificationApprovalRequestLocationDto>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CertificationApprovalRequest.kt
@@ -70,7 +70,7 @@ abstract class CertificationApprovalRequest(
 
     if (prisonId != other.prisonId) return false
     if (approvalType != other.approvalType) return false
-    if (requestedDate != other.requestedDate) return false
+    if (!requestedDate.isEqual(other.requestedDate)) return false
     if (status != other.status) return false
 
     return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/SignedOpCapCertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/SignedOpCapCertificationApprovalRequest.kt
@@ -22,6 +22,9 @@ open class SignedOpCapCertificationApprovalRequest(
   approvedOrRejectedDate: LocalDateTime? = null,
   comments: String? = null,
 
+  @Column
+  private val reasonForChange: String,
+
   @ManyToOne(fetch = FetchType.EAGER, cascade = [CascadeType.ALL])
   private val signedOperationCapacity: SignedOperationCapacity,
 
@@ -40,6 +43,7 @@ open class SignedOpCapCertificationApprovalRequest(
   comments = comments,
 ) {
   override fun toDto(showLocations: Boolean) = super.toDto(showLocations).copy(
+    reasonForSignedOpChange = reasonForChange,
     signedOperationCapacityChange = signedOperationCapacityChange,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/SignedOperationCapacity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/SignedOperationCapacity.kt
@@ -35,7 +35,7 @@ class SignedOperationCapacity(
 
   fun findPendingApprovalRequest(): SignedOpCapCertificationApprovalRequest? = approvalRequests.findLast { it.isPending() }
 
-  fun requestApproval(pendingSignedOperationCapacity: Int, requestedDate: LocalDateTime, requestedBy: String): SignedOpCapCertificationApprovalRequest {
+  fun requestApproval(pendingSignedOperationCapacity: Int, reasonForChange: String, requestedDate: LocalDateTime, requestedBy: String): SignedOpCapCertificationApprovalRequest {
     val approvalRequest = SignedOpCapCertificationApprovalRequest(
       approvalType = ApprovalType.SIGNED_OP_CAP,
       prisonId = this.prisonId,
@@ -43,6 +43,7 @@ class SignedOperationCapacity(
       requestedDate = requestedDate,
       signedOperationCapacityChange = pendingSignedOperationCapacity - signedOperationCapacity,
       signedOperationCapacity = this,
+      reasonForChange = reasonForChange,
     )
     approvalRequests.add(approvalRequest)
     return approvalRequest

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CertificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CertificationService.kt
@@ -109,7 +109,7 @@ class CertificationService(
       now,
       username,
     )
-    val approvalRequest = certificationApprovalRequestRepository.save(signedOpCap.requestApproval(pendingSignedOperationCapacity = requestToApprove.signedOperationalCapacity, requestedBy = username, requestedDate = now))
+    val approvalRequest = certificationApprovalRequestRepository.save(signedOpCap.requestApproval(pendingSignedOperationCapacity = requestToApprove.signedOperationalCapacity, reasonForChange = requestToApprove.reasonForChange, requestedBy = username, requestedDate = now))
 
     telemetryClient.trackEvent(
       "certification-op-cap-approval-requested",
@@ -341,4 +341,7 @@ data class SignedOpCapApprovalRequest(
 
   @param:Schema(description = "The new value of the signed operational capacity", example = "456", required = true)
   val signedOperationalCapacity: Int,
+
+  @param:Schema(description = "Explanation of why the signed op cap is changing", example = "The size of the prison has changed", required = true)
+  val reasonForChange: String,
 )

--- a/src/main/resources/db/migration/V1_67__reason_for_op_cap_change.sql
+++ b/src/main/resources/db/migration/V1_67__reason_for_op_cap_change.sql
@@ -1,0 +1,1 @@
+ALTER TABLE certification_approval_request add column reason_for_change TEXT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
@@ -191,7 +191,7 @@ class CertificationResourceTest : CommonDataTestBase() {
               "prisonId":"LEI",
               "status": "PENDING",
               "signedOperationCapacityChange": -190,
-              "reasonForChange": "Damp cells"
+              "reasonForSignedOpChange": "Damp cells"
               }
           """,
             JsonCompareMode.LENIENT,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
@@ -93,6 +93,7 @@ class CertificationResourceTest : CommonDataTestBase() {
             SignedOpCapApprovalRequest(
               prisonId = "LEI",
               signedOperationalCapacity = 300,
+              reasonForChange = "Prison cells offline",
             ),
           ),
         ),
@@ -113,6 +114,7 @@ class CertificationResourceTest : CommonDataTestBase() {
               SignedOpCapApprovalRequest(
                 prisonId = "LEI",
                 signedOperationalCapacity = 11,
+                reasonForChange = "Fire",
               ),
             ),
           )
@@ -128,6 +130,7 @@ class CertificationResourceTest : CommonDataTestBase() {
                 SignedOpCapApprovalRequest(
                   prisonId = "LEI",
                   signedOperationalCapacity = 10,
+                  reasonForChange = "Flood",
                 ),
               ),
             )
@@ -149,6 +152,7 @@ class CertificationResourceTest : CommonDataTestBase() {
                 SignedOpCapApprovalRequest(
                   prisonId = "LEI",
                   signedOperationalCapacity = 50,
+                  reasonForChange = "We built more cells",
                 ),
               ),
             )
@@ -173,6 +177,7 @@ class CertificationResourceTest : CommonDataTestBase() {
               SignedOpCapApprovalRequest(
                 prisonId = "LEI",
                 signedOperationalCapacity = 10,
+                reasonForChange = "Damp cells",
               ),
             ),
           )
@@ -185,7 +190,8 @@ class CertificationResourceTest : CommonDataTestBase() {
               "approvalType":"SIGNED_OP_CAP",
               "prisonId":"LEI",
               "status": "PENDING",
-              "signedOperationCapacityChange": -190
+              "signedOperationCapacityChange": -190,
+              "reasonForChange": "Damp cells"
               }
           """,
             JsonCompareMode.LENIENT,
@@ -498,6 +504,7 @@ class CertificationResourceTest : CommonDataTestBase() {
               SignedOpCapApprovalRequest(
                 prisonId = "LEI",
                 signedOperationalCapacity = 10,
+                reasonForChange = "Broken door",
               ),
             ),
           )


### PR DESCRIPTION
This pull request introduces support for including a reason related to signed operation capacity changes. Updates were made to DTOs, entities, services, migrations, and tests to implement and validate this feature.