### PR TITLE
MAP-3160 Remove unused configurations and simplify prisoner location logic

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,8 +15,6 @@ generic-service:
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search-dev.prison.service.justice.gov.uk
     API_BASE_URL_PRISON_REGISTER: https://prison-register-dev.hmpps.service.justice.gov.uk
     API_BASE_URL_PRISON_API: https://prison-api-dev.prison.service.justice.gov.uk
-    API_BASE_URL_MANAGE_USERS: https://manage-users-api-dev.hmpps.service.justice.gov.uk
-    URL_ENV_SUFFIX: dev
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,8 +15,6 @@ generic-service:
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search-preprod.prison.service.justice.gov.uk
     API_BASE_URL_PRISON_REGISTER: https://prison-register-preprod.hmpps.service.justice.gov.uk
     API_BASE_URL_PRISON_API: https://prison-api-preprod.prison.service.justice.gov.uk
-    API_BASE_URL_MANAGE_USERS: https://manage-users-api-preprod.hmpps.service.justice.gov.uk
-    URL_ENV_SUFFIX: preprod
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,7 +13,6 @@ generic-service:
     API_BASE_URL_PRISONER_SEARCH: https://prisoner-search.prison.service.justice.gov.uk
     API_BASE_URL_PRISON_REGISTER: https://prison-register.hmpps.service.justice.gov.uk
     API_BASE_URL_PRISON_API: https://prison-api.prison.service.justice.gov.uk
-    API_BASE_URL_MANAGE_USERS: https://manage-users-api.hmpps.service.justice.gov.uk
 
   namespace_secrets:
     hmpps-domain-events-topic:

--- a/helm_deploy/values-train.yaml
+++ b/helm_deploy/values-train.yaml
@@ -23,10 +23,8 @@ generic-service:
     API_BASE_URL_PRISONER_SEARCH: http://localhost:8090
     API_BASE_URL_PRISON_REGISTER: https://prison-register.hmpps.service.justice.gov.uk
     API_BASE_URL_PRISON_API: https://prison-api-preprod.prison.service.justice.gov.uk
-    API_BASE_URL_MANAGE_USERS: http://localhost:8090
     HMPPS_SQS_LOCALSTACK_URL: http://localhost:4566
     SPRING_PROFILES_ACTIVE: train
-    URL_ENV_SUFFIX: train
 
   extraContainers:
     - name: wiremock

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/WebClientConfiguration.kt
@@ -16,7 +16,6 @@ class WebClientConfiguration(
   @param:Value($$"${api.base.url.prisoner-search}") private val prisonerSearchUri: String,
   @param:Value($$"${api.base.url.prison-register}") private val prisonRegisterUri: String,
   @param:Value($$"${api.base.url.prison-api}") private val prisonApiUri: String,
-  @param:Value($$"${api.base.url.manage-users}") private val manageUsersApiUri: String,
   @param:Value($$"${api.timeout:20s}") val healthTimeout: Duration,
 ) {
 
@@ -33,14 +32,24 @@ class WebClientConfiguration(
   fun prisonApiHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(prisonApiUri, healthTimeout)
 
   @Bean
-  fun prisonerSearchWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = builder.authorisedWebClient(authorizedClientManager, registrationId = SYSTEM_USERNAME, url = prisonerSearchUri, healthTimeout)
+  fun prisonerSearchWebClient(
+    authorizedClientManager: OAuth2AuthorizedClientManager,
+    builder: WebClient.Builder,
+  ): WebClient = builder.authorisedWebClient(
+    authorizedClientManager,
+    registrationId = SYSTEM_USERNAME,
+    url = prisonerSearchUri,
+    healthTimeout,
+  )
 
   @Bean
-  fun prisonApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = builder.authorisedWebClient(authorizedClientManager, registrationId = SYSTEM_USERNAME, url = prisonApiUri, healthTimeout)
-
-  @Bean
-  fun manageUsersHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(manageUsersApiUri, healthTimeout)
-
-  @Bean
-  fun manageUsersWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = builder.authorisedWebClient(authorizedClientManager, registrationId = SYSTEM_USERNAME, url = manageUsersApiUri, healthTimeout)
+  fun prisonApiWebClient(
+    authorizedClientManager: OAuth2AuthorizedClientManager,
+    builder: WebClient.Builder,
+  ): WebClient = builder.authorisedWebClient(
+    authorizedClientManager,
+    registrationId = SYSTEM_USERNAME,
+    url = prisonApiUri,
+    healthTimeout,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -825,8 +825,6 @@ data class TemporaryDeactivationLocationRequest(
   val requiresApproval: Boolean = false,
   @param:Schema(description = "Explanation of why the capacity need to be decreased", example = "The cell is damaged and will be take 6 months to repair", required = false)
   val reasonForChange: String? = null,
-  @param:Schema(description = "Skip certificate approval", example = "true", required = false)
-  val forceReactivation: Boolean = false,
 ) {
   fun toBasicDeactivation() = BasicTemporaryDeactivationRequest(
     deactivationReason = deactivationReason,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/health/HealthCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/health/HealthCheck.kt
@@ -16,6 +16,3 @@ class PrisonRegisterApiHealth(@Qualifier("prisonRegisterWebClient") webClient: W
 
 @Component("prisonApi")
 class PrisonApiHealth(@Qualifier("prisonApiHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)
-
-@Component("manageUsersApi")
-class ManageUsersApiHealth(@Qualifier("manageUsersHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -1604,7 +1604,11 @@ class LocationService(
   private fun checkForPrisonersInLocation(location: Location) {
     val locationsWithPrisoners = prisonerLocationService.prisonersInLocations(location).groupBy { it.cellLocation!! }
     if (locationsWithPrisoners.isNotEmpty()) {
-      throw LocationContainsPrisonersException(locationsWithPrisoners)
+      location.cellLocations().forEach {
+        if (!locationsWithPrisoners[it.getPathHierarchy()].isNullOrEmpty()) {
+          throw LocationContainsPrisonersException(locationsWithPrisoners)
+        }
+      }
     }
   }
 

--- a/src/main/resources/db/seed/R__02_location_docker_seed.sql
+++ b/src/main/resources/db/seed/R__02_location_docker_seed.sql
@@ -1,3 +1,3 @@
-call setup_prison_demo_locations('LEI', 'ITAG_USER', true);
-call setup_prison_demo_locations('BXI', 'ITAG_USER', true);
-call setup_prison_demo_locations('MDI', 'ITAG_USER', true);
+call setup_prison_demo_locations('LEI', 'ITAG_USER', false);
+call setup_prison_demo_locations('BXI', 'ITAG_USER', false);
+call setup_prison_demo_locations('MDI', 'ITAG_USER', false);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/ResourceSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/ResourceSecurityTest.kt
@@ -20,18 +20,6 @@ class ResourceSecurityTest : SqsIntegrationTestBase() {
     "GET /v3/api-docs/swagger-config",
     " /error",
     "PUT /queue-admin/retry-all-dlqs",
-    "GET /reports/{reportId}/{reportVariantId}/count",
-    "GET /reports/{reportId}/{reportVariantId}",
-    "GET /reports/{reportId}/{reportVariantId}/{fieldId}",
-    "GET /definitions",
-    "GET /definitions/{reportId}",
-    "GET /definitions/{reportId}/{variantId}",
-    "GET /definitions/{dataProductDefinitionId}/dashboards/{dashboardId}",
-    "GET /statements",
-    "GET /async",
-    "GET /productCollections",
-    "GET /reports/{reportId}/dashboards/{dashboardId}",
-    "GET /productCollections/{id}",
   )
 
   @Test


### PR DESCRIPTION
Simplified the application by removing unused `manageUsers` configurations and related DTO fields. Refactored and streamlined prisoner location checking logic, and updated location seed setup accordingly.