### PR TITLE
MAP-2777 🐛 Newly approved locations (from Draft) where not published as created so FAIL to sync into NOMIS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CertificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CertificationService.kt
@@ -140,6 +140,7 @@ class CertificationService(
     val now = LocalDateTime.now(clock)
     val transactionInvokedBy = getUsername()
     val approvedLocation = (approvalRequest as? LocationCertificationApprovalRequest)?.location
+    val wasDraft = approvedLocation?.isDraft() ?: false
 
     val linkedTransaction = createLinkedTransaction(
       transactionType = TransactionType.APPROVE_CERTIFICATION_REQUEST,
@@ -187,7 +188,7 @@ class CertificationService(
     return ApprovalResponse(
       approvalRequest = approvalRequest.toDto(),
       prisonId = approvalRequest.prisonId,
-      newLocation = approvedLocation?.isDraft() ?: false,
+      newLocation = wasDraft,
       location = approvedLocation?.toDto(includeChildren = true, includeParent = true),
     ).also { linkedTransaction.txEndTime = LocalDateTime.now(clock) }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
@@ -617,7 +617,20 @@ class CertificationResourceTest : CommonDataTestBase() {
           )
 
         assertThat(getNumberOfMessagesCurrentlyOnQueue()).isEqualTo(9)
-
+        getDomainEvents(9).let {
+          assertThat(it).hasSize(9)
+          assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
+            "location.inside.prison.created" to "LEI-M-1-001",
+            "location.inside.prison.created" to "LEI-M-1-002",
+            "location.inside.prison.created" to "LEI-M-1-003",
+            "location.inside.prison.created" to "LEI-M-2-001",
+            "location.inside.prison.created" to "LEI-M-2-002",
+            "location.inside.prison.created" to "LEI-M-2-003",
+            "location.inside.prison.created" to "LEI-M-1",
+            "location.inside.prison.created" to "LEI-M-2",
+            "location.inside.prison.created" to "LEI-M",
+          )
+        }
         webTestClient.get().uri("/locations/${mWing.id}?includeChildren=true")
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
           .exchange()


### PR DESCRIPTION
This pull request resolves the issue where newly approved locations, transitioning from Draft status, were not being marked as created, causing them to fail synchronization with NOMIS.