### PR TITLE
MAP-2777 🐛 Extend `specialist_cell_types` length and update `CertificationApprovalRequest` visibility modifiers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CertificationApprovalRequest.kt
@@ -26,29 +26,29 @@ abstract class CertificationApprovalRequest(
   open val id: UUID? = null,
 
   @Enumerated(EnumType.STRING)
-  val approvalType: ApprovalType,
+  open val approvalType: ApprovalType,
 
   @Column(nullable = false)
-  val prisonId: String,
+  open val prisonId: String,
 
   @Column(nullable = false)
-  protected val requestedBy: String,
+  open val requestedBy: String,
 
   @Column(nullable = false)
-  protected val requestedDate: LocalDateTime,
+  open val requestedDate: LocalDateTime,
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   open var status: ApprovalRequestStatus = ApprovalRequestStatus.PENDING,
 
   @Column(nullable = true)
-  protected var approvedOrRejectedBy: String? = null,
+  open var approvedOrRejectedBy: String? = null,
 
   @Column(nullable = true)
-  protected var approvedOrRejectedDate: LocalDateTime? = null,
+  open var approvedOrRejectedDate: LocalDateTime? = null,
 
   @Column(nullable = true)
-  protected var comments: String? = null,
+  open var comments: String? = null,
 
 ) : Comparable<CertificationApprovalRequest> {
 

--- a/src/main/resources/db/migration/V1_68__extend_specialist_cell_types_length.sql
+++ b/src/main/resources/db/migration/V1_68__extend_specialist_cell_types_length.sql
@@ -1,0 +1,6 @@
+-- Increase the size of specialist_cell_types to 4000 characters
+-- Context: HMPPS Locations Inside Prison API
+-- Reason: Need to store more specialist cell types details per location
+
+ALTER TABLE cell_certificate_location
+    ALTER COLUMN specialist_cell_types TYPE VARCHAR(4000);


### PR DESCRIPTION
- Increased the `specialist_cell_types` database column size to 4000 characters, enabling support for larger data.
- Updated visibility of properties in `CertificationApprovalRequest` to `open` for enhanced flexibility and extensibility.
  
No additional issues were linked with this pull request.