### PR TITLE
MAP-3187 Fix cell reactivation skipped when reactivating a single cell

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestLocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestLocationDto.kt
@@ -69,6 +69,9 @@ data class CertificationApprovalRequestLocationDto(
   @param:Schema(description = "Converted cell type", example = "OFFICE", required = false)
   val convertedCellType: ConvertedCellType? = null,
 
+  @param:Schema(description = "Indicates this location will be reactivated", example = "true", required = false)
+  val reactivateThisLocation: Boolean? = null,
+
   @param:Schema(description = "Sub-locations", required = false)
   val subLocations: List<CertificationApprovalRequestLocationDto>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -252,6 +252,20 @@ abstract class Location(
     return parents
   }
 
+  fun findParentLocations(): List<Location> {
+    val parents = mutableListOf<Location>()
+
+    fun traverseUp(location: Location?) {
+      if (location != null) {
+        parents.add(location)
+        traverseUp(location.getParent())
+      }
+    }
+
+    traverseUp(this.getParent())
+    return parents
+  }
+
   protected fun getLevel(): Int {
     fun goUp(location: Location?, level: Int): Int {
       if (location == null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequestLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequestLocation.kt
@@ -66,7 +66,7 @@ open class CertificationApprovalRequestLocation(
 
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
-  private val locationType: LocationType,
+  val locationType: LocationType,
 
   open var currentSpecialistCellTypes: String? = null,
 
@@ -128,6 +128,7 @@ open class CertificationApprovalRequestLocation(
     accommodationTypes = getAccommodationTypesFromList(),
     usedFor = getUsedForTypesFromList(),
     convertedCellType = convertedCellType,
+    reactivateThisLocation = reactivateThisLocation,
     subLocations = subLocations.map { it.toDto() }.takeIf { it.isNotEmpty() },
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
@@ -7,8 +7,10 @@ import jakarta.xml.bind.ValidationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequestLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ReactivationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CertificationApprovalRequestRepository
@@ -122,16 +124,9 @@ class ApprovalRequestService(
 
     // Update the current capacities from the certificate if there is one.
     val locationHierarchy = approvalRequest.getTopLevelLocation() ?: throw LocationNotFoundException("No top level location")
+    updateApprovalLocationDetails(topLevelLocation.prisonId, locationHierarchy, true)
     locationHierarchy.findSubLocations().forEach { subLocation ->
-      cellCertificateRepository.findByPrisonIdAndPathHierarchy(topLevelLocation.prisonId, subLocation.pathHierarchy)?.let { currentCellCert ->
-        subLocation.currentWorkingCapacity = currentCellCert.workingCapacity
-        subLocation.currentMaxCapacity = currentCellCert.maxCapacity
-        subLocation.currentCertifiedNormalAccommodation = currentCellCert.certifiedNormalAccommodation
-        subLocation.currentSpecialistCellTypes = currentCellCert.specialistCellTypes
-      }
-      if (reactivationApprovalRequest.cascadeReactivation && subLocation.findSubLocations().isEmpty()) {
-        subLocation.reactivateThisLocation = true
-      }
+      updateApprovalLocationDetails(topLevelLocation.prisonId, subLocation, reactivationApprovalRequest.cascadeReactivation)
     }
 
     // Go through the cellReactivationChanges and update the certificationChanges to reflect the capacity and specialist cell types held in the cellReactivationChanges
@@ -147,16 +142,11 @@ class ApprovalRequestService(
         throw ValidationException("Location [${cellToUpdate.getKey()}] is not a child of location [${topLevelLocation.getKey()}]")
       }
 
+      if (locationHierarchy.pathHierarchy == cellToUpdate.getPathHierarchy()) {
+        updateLocationCapacitiesForApproval(locationHierarchy, details)
+      }
       locationHierarchy.findLocationByPathHierarchy(cellToUpdate.getPathHierarchy())?.let { approvalCell ->
-        approvalCell.reactivateThisLocation = true
-        details.capacity?.let {
-          approvalCell.workingCapacity = it.workingCapacity
-          approvalCell.maxCapacity = it.maxCapacity
-          approvalCell.certifiedNormalAccommodation = it.certifiedNormalAccommodation
-        }
-        details.specialistCellTypes?.let {
-          approvalCell.specialistCellTypes = if (it.isNotEmpty()) details.getSpecialistCellTypesAsCSV() else ""
-        }
+        updateLocationCapacitiesForApproval(approvalCell, details)
       }
     }
 
@@ -176,6 +166,38 @@ class ApprovalRequestService(
     log.info("Reactivation approval requested (${approvalRequest.id}) for location ${topLevelLocation.getKey()} by ${linkedTransaction.transactionInvokedBy}")
     return approvalRequest.toDto(showLocations = true).also {
       linkedTransaction.txEndTime = now(clock)
+    }
+  }
+
+  private fun updateLocationCapacitiesForApproval(
+    approvalRequestLocation: CertificationApprovalRequestLocation,
+    reactivationDetails: CellReactivationDetail,
+  ) {
+    approvalRequestLocation.reactivateThisLocation = true
+    reactivationDetails.capacity?.let {
+      approvalRequestLocation.workingCapacity = it.workingCapacity
+      approvalRequestLocation.maxCapacity = it.maxCapacity
+      approvalRequestLocation.certifiedNormalAccommodation = it.certifiedNormalAccommodation
+    }
+    reactivationDetails.specialistCellTypes?.let {
+      approvalRequestLocation.specialistCellTypes = if (it.isNotEmpty()) reactivationDetails.getSpecialistCellTypesAsCSV() else ""
+    }
+  }
+
+  private fun updateApprovalLocationDetails(
+    prisonId: String,
+    approvalRequestLocation: CertificationApprovalRequestLocation,
+    cascadeReactivation: Boolean,
+  ) {
+    cellCertificateRepository.findByPrisonIdAndPathHierarchy(prisonId, approvalRequestLocation.pathHierarchy)
+      ?.let { currentCellCert ->
+        approvalRequestLocation.currentWorkingCapacity = currentCellCert.workingCapacity
+        approvalRequestLocation.currentMaxCapacity = currentCellCert.maxCapacity
+        approvalRequestLocation.currentCertifiedNormalAccommodation = currentCellCert.certifiedNormalAccommodation
+        approvalRequestLocation.currentSpecialistCellTypes = currentCellCert.specialistCellTypes
+      }
+    if (cascadeReactivation && approvalRequestLocation.locationType == LocationType.CELL) {
+      approvalRequestLocation.reactivateThisLocation = true
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SharedLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/SharedLocationService.kt
@@ -2,7 +2,8 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.service
 
 import com.microsoft.applicationinsights.TelemetryClient
 import jakarta.validation.ValidationException
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.locationsinsideprison.SYSTEM_USERNAME
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PatchLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
@@ -23,7 +24,8 @@ import java.time.LocalDateTime
 import kotlin.jvm.optionals.getOrNull
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Location as LocationDTO
 
-@Component
+@Service
+@Transactional
 class SharedLocationService(
   private val locationRepository: LocationRepository,
   private val linkedTransactionRepository: LinkedTransactionRepository,
@@ -162,6 +164,8 @@ class SharedLocationService(
         )
       }
     }
+
+    locationRepository.saveAll(locationsReactivated)
   }
 
   fun checkParentValid(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonData
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.EXPECTED_USERNAME
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalType
@@ -154,8 +155,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       getDomainEvents(3).let {
         assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
           "location.inside.prison.amended" to firstCell.getKey(),
-          "location.inside.prison.amended" to firstCell.getParent()?.getKey(),
-          "location.inside.prison.amended" to firstCell.getParent()?.getParent()?.getKey(),
+          *firstCell.getParentLocations().map { "location.inside.prison.amended" to it.getKey() }.toTypedArray(),
         )
       }
 
@@ -457,8 +457,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       getDomainEvents(3).let {
         assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
           "location.inside.prison.amended" to firstCell.getKey(),
-          "location.inside.prison.amended" to firstCell.getParent()?.getKey(),
-          "location.inside.prison.amended" to firstCell.getParent()?.getParent()?.getKey(),
+          *firstCell.getParentLocations().map { "location.inside.prison.amended" to it.getKey() }.toTypedArray(),
         )
       }
       return firstCell
@@ -546,7 +545,122 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
     }
 
     @Test
-    fun `can deactivate a location and request approval`() {
+    fun `can deactivate a cell and request approval`() {
+      val firstCell = leedsWing.findAllLeafLocations().first() as Cell
+      val reasonForChange = "The cell has been flooded"
+      deactivateLocation(firstCell, true, reasonForChange)
+
+      val deactivatedLocation = webTestClient.get().uri("/locations/${firstCell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(deactivatedLocation.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
+      assertThat(deactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
+      assertThat(deactivatedLocation.pendingApprovalRequestId).isNotNull
+      assertThat(deactivatedLocation.lastDeactivationReasonForChange).isEqualTo(reasonForChange)
+
+      val firstApprovedDeactivatedCell = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(firstApprovedDeactivatedCell.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
+
+      val pendingApprovalRequestId = deactivatedLocation.pendingApprovalRequestId!!
+
+      val parentResults = firstCell.getParentLocations().associate {
+        it.getKey() to "location.inside.prison.amended"
+      }
+      val results = mapOf(firstCell.getKey() to "location.inside.prison.deactivated") + parentResults
+
+      getDomainEvents(results.size).let { messages ->
+        assertThat(messages.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
+          *results.map { it.value to it.key }.toTypedArray(),
+        )
+      }
+
+      val pendingApproval = webTestClient.get().uri("/certification/request-approvals/$pendingApprovalRequestId")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(pendingApproval.approvalType).isEqualTo(ApprovalType.DEACTIVATION)
+      assertThat(pendingApproval.locationId).isEqualTo(firstCell.id)
+      assertThat(pendingApproval.prisonId).isEqualTo(firstCell.prisonId)
+      assertThat(pendingApproval.locationKey).isEqualTo(firstCell.getKey())
+      assertThat(pendingApproval.workingCapacityChange).isEqualTo(-1)
+      assertThat(pendingApproval.certifiedNormalAccommodationChange).isEqualTo(0)
+      assertThat(pendingApproval.maxCapacityChange).isEqualTo(0)
+      assertThat(pendingApproval.reasonForChange).isEqualTo(reasonForChange)
+      assertThat(pendingApproval.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
+      assertThat(pendingApproval.locations).hasSize(1)
+      assertThat(pendingApproval.locations!![0].subLocations).isNull()
+
+      val approvedRequest = webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            ApproveCertificationRequestDto(
+              approvalRequestReference = pendingApprovalRequestId,
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      webTestClient.get().uri("/cell-certificates/${approvedRequest.certificateId}")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.id").isEqualTo(approvedRequest.certificateId)
+        .jsonPath("$.prisonId").isEqualTo(firstCell.prisonId)
+        .jsonPath("$.current").isEqualTo(true)
+        .jsonPath("$.locations").isArray()
+        .jsonPath("$.totalMaxCapacity").isEqualTo(12)
+        .jsonPath("$.totalWorkingCapacity").isEqualTo(5)
+        .jsonPath("$.totalCertifiedNormalAccommodation").isEqualTo(6)
+        // Verify that there are locations in the response
+        .jsonPath("$.locations.length()").isEqualTo(1)
+        .jsonPath("$.locations[0].workingCapacity").isEqualTo(5)
+        .jsonPath("$.locations[0].subLocations.length()").isEqualTo(2)
+        .jsonPath("$.locations[0].subLocations[0].subLocations.length()").isEqualTo(3)
+        .jsonPath("$.locations[0].subLocations[1].subLocations.length()").isEqualTo(3)
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].workingCapacity").isEqualTo(0)
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].maxCapacity").isEqualTo(2)
+        .jsonPath("$.locations[0].subLocations[1].subLocations[0].workingCapacity").isEqualTo(1)
+        .jsonPath("$.locations[0].subLocations[1].subLocations[0].maxCapacity").isEqualTo(2)
+
+      val approvedDeactivatedCell = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(approvedDeactivatedCell.status).isEqualTo(DerivedLocationStatus.INACTIVE)
+      assertThat(approvedDeactivatedCell.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
+      assertThat(approvedDeactivatedCell.pendingApprovalRequestId).isNull()
+      assertThat(approvedDeactivatedCell.currentCellCertificate).isNotNull
+      assertThat(approvedDeactivatedCell.currentCellCertificate!!.workingCapacity).isEqualTo(0)
+      assertThat(approvedDeactivatedCell.lastDeactivationReasonForChange).isEqualTo(reasonForChange)
+    }
+
+    @Test
+    fun `can deactivate a wing and sublocations and request approval`() {
       val now = LocalDateTime.now(clock)
       val proposedReactivationDate = now.plusMonths(1).toLocalDate()
       prisonerSearchMockServer.stubSearchByLocations(
@@ -792,8 +906,137 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
   inner class ReactivateLocationTest {
 
     @Test
-    fun `can request to reactivate a location with cascade and then approve`() {
-      deactivateOffCert()
+    fun `can request to reactivate a cell and then approve`() {
+      val firstCell = leedsWing.findAllLeafLocations().first() as Cell
+      deactivateLocation(firstCell, reasonForChange = "The wing has been flooded")
+      webTestClient.put().uri("/certification/location/reactivation-request-approval")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            ReactivationLocationsApprovalRequest(
+              topLevelLocationId = firstCell.id!!,
+              cellReactivationChanges = mapOf(
+                firstCell.id!! to CellReactivationDetail(
+                  capacity = Capacity(
+                    workingCapacity = 1,
+                    maxCapacity = 2,
+                    certifiedNormalAccommodation = 1,
+                  ),
+                  specialistCellTypes = setOf(SpecialistCellType.SAFE_CELL, SpecialistCellType.CONSTANT_SUPERVISION),
+                ),
+              ),
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+
+      val pendingReactivationLocation = webTestClient.get().uri("/locations/${firstCell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(pendingReactivationLocation.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
+      val pendingApprovalRequestId = pendingReactivationLocation.pendingApprovalRequestId!!
+
+      val pendingApproval = webTestClient.get().uri("/certification/request-approvals/$pendingApprovalRequestId")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(pendingApproval.approvalType).isEqualTo(ApprovalType.REACTIVATION)
+      assertThat(pendingApproval.locationId).isEqualTo(firstCell.id)
+      assertThat(pendingApproval.prisonId).isEqualTo(firstCell.prisonId)
+      assertThat(pendingApproval.locationKey).isEqualTo(firstCell.getKey())
+      assertThat(pendingApproval.workingCapacityChange).isEqualTo(0)
+      assertThat(pendingApproval.certifiedNormalAccommodationChange).isEqualTo(0)
+      assertThat(pendingApproval.maxCapacityChange).isEqualTo(0)
+      assertThat(pendingApproval.locations).hasSize(1)
+      assertThat(pendingApproval.locations!![0].subLocations).isNull()
+      assertThat(pendingApproval.locations[0].currentWorkingCapacity).isEqualTo(1)
+      assertThat(pendingApproval.locations[0].currentMaxCapacity).isEqualTo(2)
+      assertThat(pendingApproval.locations[0].currentCertifiedNormalAccommodation).isEqualTo(1)
+      assertThat(pendingApproval.locations[0].workingCapacity).isEqualTo(1)
+      assertThat(pendingApproval.locations[0].maxCapacity).isEqualTo(2)
+      assertThat(pendingApproval.locations[0].certifiedNormalAccommodation).isEqualTo(1)
+      assertThat(pendingApproval.locations[0].currentSpecialistCellTypes).containsExactlyInAnyOrder(
+        SpecialistCellType.ESCAPE_LIST,
+      )
+      assertThat(pendingApproval.locations[0].specialistCellTypes).containsExactlyInAnyOrder(
+        SpecialistCellType.SAFE_CELL,
+        SpecialistCellType.CONSTANT_SUPERVISION,
+      )
+
+      val approvedRequest = webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            ApproveCertificationRequestDto(
+              approvalRequestReference = pendingApprovalRequestId,
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      val parentResults = firstCell.getParentLocations().plus(firstCell).associate {
+        it.getKey() to "location.inside.prison.amended"
+      }
+      val results = mapOf(firstCell.getKey() to "location.inside.prison.reactivated") + parentResults
+
+      getDomainEvents(results.size).let { messages ->
+        assertThat(messages.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
+          *results.map { it.value to it.key }.toTypedArray(),
+        )
+      }
+
+      webTestClient.get().uri("/cell-certificates/${approvedRequest.certificateId}")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.id").isEqualTo(approvedRequest.certificateId)
+        .jsonPath("$.prisonId").isEqualTo("LEI")
+        .jsonPath("$.current").isEqualTo(true)
+        .jsonPath("$.locations").isArray()
+        .jsonPath("$.totalMaxCapacity").isEqualTo(12)
+        .jsonPath("$.totalWorkingCapacity").isEqualTo(6)
+        .jsonPath("$.totalCertifiedNormalAccommodation").isEqualTo(6)
+        // Verify that there are locations in the response
+        .jsonPath("$.locations.length()").isEqualTo(1)
+        .jsonPath("$.locations[0].workingCapacity").isEqualTo(6)
+        .jsonPath("$.locations[0].subLocations.length()").isEqualTo(2)
+        .jsonPath("$.locations[0].subLocations[0].subLocations.length()").isEqualTo(3)
+        .jsonPath("$.locations[0].subLocations[1].subLocations.length()").isEqualTo(3)
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].workingCapacity").isEqualTo(1)
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].maxCapacity").isEqualTo(2)
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].specialistCellTypes").isEqualTo(listOf("CONSTANT_SUPERVISION", "SAFE_CELL"))
+
+      val reactivatedLocation = webTestClient.get().uri("/locations/key/${firstCell.getKey()}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(reactivatedLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
+      assertThat(reactivatedLocation.pendingChanges).isNull()
+      assertThat(reactivatedLocation.pendingApprovalRequestId).isNull()
+    }
+
+    @Test
+    fun `can request to reactivate a wing with cascade and then approve`() {
+      deactivateLocation(leedsWing, reasonForChange = "The wing has been flooded")
       webTestClient.put().uri("/certification/location/reactivation-request-approval")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
@@ -897,8 +1140,8 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
     }
 
     @Test
-    fun `can request to reactivate a locations explicitly and then approve`() {
-      deactivateOffCert()
+    fun `can request to reactivate a wing explicitly and then approve`() {
+      deactivateLocation(leedsWing, reasonForChange = "The wing has been flooded")
       webTestClient.put().uri("/certification/location/reactivation-request-approval")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
@@ -925,6 +1168,18 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         )
         .exchange()
         .expectStatus().isOk
+
+      val deactivatedCell = webTestClient.get().uri("/locations/key/LEI-A-1-001")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(deactivatedCell.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
+      assertThat(deactivatedCell.pendingChanges).isNotNull()
+      assertThat(deactivatedCell.pendingApprovalRequestId).isNotNull()
 
       val pendingReactivationLocation = webTestClient.get().uri("/locations/${leedsWing.id}")
         .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
@@ -1022,11 +1277,23 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         .jsonPath("$.locations[0].subLocations[1].subLocations[0].maxCapacity").isEqualTo(2)
         .jsonPath("$.locations[0].subLocations[1].subLocations[0].certifiedNormalAccommodation").isEqualTo(2)
         .jsonPath("$.locations[0].subLocations[1].subLocations[0].specialistCellTypes").isEqualTo(listOf("CONSTANT_SUPERVISION", "SAFE_CELL"))
+
+      val reactivatedLocation = webTestClient.get().uri("/locations/key/LEI-A-1-001")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(reactivatedLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
+      assertThat(reactivatedLocation.pendingChanges).isNull()
+      assertThat(reactivatedLocation.pendingApprovalRequestId).isNull()
     }
 
     @Test
     fun `can request to reactivate a locations explicitly and then reject`() {
-      deactivateOffCert()
+      deactivateLocation(leedsWing, reasonForChange = "The wing has been flooded")
       webTestClient.put().uri("/certification/location/reactivation-request-approval")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
@@ -1090,38 +1357,6 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(rejectedDeactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
       assertThat(rejectedDeactivatedLocation.pendingApprovalRequestId).isNull()
       assertThat(rejectedDeactivatedLocation.lastDeactivationReasonForChange).isNull()
-    }
-
-    private fun deactivateOffCert() {
-      val now = LocalDateTime.now(clock)
-      val proposedReactivationDate = now.plusMonths(1).toLocalDate()
-      prisonerSearchMockServer.stubSearchByLocations(
-        leedsWing.prisonId,
-        leedsWing.findAllLeafLocations().map { it.getPathHierarchy() },
-        false,
-      )
-
-      webTestClient.put().uri("/locations/${leedsWing.id}/deactivate/temporary")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
-        .header("Content-Type", "application/json")
-        .bodyValue(
-          jsonString(
-            TemporaryDeactivationLocationRequest(
-              reasonForChange = "The wing has been flooded",
-              deactivationReason = DeactivatedReason.MOTHBALLED,
-              proposedReactivationDate = proposedReactivationDate,
-              planetFmReference = "11111",
-            ),
-          ),
-        )
-        .exchange()
-        .expectStatus().isOk
-      val deactivatedLocations = leedsWing.findSubLocations().map { it.getKey() }.plus(leedsWing.getKey())
-      getDomainEvents(deactivatedLocations.size).let { messages ->
-        assertThat(messages.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
-          *deactivatedLocations.map { "location.inside.prison.deactivated" to it }.toTypedArray(),
-        )
-      }
     }
   }
 
@@ -1454,6 +1689,48 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(rejectedLocation.inCellSanitation).isEqualTo(true)
       assertThat(rejectedLocation.pendingChanges).isNull()
       assertThat(rejectedLocation.pendingApprovalRequestId).isNull()
+    }
+  }
+
+  private fun deactivateLocation(
+    location: ResidentialLocation,
+    requiresApproval: Boolean = false,
+    reasonForChange: String,
+  ) {
+    val now = LocalDateTime.now(clock)
+    val proposedReactivationDate = now.plusMonths(1).toLocalDate()
+    prisonerSearchMockServer.stubSearchByLocations(
+      location.prisonId,
+      location.findAllLeafLocations().map { it.getPathHierarchy() },
+      false,
+    )
+
+    webTestClient.put().uri("/locations/${location.id}/deactivate/temporary")
+      .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        jsonString(
+          TemporaryDeactivationLocationRequest(
+            requiresApproval = requiresApproval,
+            reasonForChange = reasonForChange,
+            deactivationReason = DeactivatedReason.MOTHBALLED,
+            proposedReactivationDate = proposedReactivationDate,
+            planetFmReference = "11111",
+          ),
+        ),
+      )
+      .exchange()
+      .expectStatus().isOk
+
+    if (!requiresApproval) {
+      val expectedEvents = (listOf(location) + location.findSubLocations())
+        .map { "location.inside.prison.deactivated" to it.getKey() } +
+        location.findParentLocations().map { "location.inside.prison.amended" to it.getKey() }
+
+      getDomainEvents(expectedEvents.size).let { messages ->
+        assertThat(messages.map { it.eventType to it.additionalInformation?.key })
+          .containsExactlyInAnyOrder(*expectedEvents.toTypedArray())
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fixed a bug where reactivating a single cell (rather than a wing or landing with sub-locations) would silently skip the reactivation — the approval location was never marked for reactivation because the existing logic only iterated over `subLocations`, which is empty for a leaf cell
- The top-level approval location is now processed directly before iterating sub-locations, ensuring a single-cell approval request correctly marks the cell for reactivation and updates its capacity details
- Fixed a related issue where `cellReactivationChanges` referencing the top-level location itself was not handled, only child locations were looked up
- Added `locationRepository.saveAll()` in `SharedLocationService` to ensure reactivated locations are persisted; also annotated the class with `@Transactional`
- Exposed `reactivateThisLocation` in `CertificationApprovalRequestLocationDto` so the flag is visible in the API response
- Extracted `updateLocationCapacitiesForApproval` and `updateApprovalLocationDetails` helpers in `ApprovalRequestService` to eliminate duplication and consistently handle both top-level and sub-locations

## Test plan

- [ ] New integration test `can request to reactivate a cell and then approve` covers the single-cell reactivation path end-to-end, verifying the approval request, approval, certificate state, and domain events
- [ ] New integration test `can deactivate a cell and request approval` covers single-cell deactivation with approval
- [ ] Existing wing-level cascade and explicit reactivation tests renamed and updated to use the new shared `deactivateLocation` helper, confirming no regression
