### PR TITLE
MAP-3185 Fix certification approval not raised when working capacity matches certificate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -769,10 +769,17 @@ class LocationService(
       throw PermanentlyDeactivatedUpdateNotAllowedException(locCapChange.getKey())
     }
 
-    val workingCapacityChange = locCapChange.calcWorkingCapacity() - workingCapacity
-    val maxCapacityChange = locCapChange.calcMaxCapacity() - maxCapacity
+    val certificateValue = cellCertificateRepository.findByPrisonIdAndPathHierarchy(locCapChange.prisonId, locCapChange.getPathHierarchy())
+
+    val workingCapacityChange = if (temporaryWorkingCapacityChange) {
+      locCapChange.calcWorkingCapacity() - workingCapacity
+    } else {
+      (certificateValue?.workingCapacity ?: locCapChange.calcWorkingCapacity()) - workingCapacity
+    }
+
+    val maxCapacityChange = (certificateValue?.maxCapacity ?: locCapChange.calcMaxCapacity()) - maxCapacity
     val cna = certifiedNormalAccommodation ?: locCapChange.calcCertifiedNormalAccommodation()
-    val cnaChange = locCapChange.calcCertifiedNormalAccommodation() - cna
+    val cnaChange = (certificateValue?.certifiedNormalAccommodation ?: locCapChange.calcCertifiedNormalAccommodation()) - cna
 
     val prisonRequiresApprovalForChanges = activePrisonService.isCertificationApprovalRequired(locCapChange.prisonId)
     val capacityChangesRequested = workingCapacityChange != 0 || maxCapacityChange != 0 || cnaChange != 0
@@ -782,7 +789,8 @@ class LocationService(
     var trackingTx = linkedTransaction
 
     if (capacityChangesRequested) {
-      val wcTempChangeAllowed = prisonRequiresApprovalForChanges && temporaryWorkingCapacityChange && workingCapacityChange != 0 && maxCapacityChange == 0 && cnaChange == 0
+      val wcTempChangeAllowed =
+        prisonRequiresApprovalForChanges && temporaryWorkingCapacityChange && workingCapacityChange != 0 && maxCapacityChange == 0 && cnaChange == 0
       val changeMustBeApproved = prisonRequiresApprovalForChanges && !wcTempChangeAllowed && !locCapChange.isDraft()
 
       if (!locCapChange.isDraft() && maxCapacityChange != 0) {
@@ -825,14 +833,15 @@ class LocationService(
             newCna = cna,
           )
           approvalRequest.locations.forEach { subLocation ->
-            cellCertificateRepository.findByPrisonIdAndPathHierarchy(locCapChange.prisonId, subLocation.pathHierarchy)?.let { currentCellCert ->
-              subLocation.currentWorkingCapacity = currentCellCert.workingCapacity
-              subLocation.currentMaxCapacity = currentCellCert.maxCapacity
-              subLocation.currentCertifiedNormalAccommodation = currentCellCert.certifiedNormalAccommodation
-              subLocation.workingCapacity = workingCapacity
-              subLocation.maxCapacity = maxCapacity
-              subLocation.certifiedNormalAccommodation = cna
-            }
+            cellCertificateRepository.findByPrisonIdAndPathHierarchy(locCapChange.prisonId, subLocation.pathHierarchy)
+              ?.let { currentCellCert ->
+                subLocation.currentWorkingCapacity = currentCellCert.workingCapacity
+                subLocation.currentMaxCapacity = currentCellCert.maxCapacity
+                subLocation.currentCertifiedNormalAccommodation = currentCellCert.certifiedNormalAccommodation
+                subLocation.workingCapacity = workingCapacity
+                subLocation.maxCapacity = maxCapacity
+                subLocation.certifiedNormalAccommodation = cna
+              }
           }
           approvalRequest.refreshCapacities()
           cellLocationRepository.saveAndFlush(locCapChange)
@@ -862,6 +871,8 @@ class LocationService(
         )
       }
       locationUpdated = locCapChange.toDto(includeParent = !locCapChange.isDraft(), includeNonResidential = false)
+    } else {
+      log.warn("No capacity changes requested for location [${locCapChange.getKey()}]")
     }
     return Pair(locationUpdated, approvalRequestDto).also {
       trackingTx?.txEndTime = now(clock)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -344,16 +344,29 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
     }
 
     @Test
-    fun `can change just working capacity a location and not required request approval`() {
-      // will return a prisoner for each location under the Leeds wing
-      leedsWing.findAllLeafLocations().forEach {
-        prisonerSearchMockServer.stubSearchByLocations(
-          leedsWing.prisonId,
-          listOf(it.getPathHierarchy()),
-          true,
-        )
-      }
-      val firstCell = leedsWing.findAllLeafLocations().first()
+    fun `can change just working capacity a location and not require a request approval`() {
+      val firstCell = temporaryUpdateWorkingCapacity()
+
+      val capacityChangedLocation = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(capacityChangedLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
+      assertThat(capacityChangedLocation.pendingApprovalRequestId).isNull()
+      assertThat(capacityChangedLocation.capacity?.maxCapacity).isEqualTo(2)
+      assertThat(capacityChangedLocation.capacity?.workingCapacity).isEqualTo(2)
+      assertThat(capacityChangedLocation.currentCellCertificate).isNotNull
+      assertThat(capacityChangedLocation.currentCellCertificate!!.workingCapacity).isEqualTo(1)
+    }
+
+    @Test
+    fun `can change a working capacity to match a capacity on a certificate`() {
+      val firstCell = temporaryUpdateWorkingCapacity()
+      // Now reflect on the cert the same values
       webTestClient.put().uri("/locations/${firstCell.id}/capacity")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
@@ -363,7 +376,6 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
               workingCapacity = 2,
               maxCapacity = 2,
               certifiedNormalAccommodation = 1,
-              temporaryWorkingCapacityChange = true,
             ),
           ),
         )
@@ -382,10 +394,63 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
                   "workingCapacity": 2,
                   "certifiedNormalAccommodation": 1
                 },
+                "pendingChanges": {
+                  "maxCapacity": 2,
+                  "workingCapacity": 2,
+                  "certifiedNormalAccommodation": 1
+                },
                 "active": true,
                 "key": "${firstCell.getKey()}"
               }
           """,
+          JsonCompareMode.LENIENT,
+        )
+
+      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
+    }
+
+    private fun temporaryUpdateWorkingCapacity(workingCapacity: Int = 2): uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location {
+      // will return a prisoner for each location under the Leeds wing
+      leedsWing.findAllLeafLocations().forEach {
+        prisonerSearchMockServer.stubSearchByLocations(
+          leedsWing.prisonId,
+          listOf(it.getPathHierarchy()),
+          true,
+        )
+      }
+      val firstCell = leedsWing.findAllLeafLocations().first()
+      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            CapacityChangeRequest(
+              workingCapacity = workingCapacity,
+              maxCapacity = 2,
+              certifiedNormalAccommodation = 1,
+              temporaryWorkingCapacityChange = true,
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          // language=json
+          """
+                  {
+                    "id": "${firstCell.id}",
+                    "prisonId": "${firstCell.prisonId}",
+                    "pathHierarchy": "${firstCell.getPathHierarchy()}",
+                    "locationType": "CELL",
+                    "capacity": {
+                      "maxCapacity": 2,
+                      "workingCapacity": 2,
+                      "certifiedNormalAccommodation": 1
+                    },
+                    "active": true,
+                    "key": "${firstCell.getKey()}"
+                  }
+              """,
           JsonCompareMode.LENIENT,
         )
 
@@ -396,21 +461,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
           "location.inside.prison.amended" to firstCell.getParent()?.getParent()?.getKey(),
         )
       }
-
-      val capacityChangedLocation = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!
-
-      assertThat(capacityChangedLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
-      assertThat(capacityChangedLocation.pendingApprovalRequestId).isNull()
-      assertThat(capacityChangedLocation.capacity?.maxCapacity).isEqualTo(2)
-      assertThat(capacityChangedLocation.capacity?.workingCapacity).isEqualTo(2)
-      assertThat(capacityChangedLocation.currentCellCertificate).isNotNull
-      assertThat(capacityChangedLocation.currentCellCertificate!!.workingCapacity).isEqualTo(1)
+      return firstCell
     }
   }
 


### PR DESCRIPTION
Summary
• Fix a bug where updating a cell's capacity to values matching an existing certificate incorrectly reported no capacity change, suppressing the approval request
• When computing capacity deltas, the service now compares against the current certificate values (not the incoming request values), so a change that brings the live location into alignment with a certificate is correctly detected as a change requiring approval
• maxCapacity and certifiedNormalAccommodation deltas are now always computed against the certificate (when one exists), not just the incoming values
• workingCapacity delta uses certificate values for non-temporary changes only, preserving existing behaviour for temporary w/c adjustments