### PR TITLE
MAP-3160 Refactor capacity handling and approval logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PendingChangeDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CapacityChangeApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CellMarkChangeApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequestLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.DraftChangeApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.LocationCertificationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.SanitationChangeApprovalRequest
@@ -62,18 +63,18 @@ class Cell(
 
   @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @SortNatural
-  val attributes: SortedSet<ResidentialAttribute> = sortedSetOf(),
+  var attributes: SortedSet<ResidentialAttribute> = sortedSetOf(),
 
   @Enumerated(EnumType.STRING)
   var accommodationType: AccommodationType = AccommodationType.NORMAL_ACCOMMODATION,
 
   @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @SortNatural
-  val usedFor: SortedSet<CellUsedFor> = sortedSetOf(),
+  var usedFor: SortedSet<CellUsedFor> = sortedSetOf(),
 
   @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @SortNatural
-  val specialistCellTypes: SortedSet<SpecialistCell> = sortedSetOf(),
+  var specialistCellTypes: SortedSet<SpecialistCell> = sortedSetOf(),
 
   @Enumerated(EnumType.STRING)
   var convertedCellType: ConvertedCellType? = null,
@@ -103,16 +104,25 @@ class Cell(
   capacity = capacity,
 ) {
 
-  fun getWorkingCapacity() = capacity?.workingCapacity
+  fun getOldWorkingCapacity(): Int? = findPendingLeafLocation(true)?.currentWorkingCapacity ?: capacity?.workingCapacity
 
-  fun getMaxCapacity(includePending: Boolean = false): Int? {
-    val pendingChange = getPendingCapacityChange(includePending)
-    return pendingChange?.maxCapacity ?: capacity?.maxCapacity
+  fun getWorkingCapacity(includePending: Boolean = false): Int? = findPendingLeafLocation(includePending)?.workingCapacity ?: if (isActiveAndAllParentsActive() || (includePending && isDraft())) {
+    getCurrentlyHeldWorkingCapacity()
+  } else {
+    null
   }
 
-  fun getCertifiedNormalAccommodation(includePending: Boolean = false): Int? {
-    val pendingChange = getPendingCapacityChange(includePending)
-    return pendingChange?.certifiedNormalAccommodation ?: capacity?.certifiedNormalAccommodation
+  fun getMaxCapacity(includePending: Boolean = false): Int? = findPendingLeafLocation(includePending)?.maxCapacity ?: capacity?.maxCapacity
+
+  fun getCertifiedNormalAccommodation(includePending: Boolean = false): Int? = findPendingLeafLocation(includePending)?.certifiedNormalAccommodation ?: capacity?.certifiedNormalAccommodation
+
+  private fun findPendingLeafLocation(includePending: Boolean): CertificationApprovalRequestLocation? {
+    val topLevelLocation = getPendingCapacityChange(includePending)?.getTopLevelLocation() ?: return null
+    return if (topLevelLocation.pathHierarchy == this.getPathHierarchy()) {
+      topLevelLocation
+    } else {
+      topLevelLocation.findSubLocations().firstOrNull { it.pathHierarchy == this.getPathHierarchy() }
+    }
   }
 
   fun getDoorCellMark(includePending: Boolean = false): String? {
@@ -134,7 +144,7 @@ class Cell(
   }
 
   private fun getPendingCapacityChange(shouldIncludePending: Boolean) = if (shouldIncludePending) {
-    getPendingApprovalRequest() as? CapacityChangeApprovalRequest
+    getPendingApprovalRequest()
   } else {
     null
   }
@@ -691,7 +701,7 @@ class Cell(
     cellCertificateLocation = cellCertificateLocation,
   ).copy(
     oldWorkingCapacity = if (isTemporarilyDeactivated()) {
-      getWorkingCapacity()
+      calcOldWorkingCapacity()
     } else {
       null
     },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -92,7 +92,7 @@ abstract class Location(
   @Id
   @GeneratedUuidV7
   @Column(name = "id", updatable = false, nullable = false)
-  open val id: UUID? = null,
+  open var id: UUID? = null,
 
   open var code: String,
 
@@ -101,7 +101,7 @@ abstract class Location(
   @Enumerated(EnumType.STRING)
   open var locationType: LocationType,
 
-  open val prisonId: String,
+  open var prisonId: String,
 
   @ManyToOne(fetch = FetchType.EAGER, cascade = [CascadeType.PERSIST])
   @JoinColumn(name = "parent_id")
@@ -126,13 +126,13 @@ abstract class Location(
 
   @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
   @SortNatural
-  protected open val childLocations: SortedSet<Location> = sortedSetOf(),
+  protected open var childLocations: SortedSet<Location> = sortedSetOf(),
 
   @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @SortNatural
-  protected open val history: SortedSet<LocationHistory> = sortedSetOf(),
+  protected open var history: SortedSet<LocationHistory> = sortedSetOf(),
 
-  open val whenCreated: LocalDateTime,
+  open var whenCreated: LocalDateTime,
   open var whenUpdated: LocalDateTime,
   open var updatedBy: String,
   open var deactivatedBy: String? = null,
@@ -980,7 +980,7 @@ abstract class Location(
       amendedLocations = amendedLocations,
     )
     val previousWorkingCapacity = if (this is ResidentialLocation) {
-      calcWorkingCapacity()
+      calcOldWorkingCapacity()
     } else {
       null
     }
@@ -989,7 +989,7 @@ abstract class Location(
     if (this is Cell && capacityAdjusted) {
       setCapacity(
         maxCapacity = maxCapacity ?: getMaxCapacity(includePending = true) ?: 0,
-        workingCapacity = workingCapacity ?: getWorkingCapacity() ?: 0,
+        workingCapacity = workingCapacity ?: getCurrentlyHeldWorkingCapacity() ?: 0,
         certifiedNormalAccommodation = certifiedNormalAccommodation ?: getCertifiedNormalAccommodation() ?: 0,
         userOrSystemInContext = userOrSystemInContext,
         amendedDate = linkedTransaction.txStartTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -69,7 +69,7 @@ open class ResidentialLocation(
 
   @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @SortNatural
-  open val approvalRequests: SortedSet<LocationCertificationApprovalRequest> = sortedSetOf(),
+  open var approvalRequests: SortedSet<LocationCertificationApprovalRequest> = sortedSetOf(),
 
 ) : Location(
   id = id,
@@ -117,14 +117,22 @@ open class ResidentialLocation(
   fun isNonResType() = locationType in ResidentialLocationType.entries.filter { it.nonResType }.map { it.baseType }
   fun isLocationShownOnResidentialSummary() = locationType in ResidentialLocationType.entries.filter { it.display }.map { it.baseType }
 
+  fun getCurrentlyHeldWorkingCapacity(): Int? = capacity?.workingCapacity
+
   fun getWorkingCapacityIgnoreParent(): Int = cellLocations().filter { it.isActive() }
-    .sumOf { it.getWorkingCapacity() ?: 0 }
+    .sumOf { it.getCurrentlyHeldWorkingCapacity() ?: 0 }
 
   fun getWorkingCapacityIgnoringInactiveStatus(): Int = cellLocations().filter { isCurrentCellOrNotPermanentlyInactive(it) }
+    .sumOf { it.getCurrentlyHeldWorkingCapacity() ?: 0 }
+
+  fun calcPendingWorkingCapacity(includeDraft: Boolean = false): Int = cellLocations().filter { it.isActiveAndAllParentsActive() || (includeDraft && it.isDraft()) }
     .sumOf { it.getWorkingCapacity() ?: 0 }
 
-  fun calcWorkingCapacity(includeDraft: Boolean = false): Int = cellLocations().filter { it.isActiveAndAllParentsActive() || (includeDraft && it.isDraft()) }
-    .sumOf { it.getWorkingCapacity() ?: 0 }
+  fun calcOldWorkingCapacity() = cellLocations().filter { isCurrentCellOrNotPermanentlyInactive(it) && (!it.isDraft()) }
+    .sumOf { it.getOldWorkingCapacity() ?: 0 }
+
+  fun calcWorkingCapacity(includePendingOrDraft: Boolean = false) = cellLocations().filter { isCurrentCellOrNotPermanentlyInactive(it) && (!it.isDraft() || includePendingOrDraft) }
+    .sumOf { it.getWorkingCapacity(includePendingOrDraft) ?: 0 }
 
   fun calcMaxCapacity(includePendingOrDraft: Boolean = false): Int = cellLocations().filter { isCurrentCellOrNotPermanentlyInactive(it) && (!it.isDraft() || includePendingOrDraft) }
     .sumOf { it.getMaxCapacity(includePendingOrDraft) ?: 0 }
@@ -746,9 +754,9 @@ open class ResidentialLocation(
     if (isCell() || isVirtualResidentialLocation()) {
       if (maxCapacity != (capacity?.maxCapacity ?: 0) ||
         certifiedNormalAccommodation != (capacity?.certifiedNormalAccommodation ?: 0) ||
-        workingCapacity != (capacity?.workingCapacity ?: 0)
+        workingCapacity != (getCurrentlyHeldWorkingCapacity() ?: 0)
       ) {
-        log.info("${getKey()}: Updating max capacity from ${capacity?.maxCapacity ?: 0} to $maxCapacity, CNA from ${capacity?.certifiedNormalAccommodation ?: 0} to $certifiedNormalAccommodation and working capacity from ${capacity?.workingCapacity ?: 0} to $workingCapacity")
+        log.info("${getKey()}: Updating max capacity from ${capacity?.maxCapacity ?: 0} to $maxCapacity, CNA from ${capacity?.certifiedNormalAccommodation ?: 0} to $certifiedNormalAccommodation and working capacity from ${getCurrentlyHeldWorkingCapacity() ?: 0} to $workingCapacity")
 
         addHistory(
           LocationAttribute.MAX_CAPACITY,
@@ -760,7 +768,7 @@ open class ResidentialLocation(
         )
         addHistory(
           LocationAttribute.WORKING_CAPACITY,
-          capacity?.workingCapacity?.let { calcWorkingCapacity().toString() } ?: "None",
+          getCurrentlyHeldWorkingCapacity()?.let { getCurrentlyHeldWorkingCapacity().toString() } ?: "None",
           workingCapacity.toString(),
           userOrSystemInContext,
           amendedDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequestLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequestLocation.kt
@@ -166,9 +166,6 @@ open class CertificationApprovalRequestLocation(
       for (childLocation in location.subLocations) {
         traverse(childLocation)
       }
-      if (this != location) {
-        subLocations.add(location)
-      }
     }
 
     traverse(this)
@@ -194,4 +191,13 @@ open class CertificationApprovalRequestLocation(
   fun certifiedNormalAccommodationChange(): Int = approvedCertifiedNormalAccommodation() - calcCurrentCertifiedNormalAccommodation()
 
   fun getSpecialistCellTypesFromList(specialCellTypes: String?): List<SpecialistCellType>? = specialCellTypes?.split(",")?.map { SpecialistCellType.valueOf(it.trim()) }
+
+  fun refreshCapacities() {
+    workingCapacity = approvedWorkingCapacity()
+    maxCapacity = approvedMaxCapacity()
+    certifiedNormalAccommodation = approvedCertifiedNormalAccommodation()
+    currentWorkingCapacity = calcCurrentWorkingCapacity()
+    currentMaxCapacity = calcCurrentMaxCapacity()
+    currentCertifiedNormalAccommodation = calcCurrentCertifiedNormalAccommodation()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/LocationCertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/LocationCertificationApprovalRequest.kt
@@ -95,6 +95,10 @@ abstract class LocationCertificationApprovalRequest(
       workingCapacityChange = topLocation.workingCapacityChange()
       maxCapacityChange = topLocation.maxCapacityChange()
       certifiedNormalAccommodationChange = topLocation.certifiedNormalAccommodationChange()
+      topLocation.refreshCapacities()
+      topLocation.findSubLocations().forEach { eachLocation ->
+        eachLocation.refreshCapacities()
+      }
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
@@ -28,7 +28,7 @@ import kotlin.collections.component1
 import kotlin.collections.component2
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 class ApprovalRequestService(
   private val certificationApprovalRequestRepository: CertificationApprovalRequestRepository,
   private val residentialLocationRepository: ResidentialLocationRepository,
@@ -41,6 +41,7 @@ class ApprovalRequestService(
   private val cellCertificateRepository: CellCertificateRepository,
 ) {
 
+  @Transactional(readOnly = true)
   fun getApprovalRequests(prisonId: String, status: ApprovalRequestStatus? = ApprovalRequestStatus.PENDING): List<CertificationApprovalRequestDto> {
     val requests = when {
       status != null -> certificationApprovalRequestRepository.findByPrisonIdAndStatusOrderByRequestedDateDesc(prisonId, status)
@@ -50,6 +51,7 @@ class ApprovalRequestService(
     return requests.map { it.toDto() }
   }
 
+  @Transactional(readOnly = true)
   fun getApprovalRequest(id: UUID): CertificationApprovalRequestDto {
     val request = certificationApprovalRequestRepository.findById(id)
       .orElseThrow { ApprovalRequestNotFoundException(id) }
@@ -57,7 +59,6 @@ class ApprovalRequestService(
     return request.toDto(showLocations = true)
   }
 
-  @Transactional
   fun requestDraftApproval(requestToApprove: LocationApprovalRequest): CertificationApprovalRequestDto {
     val location = residentialLocationRepository.findById(requestToApprove.locationId)
       .orElseThrow { LocationNotFoundException(requestToApprove.locationId.toString()) }
@@ -89,7 +90,6 @@ class ApprovalRequestService(
     }
   }
 
-  @Transactional
   fun requestReactivationApproval(reactivationApprovalRequest: ReactivationLocationsApprovalRequest): CertificationApprovalRequestDto {
     val topLevelLocation = residentialLocationRepository.findById(reactivationApprovalRequest.topLevelLocationId)
       .orElseThrow { LocationNotFoundException(reactivationApprovalRequest.topLevelLocationId.toString()) }
@@ -179,7 +179,6 @@ class ApprovalRequestService(
     }
   }
 
-  @Transactional
   fun requestSignedOpCapApproval(requestToApprove: SignedOpCapApprovalRequest): CertificationApprovalRequestDto {
     val signedOpCap = signedOperationCapacityRepository.findByPrisonId(requestToApprove.prisonId)
       ?: throw LocationNotFoundException(requestToApprove.prisonId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -886,7 +886,7 @@ class LocationService(
     }
 
     // Check that the workingCapacity is not set to 0 for normal accommodations when removing the specialist cell types
-    if (isCapacityRequired(specialistCellTypes, cell.accommodationType) && cell.getWorkingCapacity() == 0) {
+    if (isCapacityRequired(specialistCellTypes, cell.accommodationType) && cell.getCurrentlyHeldWorkingCapacity() == 0) {
       throw CapacityException(
         cell.getKey(),
         "Cannot removes specialist cell types for a normal accommodation with a working capacity of 0",
@@ -1208,9 +1208,9 @@ class LocationService(
         if (!location.isPermanentlyDeactivated()) {
           if (location is Cell) {
             with(capacityChange) {
-              if (location.getMaxCapacity(includePending = true) != maxCapacity || location.getWorkingCapacity() != workingCapacity) {
+              if (location.getMaxCapacity(includePending = true) != maxCapacity || location.getCurrentlyHeldWorkingCapacity() != workingCapacity) {
                 try {
-                  val oldWorkingCapacity = location.getWorkingCapacity()
+                  val oldWorkingCapacity = location.getCurrentlyHeldWorkingCapacity()
                   val oldMaxCapacity = location.getMaxCapacity(includePending = true)
                   val oldCertifiedNormalAccommodation = location.getCertifiedNormalAccommodation()
                   updateCellCapacity(
@@ -1644,7 +1644,7 @@ class LocationService(
         prisonId = cell.prisonId,
         pathHierarchy = cell.getPathHierarchy(),
         maxCapacity = cell.getMaxCapacity() ?: 0,
-        workingCapacity = cell.getWorkingCapacity() ?: 0,
+        workingCapacity = cell.getCurrentlyHeldWorkingCapacity() ?: 0,
         localName = cell.localName,
         specialistCellTypes = cell.specialistCellTypes.map {
           CellWithSpecialistCellTypes.CellType(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,7 @@ spring:
       max-lifetime: 600000
       connection-timeout: 1000
       validation-timeout: 500
+      auto-commit: false
 
 server:
   port: 8080

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/CommonDataTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/CommonDataTestBase.kt
@@ -331,4 +331,11 @@ class CommonDataTestBase : SqsIntegrationTestBase() {
       ),
     )
   }
+  fun baselinePrison(prisonId: String) {
+    webTestClient.post().uri("/cell-certificates/prison/$prisonId/baseline")
+      .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
+      .header("Content-Type", "application/json")
+      .exchange()
+      .expectStatus().isCreated
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -785,6 +785,12 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.locations!![0].subLocations).hasSize(2)
       assertThat(pendingApproval.workingCapacityChange).isEqualTo(0)
       assertThat(pendingApproval.locations).hasSize(1)
+      assertThat(pendingApproval.locations[0].currentWorkingCapacity).isEqualTo(6)
+      assertThat(pendingApproval.locations[0].currentMaxCapacity).isEqualTo(12)
+      assertThat(pendingApproval.locations[0].currentCertifiedNormalAccommodation).isEqualTo(6)
+      assertThat(pendingApproval.locations[0].workingCapacity).isEqualTo(6)
+      assertThat(pendingApproval.locations[0].maxCapacity).isEqualTo(12)
+      assertThat(pendingApproval.locations[0].certifiedNormalAccommodation).isEqualTo(6)
       assertThat(pendingApproval.locations[0].subLocations).hasSize(2)
       assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations).hasSize(3)
       assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).containsExactlyInAnyOrder(
@@ -892,6 +898,12 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.workingCapacityChange).isEqualTo(6)
       assertThat(pendingApproval.certifiedNormalAccommodationChange).isEqualTo(6)
       assertThat(pendingApproval.maxCapacityChange).isEqualTo(0)
+      assertThat(pendingApproval.locations[0].currentWorkingCapacity).isEqualTo(6)
+      assertThat(pendingApproval.locations[0].currentMaxCapacity).isEqualTo(12)
+      assertThat(pendingApproval.locations[0].currentCertifiedNormalAccommodation).isEqualTo(6)
+      assertThat(pendingApproval.locations[0].workingCapacity).isEqualTo(12)
+      assertThat(pendingApproval.locations[0].maxCapacity).isEqualTo(12)
+      assertThat(pendingApproval.locations[0].certifiedNormalAccommodation).isEqualTo(12)
       assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).containsExactlyInAnyOrder(
         SpecialistCellType.ESCAPE_LIST,
       )
@@ -1380,13 +1392,5 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(rejectedLocation.pendingChanges).isNull()
       assertThat(rejectedLocation.pendingApprovalRequestId).isNull()
     }
-  }
-
-  private fun baselinePrison(prisonId: String) {
-    webTestClient.post().uri("/cell-certificates/prison/$prisonId/baseline")
-      .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
-      .header("Content-Type", "application/json")
-      .exchange()
-      .expectStatus().isCreated
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
@@ -48,6 +48,12 @@ class CertificationResourceTest(@param:Autowired private val locationService: Lo
     cellCertificateRepository.deleteAll()
     super.setUp()
 
+    webTestClient.put().uri("/prison-configuration/${wingZ.prisonId}/certification-approval-required/ACTIVE")
+      .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+      .header("Content-Type", "application/json")
+      .exchange()
+      .expectStatus().isOk
+
     locationService.createCells(
       createCellsRequest = CellInitialisationRequest(
         prisonId = wingZ.prisonId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
@@ -38,6 +38,7 @@ class DraftLocationResourceTest : CommonDataTestBase() {
   @BeforeEach
   override fun setUp() {
     super.setUp()
+    baselinePrison("LEI")
     // Create a draft wing in Leeds prison
     draftWing = repository.saveAndFlush(
       CreateEntireWingRequest(
@@ -1172,7 +1173,7 @@ fun Cell.toCellInformation(specialistCellTypes: Set<SpecialistCellType>? = setOf
   code = getLocationCode(),
   cellMark = cellMark,
   maxCapacity = getMaxCapacity()!!,
-  workingCapacity = getWorkingCapacity()!!,
+  workingCapacity = getCurrentlyHeldWorkingCapacity()!!,
   certifiedNormalAccommodation = getCertifiedNormalAccommodation()!!,
   specialistCellTypes = specialistCellTypes,
   inCellSanitation = inCellSanitation ?: false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -1293,11 +1293,6 @@ class LocationResourceIntTest : CommonDataTestBase() {
                           "newValues": ["Active"]
                         },
                         {
-                          "attribute": "Working capacity",
-                          "oldValues": ["0"],
-                          "newValues": ["2"]
-                        },
-                        {
                           "attribute": "Deactivation reason",
                           "newValues": ["Mothballed"]
                         },
@@ -1509,12 +1504,6 @@ class LocationResourceIntTest : CommonDataTestBase() {
                           "attribute": "Status",
                           "oldValues": ["Inactive"],
                           "newValues": ["Active"]
-                        },
-                        {
-                          "transactionType": "REACTIVATION",
-                          "attribute": "Working capacity",
-                          "oldValues": ["0"],
-                          "newValues": ["2"]
                         },
                         {
                           "transactionType": "DEACTIVATION",
@@ -2235,7 +2224,7 @@ class LocationResourceIntTest : CommonDataTestBase() {
                         },
                         {
                           "attribute": "Working capacity",
-                          "oldValues": ["0"],
+                          "oldValues": ["2"],
                           "newValues": ["3"]
                         },
                         {
@@ -2276,11 +2265,6 @@ class LocationResourceIntTest : CommonDataTestBase() {
                           "attribute": "Status",
                           "oldValues": ["Inactive"],
                           "newValues": ["Active"]
-                        },
-                        {
-                          "attribute": "Working capacity",
-                          "oldValues": ["0"],
-                          "newValues": ["2"]
                         },
                        {
                           "attribute": "Deactivation reason",


### PR DESCRIPTION
Refactored the logic to calculate and refresh capacities, improved approval handling processes, and updated related tests for better accuracy and coverage. Changes include enhancements to `ApprovalRequestService`, adjustments in JPA entity mappings, and reintroduction of the `baselinePrison` method.