### PR TITLE
MAP-2778 Add fallback to default next level type for sub-location descriptions in ResidentialSummary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -179,6 +179,10 @@ open class ResidentialLocation(
     if (pos < structure.size) structure[pos] else ResidentialStructuralType.valueOf(locationType.name).defaultNextLevel
   }
 
+  fun getDefaultNextLevel() = getResidentialStructuralType()?.defaultNextLevel
+
+  fun getResidentialStructuralType() = ResidentialStructuralType.entries.firstOrNull { it.locationType == locationType }
+
   fun requestApproval(requestedDate: LocalDateTime, requestedBy: String, linkedTransaction: LinkedTransaction): LocationCertificationApprovalRequest {
     fun traverseAndLock(location: ResidentialLocation) {
       location.lock(requestedDate, requestedBy, linkedTransaction)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -1351,7 +1351,7 @@ class LocationService(
       .map { it.toDto(countInactiveCells = true, countCells = true) }
       .sortedWith(NaturalOrderComparator())
 
-    val subLocationTypes = calculateSubLocationDescription(locations) ?: currentLocation?.getNextLevelTypeWithinStructure()?.getPlural() ?: "Wings"
+    val subLocationTypes = calculateSubLocationDescription(locations) ?: currentLocation?.getNextLevelTypeWithinStructure()?.getPlural() ?: currentLocation?.getDefaultNextLevel()?.getPlural() ?: "Wings"
     return ResidentialSummary(
       topLevelLocationType = currentLocation?.let { it.getHierarchy()[0].type.getPlural() } ?: "Wings",
       prisonSummary = if (id == null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResourceTest.kt
@@ -263,6 +263,7 @@ class LocationResidentialResourceTest : CommonDataTestBase() {
             """
            {
               "topLevelLocationType": "Wings",
+              "subLocationName": "Cells",
               "parentLocation": {
                 "prisonId": "MDI",
                 "code": "1",
@@ -373,6 +374,66 @@ class LocationResidentialResourceTest : CommonDataTestBase() {
                     "localName": "Store Room"
                 }
             ]
+          }
+          """,
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `can retrieve details of a locations on a landing without any cells`() {
+        webTestClient.get().uri("/locations/residential-summary/MDI?parentLocationId=${landingZ2.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+           {
+              "topLevelLocationType": "Wings",
+              "subLocationName": "Cells",
+              "parentLocation": {
+                "prisonId": "MDI",
+                "code": "2",
+                "pathHierarchy": "Z-2",
+                "locationType": "LANDING",
+                "level": 2,
+                "permanentlyInactive": false,
+                "capacity": {
+                  "maxCapacity": 0,
+                  "workingCapacity": 0
+                },
+                "certification": {
+                  "certified": false
+                },
+                "accommodationTypes": [
+                ],
+                "specialistCellTypes": [
+                ],
+                "usedFor": [
+                ],
+                "numberOfCellLocations": 0,
+                "status": "ACTIVE",
+                "active": true,
+                "inactiveCells": 0,
+                "key": "MDI-Z-2"
+              },
+               "locationHierarchy": [
+                  {
+                    "prisonId": "MDI",
+                    "code": "Z",
+                    "type": "WING",
+                    "pathHierarchy": "Z",
+                    "level": 1
+                  },
+                  {
+                    "prisonId": "MDI",
+                    "code": "2",
+                    "type": "LANDING",
+                    "pathHierarchy": "Z-2",
+                    "level": 2
+                 }
+                ]
           }
           """,
             JsonCompareMode.LENIENT,


### PR DESCRIPTION
### Summary
This pull request adds a fallback mechanism to default to the next level type for sub-location descriptions within the `ResidentialSummary` component.

### Testing
- [ ] Verify that sub-location descriptions correctly use the default next level type when none is specified.