### PR TITLE
MAP-2765: increase nginx timeout in dev to handle long running bulk updates

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -8,6 +8,8 @@ generic-service:
 
   ingress:
     host: locations-inside-prison-api-dev.hmpps.service.justice.gov.uk
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json


### PR DESCRIPTION
Running a bulk update for capacity changes with a large number of locations causes a 504 timeout. Increase the read timeout 