### PR TITLE
MAP-2800 Add `usedForTypes` and `accommodationTypes` to locations and signed operation capacity to cell certificates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDto.kt
@@ -2,9 +2,11 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.AccommodationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ConvertedCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.UsedForType
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -34,6 +36,9 @@ data class CellCertificateDto(
 
   @param:Schema(description = "Total capacity of certified cells for the prison", example = "110", required = true)
   val totalCertifiedNormalAccommodation: Int,
+
+  @param:Schema(description = "Signed operational capacity for the prison", example = "500", required = true)
+  val signedOperationCapacity: Int,
 
   @param:Schema(description = "Whether this is the current certificate", example = "true", required = true)
   val current: Boolean,
@@ -70,8 +75,14 @@ data class CellCertificateLocationDto(
   @param:Schema(description = "Location type", example = "CELL", required = true)
   val locationType: LocationType,
 
-  @param:Schema(description = "Specialist cell types")
-  val specialistCellTypes: List<SpecialistCellType>,
+  @param:Schema(description = "Accommodation Types", required = false)
+  val accommodationTypes: List<AccommodationType>? = null,
+
+  @param:Schema(description = "Specialist Cell Types", required = false)
+  val specialistCellTypes: List<SpecialistCellType>? = null,
+
+  @param:Schema(description = "Usage For", required = false)
+  val usedFor: List<UsedForType>? = null,
 
   @param:Schema(description = "Local name for the location, not used in cells", example = "Houseblock A")
   val localName: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestDto.kt
@@ -70,9 +70,6 @@ data class CertificationApprovalRequestDto(
 data class ApproveCertificationRequestDto(
   @param:Schema(description = "Approval request reference", example = "2475f250-434a-4257-afe7-b911f1773a4d", required = true)
   val approvalRequestReference: UUID,
-
-  @param:Schema(description = "Comments about the approval", required = true)
-  val comments: String,
 )
 
 @Schema(description = "Request to reject a certification request")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestLocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestLocationDto.kt
@@ -2,9 +2,11 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.AccommodationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ConvertedCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.UsedForType
 import java.util.UUID
 
 @Schema(description = "Location affected by certification approval")
@@ -43,8 +45,14 @@ data class CertificationApprovalRequestLocationDto(
   @param:Schema(description = "Location type", example = "CELL", required = true)
   val locationType: LocationType,
 
-  @param:Schema(description = "Specialist cell types", example = "LISTENER,SAFE_CELL", required = false)
+  @param:Schema(description = "Accommodation Types", required = false)
+  val accommodationTypes: List<AccommodationType>? = null,
+
+  @param:Schema(description = "Specialist Cell Types", required = false)
   val specialistCellTypes: List<SpecialistCellType>? = null,
+
+  @param:Schema(description = "Usage For", required = false)
+  val usedFor: List<UsedForType>? = null,
 
   @param:Schema(description = "Converted cell type", example = "OFFICE", required = false)
   val convertedCellType: ConvertedCellType? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CreateEntireWingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CreateEntireWingRequest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationAttribute
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.UsedForType
 import java.time.Clock
 import java.time.LocalDateTime
@@ -177,6 +178,7 @@ data class CreateEntireWingRequest(
           ),
         ).apply {
           addUsedFor(UsedForType.STANDARD_ACCOMMODATION, createdBy, clock, linkedTransaction = linkedTransaction)
+          addSpecialistCellType(SpecialistCellType.ESCAPE_LIST, linkedTransaction = linkedTransaction, userOrSystemInContext = createdBy, clock = clock)
           leaf.addChildLocation(this)
 
           addHistory(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -49,6 +49,9 @@ open class CellCertificate(
   open var totalCertifiedNormalAccommodation: Int = 0,
 
   @Column(nullable = false)
+  open var signedOperationCapacity: Int = 0,
+
+  @Column(nullable = false)
   private var current: Boolean = true,
 
   @SortNatural
@@ -71,6 +74,7 @@ open class CellCertificate(
     totalWorkingCapacity = totalWorkingCapacity,
     totalMaxCapacity = totalMaxCapacity,
     totalCertifiedNormalAccommodation = totalCertifiedNormalAccommodation,
+    signedOperationCapacity = signedOperationCapacity,
     current = current,
     approvedRequest = certificationApprovalRequest.toDto(),
     locations = if (showLocations) {
@@ -120,8 +124,11 @@ open class CellCertificateLocation(
   @Enumerated(EnumType.STRING)
   private val locationType: LocationType,
 
-  @Column(name = "specialist_cell_types", nullable = true)
   private val specialistCellTypes: String? = null,
+
+  private val usedForTypes: String? = null,
+
+  private val accommodationTypes: String? = null,
 
   @Column(nullable = true)
   @Enumerated(EnumType.STRING)
@@ -151,8 +158,6 @@ open class CellCertificateLocation(
     return pathHierarchy == other.pathHierarchy
   }
 
-  private fun getSpecialistCellTypesAsList(): List<SpecialistCellType> = specialistCellTypes?.split(",")?.map { SpecialistCellType.valueOf(it.trim()) } ?: emptyList()
-
   fun toDto(): CellCertificateLocationDto = CellCertificateLocationDto(
     locationCode = locationCode,
     pathHierarchy = pathHierarchy,
@@ -161,11 +166,19 @@ open class CellCertificateLocation(
     maxCapacity = maxCapacity,
     inCellSanitation = inCellSanitation,
     locationType = locationType,
-    specialistCellTypes = getSpecialistCellTypesAsList(),
+    specialistCellTypes = getSpecialistCellTypesFromList(),
+    accommodationTypes = getAccommodationTypesFromList(),
+    usedFor = getUsedForTypesFromList(),
     localName = localName,
     cellMark = cellMark,
     level = level,
     convertedCellType = convertedCellType,
     subLocations = subLocations.map { it.toDto() },
   )
+
+  private fun getSpecialistCellTypesFromList(): List<SpecialistCellType>? = specialistCellTypes?.split(",")?.map { SpecialistCellType.valueOf(it.trim()) }
+
+  private fun getUsedForTypesFromList(): List<UsedForType>? = usedForTypes?.split(",")?.map { UsedForType.valueOf(it.trim()) }
+
+  private fun getAccommodationTypesFromList(): List<AccommodationType>? = accommodationTypes?.split(",")?.map { AccommodationType.valueOf(it.trim()) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CertificationApprovalRequest.kt
@@ -98,11 +98,10 @@ abstract class CertificationApprovalRequest(
     comments = comments,
   )
 
-  open fun approve(approvedBy: String, approvedDate: LocalDateTime, linkedTransaction: LinkedTransaction, comments: String) {
+  open fun approve(approvedBy: String, approvedDate: LocalDateTime, linkedTransaction: LinkedTransaction) {
     this.status = ApprovalRequestStatus.APPROVED
     this.approvedOrRejectedBy = approvedBy
     this.approvedOrRejectedDate = approvedDate
-    this.comments = comments
   }
 
   open fun reject(rejectedBy: String, rejectedDate: LocalDateTime, linkedTransaction: LinkedTransaction, comments: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CertificationApprovalRequestLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CertificationApprovalRequestLocation.kt
@@ -53,8 +53,11 @@ open class CertificationApprovalRequestLocation(
   @Enumerated(EnumType.STRING)
   private val locationType: LocationType,
 
-  @Column(name = "specialist_cell_types", nullable = true)
   private val specialistCellTypes: String? = null,
+
+  private val usedForTypes: String? = null,
+
+  private val accommodationTypes: String? = null,
 
   @Column(nullable = true)
   @Enumerated(EnumType.STRING)
@@ -84,8 +87,6 @@ open class CertificationApprovalRequestLocation(
     return pathHierarchy == other.pathHierarchy
   }
 
-  private fun getSpecialistCellTypesAsList(): List<SpecialistCellType> = specialistCellTypes?.split(",")?.map { SpecialistCellType.valueOf(it.trim()) } ?: emptyList()
-
   fun toDto(): CertificationApprovalRequestLocationDto = CertificationApprovalRequestLocationDto(
     id = id!!,
     locationCode = locationCode,
@@ -98,8 +99,16 @@ open class CertificationApprovalRequestLocation(
     maxCapacity = maxCapacity,
     inCellSanitation = inCellSanitation,
     locationType = locationType,
-    specialistCellTypes = getSpecialistCellTypesAsList().takeIf { it.isNotEmpty() },
+    specialistCellTypes = getSpecialistCellTypesFromList(),
+    accommodationTypes = getAccommodationTypesFromList(),
+    usedFor = getUsedForTypesFromList(),
     convertedCellType = convertedCellType,
     subLocations = subLocations.map { it.toDto() }.takeIf { it.isNotEmpty() },
   )
+
+  private fun getSpecialistCellTypesFromList(): List<SpecialistCellType>? = specialistCellTypes?.split(",")?.map { SpecialistCellType.valueOf(it.trim()) }
+
+  private fun getUsedForTypesFromList(): List<UsedForType>? = usedForTypes?.split(",")?.map { UsedForType.valueOf(it.trim()) }
+
+  private fun getAccommodationTypesFromList(): List<AccommodationType>? = accommodationTypes?.split(",")?.map { AccommodationType.valueOf(it.trim()) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationCertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationCertificationApprovalRequest.kt
@@ -71,8 +71,8 @@ open class LocationCertificationApprovalRequest(
     },
   )
 
-  override fun approve(approvedBy: String, approvedDate: LocalDateTime, linkedTransaction: LinkedTransaction, comments: String) {
-    super.approve(approvedBy, approvedDate, linkedTransaction, comments)
+  override fun approve(approvedBy: String, approvedDate: LocalDateTime, linkedTransaction: LinkedTransaction) {
+    super.approve(approvedBy, approvedDate, linkedTransaction)
     location.approve(
       approvedDate = approvedDate,
       approvedBy = approvedBy,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -463,7 +463,9 @@ open class ResidentialLocation(
         calcWorkingCapacity()
       },
       certifiedNormalAccommodation = calcCertifiedNormalAccommodation(),
-      specialistCellTypes = getSpecialistCellTypes().map { it.specialistCellType }.takeIf { it.isNotEmpty() }?.joinToString(separator = ",") { it.name },
+      usedForTypes = getUsedForValuesAsCSV(),
+      accommodationTypes = getAccommodationTypesAsCSV(),
+      specialistCellTypes = getSpecialistCellTypesAsCSV(),
       convertedCellType = if (this is Cell && isConvertedCell()) {
         convertedCellType
       } else {
@@ -498,7 +500,9 @@ open class ResidentialLocation(
       maxCapacity = calcMaxCapacity(true),
       workingCapacity = calcWorkingCapacity(true),
       certifiedNormalAccommodation = calcCertifiedNormalAccommodation(true),
-      specialistCellTypes = getSpecialistCellTypes().map { it.specialistCellType }.takeIf { it.isNotEmpty() }?.joinToString(separator = ",") { it.name },
+      usedForTypes = getUsedForValuesAsCSV(),
+      accommodationTypes = getAccommodationTypesAsCSV(),
+      specialistCellTypes = getSpecialistCellTypesAsCSV(),
       convertedCellType = if (this is Cell && isConvertedCell()) {
         convertedCellType
       } else {
@@ -507,6 +511,14 @@ open class ResidentialLocation(
       subLocations = subLocations.toSortedSet(),
     )
   }
+
+  private fun getSpecialistCellTypesAsCSV(): String? = getSpecialistCellTypes().map { it.specialistCellType }.distinct().takeIf { it.isNotEmpty() }
+    ?.joinToString(separator = ",") { it.name }
+
+  private fun getAccommodationTypesAsCSV(): String? = getAccommodationTypes().takeIf { it.isNotEmpty() }?.joinToString(separator = ",") { it.name }
+
+  private fun getUsedForValuesAsCSV(): String? = getUsedForValues().map { it.usedFor }.distinct().takeIf { it.isNotEmpty() }
+    ?.joinToString(separator = ",") { it.name }
 
   override fun toDto(
     includeChildren: Boolean,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/SignedOpCapCertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/SignedOpCapCertificationApprovalRequest.kt
@@ -55,9 +55,8 @@ open class SignedOpCapCertificationApprovalRequest(
     approvedBy: String,
     approvedDate: LocalDateTime,
     linkedTransaction: LinkedTransaction,
-    comments: String,
   ) {
-    super.approve(approvedBy, approvedDate, linkedTransaction, comments)
+    super.approve(approvedBy, approvedDate, linkedTransaction)
     signedOperationCapacity.signedOperationCapacity += signedOperationCapacityChange
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -29,6 +29,7 @@ class CellCertificateService(
     approvedBy: String,
     approvedDate: LocalDateTime,
     approvalRequest: CertificationApprovalRequest,
+    signedOperationCapacity: Int,
     approvedLocation: ResidentialLocation? = null,
   ): CellCertificateDto {
     // Mark any existing current certificates as not current
@@ -41,6 +42,7 @@ class CellCertificateService(
         approvedBy = approvedBy,
         approvedDate = approvedDate,
         certificationApprovalRequest = approvalRequest,
+        signedOperationCapacity = signedOperationCapacity,
         locations = residentialLocationRepository.findAllByPrisonIdAndParentIsNull(approvalRequest.prisonId)
           .filter { !it.isPermanentlyDeactivated() && !it.isDraft() && it.isStructural() }
           .map {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CertificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CertificationService.kt
@@ -153,7 +153,6 @@ class CertificationService(
       approvedBy = username,
       approvedDate = now,
       linkedTransaction = linkedTransaction,
-      comments = approveCertificationRequest.comments,
     )
 
     // Create the cell certificate
@@ -162,6 +161,8 @@ class CertificationService(
       approvedBy = transactionInvokedBy,
       approvedDate = now,
       approvedLocation = approvedLocation,
+      signedOperationCapacity = signedOperationCapacityRepository.findByPrisonId(approvalRequest.prisonId)?.signedOperationCapacity
+        ?: 0,
     )
 
     telemetryClient.trackEvent(

--- a/src/main/resources/db/migration/V1_71__used_for_accommodation_type.sql
+++ b/src/main/resources/db/migration/V1_71__used_for_accommodation_type.sql
@@ -1,0 +1,12 @@
+ALTER TABLE cell_certificate_location
+    ADD COLUMN used_for_types      VARCHAR(300),
+    ADD COLUMN accommodation_types VARCHAR(120),
+    ALTER COLUMN specialist_cell_types TYPE VARCHAR(300);
+
+ALTER TABLE certification_approval_request_location
+    ADD COLUMN used_for_types      VARCHAR(300),
+    ADD COLUMN accommodation_types VARCHAR(120),
+    ALTER COLUMN specialist_cell_types TYPE VARCHAR(300);
+
+ALTER TABLE cell_certificate
+    ADD COLUMN signed_operation_capacity INTEGER NOT NULL DEFAULT 0;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
@@ -89,7 +89,6 @@ class CellCertificateResourceTest : CommonDataTestBase() {
         jsonString(
           ApproveCertificationRequestDto(
             approvalRequestReference = approvalRequestId,
-            comments = "All locations OK",
           ),
         ),
       )
@@ -146,7 +145,6 @@ class CellCertificateResourceTest : CommonDataTestBase() {
         jsonString(
           ApproveCertificationRequestDto(
             approvalRequestReference = approvalRequestId,
-            comments = "Cell ok",
           ),
         ),
       )
@@ -316,9 +314,14 @@ class CellCertificateResourceTest : CommonDataTestBase() {
         // Verify that there are locations in the response
         .jsonPath("$.locations.length()").isEqualTo(2)
         .jsonPath("$.locations[0].workingCapacity").isEqualTo(6)
+        .jsonPath("$.locations[0].accommodationTypes[0]").isEqualTo("NORMAL_ACCOMMODATION")
+        .jsonPath("$.locations[0].usedFor[0]").isEqualTo("STANDARD_ACCOMMODATION")
+        .jsonPath("$.locations[0].specialistCellTypes[0]").isEqualTo("ESCAPE_LIST")
         .jsonPath("$.locations[0].subLocations.length()").isEqualTo(2)
         .jsonPath("$.locations[0].subLocations[0].subLocations.length()").isEqualTo(3)
         .jsonPath("$.locations[0].subLocations[0].subLocations[0].workingCapacity").isEqualTo(1)
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].accommodationTypes[0]").isEqualTo("NORMAL_ACCOMMODATION")
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].usedFor[0]").isEqualTo("STANDARD_ACCOMMODATION")
         .jsonPath("$.locations[0].subLocations[0].subLocations[0].maxCapacity").isEqualTo(2)
         .jsonPath("$.locations[0].subLocations[1].subLocations.length()").isEqualTo(3)
         .jsonPath("$.locations[1].workingCapacity").isEqualTo(6)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
@@ -375,6 +375,12 @@ class CertificationResourceTest : CommonDataTestBase() {
                 "workingCapacity": 6,
                 "maxCapacity": 12,
                 "locationType": "WING",
+                "accommodationTypes": [
+                  "NORMAL_ACCOMMODATION"
+                ],
+                "usedFor": [
+                  "STANDARD_ACCOMMODATION"
+                ],
                 "subLocations": [
                   {
                     "pathHierarchy": "M-1",
@@ -383,6 +389,12 @@ class CertificationResourceTest : CommonDataTestBase() {
                     "workingCapacity": 3,
                     "maxCapacity": 6,
                     "locationType": "LANDING",
+                    "accommodationTypes": [
+                      "NORMAL_ACCOMMODATION"
+                    ],
+                    "usedFor": [
+                      "STANDARD_ACCOMMODATION"
+                    ],
                     "subLocations": [
                       {
                         "cellMark": "M-1",
@@ -392,7 +404,13 @@ class CertificationResourceTest : CommonDataTestBase() {
                         "workingCapacity": 1,
                         "maxCapacity": 2,
                         "inCellSanitation": true,
-                        "locationType": "CELL"
+                        "locationType": "CELL",
+                        "accommodationTypes": [
+                          "NORMAL_ACCOMMODATION"
+                        ],
+                        "usedFor": [
+                          "STANDARD_ACCOMMODATION"
+                        ]
                       },
                       {
                         "cellMark": "M-2",
@@ -402,7 +420,13 @@ class CertificationResourceTest : CommonDataTestBase() {
                         "workingCapacity": 1,
                         "maxCapacity": 2,
                         "inCellSanitation": true,
-                        "locationType": "CELL"
+                        "locationType": "CELL",
+                        "accommodationTypes": [
+                          "NORMAL_ACCOMMODATION"
+                        ],
+                        "usedFor": [
+                          "STANDARD_ACCOMMODATION"
+                        ]
                       },
                       {
                         "cellMark": "M-3",
@@ -412,7 +436,13 @@ class CertificationResourceTest : CommonDataTestBase() {
                         "workingCapacity": 1,
                         "maxCapacity": 2,
                         "inCellSanitation": true,
-                        "locationType": "CELL"
+                        "locationType": "CELL",
+                        "accommodationTypes": [
+                          "NORMAL_ACCOMMODATION"
+                        ],
+                        "usedFor": [
+                          "STANDARD_ACCOMMODATION"
+                        ]
                       }
                     ]
                   },
@@ -432,7 +462,13 @@ class CertificationResourceTest : CommonDataTestBase() {
                         "workingCapacity": 1,
                         "maxCapacity": 2,
                         "inCellSanitation": true,
-                        "locationType": "CELL"
+                        "locationType": "CELL",
+                        "accommodationTypes": [
+                          "NORMAL_ACCOMMODATION"
+                        ],
+                        "usedFor": [
+                          "STANDARD_ACCOMMODATION"
+                        ]
                       },
                       {
                         "cellMark": "M-2",
@@ -442,7 +478,13 @@ class CertificationResourceTest : CommonDataTestBase() {
                         "workingCapacity": 1,
                         "maxCapacity": 2,
                         "inCellSanitation": true,
-                        "locationType": "CELL"
+                        "locationType": "CELL",
+                        "accommodationTypes": [
+                          "NORMAL_ACCOMMODATION"
+                        ],
+                        "usedFor": [
+                          "STANDARD_ACCOMMODATION"
+                        ]
                       },
                       {
                         "cellMark": "M-3",
@@ -452,7 +494,13 @@ class CertificationResourceTest : CommonDataTestBase() {
                         "workingCapacity": 1,
                         "maxCapacity": 2,
                         "inCellSanitation": true,
-                        "locationType": "CELL"
+                        "locationType": "CELL",
+                        "accommodationTypes": [
+                          "NORMAL_ACCOMMODATION"
+                        ],
+                        "usedFor": [
+                          "STANDARD_ACCOMMODATION"
+                        ]
                       }
                     ]
                   }
@@ -484,7 +532,6 @@ class CertificationResourceTest : CommonDataTestBase() {
           jsonString(
             ApproveCertificationRequestDto(
               approvalRequestReference = UUID.randomUUID(),
-              comments = "TEST",
             ),
           ),
         ),
@@ -520,7 +567,6 @@ class CertificationResourceTest : CommonDataTestBase() {
             jsonString(
               ApproveCertificationRequestDto(
                 approvalRequestReference = approvalId,
-                comments = "Op Cap Approved",
               ),
             ),
           )
@@ -600,7 +646,6 @@ class CertificationResourceTest : CommonDataTestBase() {
             jsonString(
               ApproveCertificationRequestDto(
                 approvalRequestReference = approvalId,
-                comments = "All locations OK",
               ),
             ),
           )
@@ -753,7 +798,6 @@ class CertificationResourceTest : CommonDataTestBase() {
             jsonString(
               ApproveCertificationRequestDto(
                 approvalRequestReference = approvalRequestId.id!!,
-                comments = "All OK",
               ),
             ),
           )
@@ -764,8 +808,7 @@ class CertificationResourceTest : CommonDataTestBase() {
             """
               {
               "locationKey": "${cell1N.getKey()}",
-              "status": "APPROVED",
-              "comments": "All OK"
+              "status": "APPROVED"
               }
           """,
             JsonCompareMode.LENIENT,
@@ -813,7 +856,6 @@ class CertificationResourceTest : CommonDataTestBase() {
             jsonString(
               ApproveCertificationRequestDto(
                 approvalRequestReference = approvalRequestId,
-                comments = "All OK",
               ),
             ),
           )
@@ -872,7 +914,6 @@ class CertificationResourceTest : CommonDataTestBase() {
             jsonString(
               ApproveCertificationRequestDto(
                 approvalRequestReference = approvalRequestId,
-                comments = "All OK",
               ),
             ),
           )


### PR DESCRIPTION
- **Added Features:**
  - `usedForTypes` and `accommodationTypes` fields to locations.
  - `signedOperationCapacity` field to cell certificates.
- **Changes & Updates:**
  - Updated entities, DTOs, services, and migrations to include the new fields.
  - Removed the `comments` field from approval-related DTOs and functions.
- **Testing:**
  - Refactored test cases to validate the newly introduced fields and ensure code integrity.