### PR TITLE
MAP-3188 Add `inactiveStatus` to support inactive cells screen categorisation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -133,6 +133,9 @@ data class Location(
   @param:Schema(description = "Indicates the location is enabled", example = "true", required = true, deprecated = true)
   val active: Boolean = true,
 
+  @param:Schema(description = "If this location is inactive, indicates the type of inactive status", example = "true", required = true, deprecated = true)
+  val inactiveStatus: InactiveStatus? = null,
+
   @param:Schema(description = "In-cell sanitation", required = false, example = "true")
   val inCellSanitation: Boolean? = null,
 
@@ -259,6 +262,14 @@ data class Location(
     result = 31 * result + pathHierarchy.hashCode()
     return result
   }
+}
+
+enum class InactiveStatus(
+  val description: String,
+) {
+  INACTIVE_TEMP("Temporary inactive cell"),
+  INACTIVE_PEND_CHANGE_REQ("Inactive cell with certificate change requests"),
+  INACTIVE_MATCHING_CELL_CERT("Inactive cell with capacity decreased on cell certificate"),
 }
 
 @Schema(description = "Pending changes")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.OneToMany
 import org.hibernate.annotations.SortNatural
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Certification
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.DerivedLocationStatus
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.InactiveStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LegacyLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.NomisSyncLocationRequest
@@ -679,6 +680,16 @@ class Cell(
     ) as SanitationChangeApprovalRequest
   }
 
+  private fun deriveInactiveStatus(cellCertificateLocation: CellCertificateLocation): InactiveStatus {
+    if (hasPendingCertificationApproval()) {
+      return InactiveStatus.INACTIVE_PEND_CHANGE_REQ
+    }
+    if (cellCertificateLocation.workingCapacity == calcWorkingCapacity()) {
+      return InactiveStatus.INACTIVE_MATCHING_CELL_CERT
+    }
+    return InactiveStatus.INACTIVE_TEMP
+  }
+
   override fun toDto(
     includeChildren: Boolean,
     includeParent: Boolean,
@@ -720,6 +731,7 @@ class Cell(
     otherConvertedCellType = otherConvertedCellType,
     inCellSanitation = getSanitationOfCell(false),
     cellMark = getDoorCellMark(false),
+    inactiveStatus = cellCertificateLocation?.let { deriveInactiveStatus(it) },
   )
 
   override fun toLegacyDto(includeHistory: Boolean): LegacyLocation = super.toLegacyDto(includeHistory = includeHistory).copy(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -997,8 +997,9 @@ class LocationService(
       transactionInvokedBy = transactionInvokedBy,
     )
 
+    val certificationApprovalRequired = activePrisonService.isCertificationApprovalRequired(prisonId)
     val approvalRequired =
-      locationsToDeactivate.requiresApproval && activePrisonService.isCertificationApprovalRequired(prisonId)
+      locationsToDeactivate.requiresApproval && certificationApprovalRequired
     locationsToDeactivate.locations.forEach { (id, deactivationDetail) ->
       val locationToDeactivate = locationRepository.findById(id)
         .orElseThrow { LocationNotFoundException(id.toString()) }
@@ -1063,7 +1064,11 @@ class LocationService(
     }
 
     locationRepository.saveAllAndFlush(deactivatedLocations)
-    val deactivatedLocationsDto = deactivatedLocations.map { it.toDto() }.toSet()
+    val deactivatedLocationsDto = deactivatedLocations.map {
+      it.toDto(
+        cellCertificateLocation = cellCertificateRepository.findByPrisonIdAndPathHierarchy(it.prisonId, it.getPathHierarchy()).takeIf { certificationApprovalRequired },
+      )
+    }.toSet()
     return mapOf(
       InternalLocationDomainEventType.LOCATION_AMENDED to deactivatedLocations.flatMap { deactivatedLoc ->
         deactivatedLoc.getParentLocations().map { it.toDto() }
@@ -1595,6 +1600,8 @@ class LocationService(
     .sortedWith(NaturalOrderComparator())
 
   fun getResidentialInactiveLocations(prisonId: String, parentLocationId: UUID?): List<LocationDTO> {
+    val certificationApprovalRequired = activePrisonService.isCertificationApprovalRequired(prisonId)
+
     val startLocation = parentLocationId?.let {
       residentialLocationRepository.findById(parentLocationId).getOrNull() ?: throw LocationNotFoundException(
         parentLocationId.toString(),
@@ -1608,7 +1615,15 @@ class LocationService(
       )
       )
       .filter { it.isTemporarilyDeactivated() }
-      .map { it.toDto() }
+      .map {
+        it.toDto(
+          cellCertificateLocation = if (certificationApprovalRequired) {
+            cellCertificateRepository.findByPrisonIdAndPathHierarchy(it.prisonId, it.getPathHierarchy())
+          } else {
+            null
+          },
+        )
+      }
       .sortedWith(NaturalOrderComparator())
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellMarkChangeRequ
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellSanitationChangeRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.DerivedLocationStatus
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.InactiveStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.RejectCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.TemporaryDeactivationLocationRequest
@@ -542,6 +543,23 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       // Even though one cell was already inactive, the workingCapacityChange should still be -6
       // because we're reporting the total change from the current working capacity from the certificate
       assertThat(pendingApproval.workingCapacityChange).isEqualTo(-6)
+
+      val inactiveCells = webTestClient.get().uri("/locations/prison/${leedsWing.prisonId}/inactive-cells")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<List<Location>>()
+        .returnResult().responseBody!!
+
+      assertThat(inactiveCells).hasSize(6)
+      assertThat(inactiveCells.map { it.getKey() to it.inactiveStatus }).containsExactlyInAnyOrder(
+        "LEI-A-1-001" to InactiveStatus.INACTIVE_PEND_CHANGE_REQ,
+        "LEI-A-1-002" to InactiveStatus.INACTIVE_PEND_CHANGE_REQ,
+        "LEI-A-1-003" to InactiveStatus.INACTIVE_PEND_CHANGE_REQ,
+        "LEI-A-2-001" to InactiveStatus.INACTIVE_PEND_CHANGE_REQ,
+        "LEI-A-2-002" to InactiveStatus.INACTIVE_PEND_CHANGE_REQ,
+        "LEI-A-2-003" to InactiveStatus.INACTIVE_PEND_CHANGE_REQ,
+      )
     }
 
     @Test
@@ -550,7 +568,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       val reasonForChange = "The cell has been flooded"
       deactivateLocation(firstCell, true, reasonForChange)
 
-      val deactivatedLocation = webTestClient.get().uri("/locations/${firstCell.id}")
+      val deactivatedLocation = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
         .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
         .header("Content-Type", "application/json")
         .exchange()
@@ -562,16 +580,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(deactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
       assertThat(deactivatedLocation.pendingApprovalRequestId).isNotNull
       assertThat(deactivatedLocation.lastDeactivationReasonForChange).isEqualTo(reasonForChange)
-
-      val firstApprovedDeactivatedCell = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!
-
-      assertThat(firstApprovedDeactivatedCell.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
+      assertThat(deactivatedLocation.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_PEND_CHANGE_REQ)
 
       val pendingApprovalRequestId = deactivatedLocation.pendingApprovalRequestId!!
 
@@ -657,34 +666,23 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(approvedDeactivatedCell.currentCellCertificate).isNotNull
       assertThat(approvedDeactivatedCell.currentCellCertificate!!.workingCapacity).isEqualTo(0)
       assertThat(approvedDeactivatedCell.lastDeactivationReasonForChange).isEqualTo(reasonForChange)
+      assertThat(approvedDeactivatedCell.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_MATCHING_CELL_CERT)
+
+      val inactiveCells = webTestClient.get().uri("/locations/prison/${leedsWing.prisonId}/inactive-cells")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<List<Location>>()
+        .returnResult().responseBody!!
+
+      assertThat(inactiveCells).hasSize(1)
+      assertThat(inactiveCells.map { it.inactiveStatus }).containsExactlyInAnyOrder(InactiveStatus.INACTIVE_MATCHING_CELL_CERT)
     }
 
     @Test
     fun `can deactivate a wing and sublocations and request approval`() {
       val now = LocalDateTime.now(clock)
-      val proposedReactivationDate = now.plusMonths(1).toLocalDate()
-      prisonerSearchMockServer.stubSearchByLocations(
-        leedsWing.prisonId,
-        leedsWing.findAllLeafLocations().map { it.getPathHierarchy() },
-        false,
-      )
-
-      webTestClient.put().uri("/locations/${leedsWing.id}/deactivate/temporary")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
-        .header("Content-Type", "application/json")
-        .bodyValue(
-          jsonString(
-            TemporaryDeactivationLocationRequest(
-              requiresApproval = true,
-              reasonForChange = "The cell as been flooded",
-              deactivationReason = DeactivatedReason.MOTHBALLED,
-              proposedReactivationDate = proposedReactivationDate,
-              planetFmReference = "222333",
-            ),
-          ),
-        )
-        .exchange()
-        .expectStatus().isOk
+      deactivateLocation(leedsWing, true, reasonForChange = "The wing is being renovated")
 
       val deactivatedLocation = webTestClient.get().uri("/locations/${leedsWing.id}")
         .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
@@ -696,9 +694,8 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
       assertThat(deactivatedLocation.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
       assertThat(deactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
-      assertThat(deactivatedLocation.proposedReactivationDate).isEqualTo(proposedReactivationDate)
       assertThat(deactivatedLocation.pendingApprovalRequestId).isNotNull
-      assertThat(deactivatedLocation.lastDeactivationReasonForChange).isEqualTo("The cell as been flooded")
+      assertThat(deactivatedLocation.lastDeactivationReasonForChange).isEqualTo("The wing is being renovated")
 
       val firstCell = leedsWing.findAllLeafLocations().first()
       val firstApprovedDeactivatedCell = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
@@ -710,6 +707,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         .returnResult().responseBody!!
 
       assertThat(firstApprovedDeactivatedCell.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
+      assertThat(firstApprovedDeactivatedCell.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_PEND_CHANGE_REQ)
 
       val pendingApprovalRequestId = deactivatedLocation.pendingApprovalRequestId!!
 
@@ -734,9 +732,8 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.workingCapacityChange).isEqualTo(-6)
       assertThat(pendingApproval.certifiedNormalAccommodationChange).isEqualTo(0)
       assertThat(pendingApproval.maxCapacityChange).isEqualTo(0)
-      assertThat(pendingApproval.reasonForChange).isEqualTo("The cell as been flooded")
+      assertThat(pendingApproval.reasonForChange).isEqualTo("The wing is being renovated")
       assertThat(pendingApproval.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
-      assertThat(pendingApproval.proposedReactivationDate).isEqualTo(proposedReactivationDate)
       assertThat(pendingApproval.locations).hasSize(1)
       assertThat(pendingApproval.locations!![0].subLocations).hasSize(2)
       assertThat(pendingApproval.locations[0].subLocations!![0].currentWorkingCapacity).isEqualTo(3)
@@ -800,9 +797,8 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
       assertThat(approvedDeactivatedLocation.status).isEqualTo(DerivedLocationStatus.INACTIVE)
       assertThat(approvedDeactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
-      assertThat(approvedDeactivatedLocation.proposedReactivationDate).isEqualTo(proposedReactivationDate)
       assertThat(approvedDeactivatedLocation.pendingApprovalRequestId).isNull()
-      assertThat(deactivatedLocation.lastDeactivationReasonForChange).isEqualTo("The cell as been flooded")
+      assertThat(deactivatedLocation.lastDeactivationReasonForChange).isEqualTo("The wing is being renovated")
 
       val approvedDeactivatedCell = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
         .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
@@ -814,11 +810,28 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
       assertThat(approvedDeactivatedCell.status).isEqualTo(DerivedLocationStatus.INACTIVE)
       assertThat(approvedDeactivatedCell.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
-      assertThat(approvedDeactivatedCell.proposedReactivationDate).isEqualTo(proposedReactivationDate)
       assertThat(approvedDeactivatedCell.pendingApprovalRequestId).isNull()
       assertThat(approvedDeactivatedCell.currentCellCertificate).isNotNull
       assertThat(approvedDeactivatedCell.currentCellCertificate!!.workingCapacity).isEqualTo(0)
-      assertThat(approvedDeactivatedCell.lastDeactivationReasonForChange).isEqualTo("The cell as been flooded")
+      assertThat(approvedDeactivatedCell.lastDeactivationReasonForChange).isEqualTo("The wing is being renovated")
+      assertThat(approvedDeactivatedCell.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_MATCHING_CELL_CERT)
+
+      val inactiveCells = webTestClient.get().uri("/locations/prison/${leedsWing.prisonId}/inactive-cells")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<List<Location>>()
+        .returnResult().responseBody!!
+
+      assertThat(inactiveCells).hasSize(6)
+      assertThat(inactiveCells.map { it.getKey() to it.inactiveStatus }).containsExactlyInAnyOrder(
+        "LEI-A-1-001" to InactiveStatus.INACTIVE_MATCHING_CELL_CERT,
+        "LEI-A-1-002" to InactiveStatus.INACTIVE_MATCHING_CELL_CERT,
+        "LEI-A-1-003" to InactiveStatus.INACTIVE_MATCHING_CELL_CERT,
+        "LEI-A-2-001" to InactiveStatus.INACTIVE_MATCHING_CELL_CERT,
+        "LEI-A-2-002" to InactiveStatus.INACTIVE_MATCHING_CELL_CERT,
+        "LEI-A-2-003" to InactiveStatus.INACTIVE_MATCHING_CELL_CERT,
+      )
     }
 
     @Test
@@ -898,6 +911,40 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(rejectedDeactivatedLocation.proposedReactivationDate).isEqualTo(proposedReactivationDate)
       assertThat(rejectedDeactivatedLocation.pendingApprovalRequestId).isNull()
       assertThat(rejectedDeactivatedLocation.lastDeactivationReasonForChange).isNull()
+
+      val firstCell = leedsWing.findAllLeafLocations().first()
+      val rejectedDeactivatedCell = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(rejectedDeactivatedCell.status).isEqualTo(DerivedLocationStatus.INACTIVE)
+      assertThat(rejectedDeactivatedCell.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
+      assertThat(rejectedDeactivatedCell.proposedReactivationDate).isEqualTo(proposedReactivationDate)
+      assertThat(rejectedDeactivatedCell.pendingApprovalRequestId).isNull()
+      assertThat(rejectedDeactivatedCell.currentCellCertificate).isNotNull
+      assertThat(rejectedDeactivatedCell.currentCellCertificate!!.workingCapacity).isEqualTo(1)
+      assertThat(rejectedDeactivatedCell.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_TEMP)
+
+      val inactiveCells = webTestClient.get().uri("/locations/prison/${leedsWing.prisonId}/inactive-cells")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<List<Location>>()
+        .returnResult().responseBody!!
+
+      assertThat(inactiveCells).hasSize(6)
+      assertThat(inactiveCells.map { it.getKey() to it.inactiveStatus }).containsExactlyInAnyOrder(
+        "LEI-A-1-001" to InactiveStatus.INACTIVE_TEMP,
+        "LEI-A-1-002" to InactiveStatus.INACTIVE_TEMP,
+        "LEI-A-1-003" to InactiveStatus.INACTIVE_TEMP,
+        "LEI-A-2-001" to InactiveStatus.INACTIVE_TEMP,
+        "LEI-A-2-002" to InactiveStatus.INACTIVE_TEMP,
+        "LEI-A-2-003" to InactiveStatus.INACTIVE_TEMP,
+      )
     }
   }
 
@@ -1357,6 +1404,22 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(rejectedDeactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
       assertThat(rejectedDeactivatedLocation.pendingApprovalRequestId).isNull()
       assertThat(rejectedDeactivatedLocation.lastDeactivationReasonForChange).isNull()
+
+      val firstCell = leedsWing.findAllLeafLocations().first()
+      val rejectedDeactivatedCell = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(rejectedDeactivatedCell.status).isEqualTo(DerivedLocationStatus.INACTIVE)
+      assertThat(rejectedDeactivatedCell.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
+      assertThat(rejectedDeactivatedCell.pendingApprovalRequestId).isNull()
+      assertThat(rejectedDeactivatedCell.currentCellCertificate).isNotNull
+      assertThat(rejectedDeactivatedCell.currentCellCertificate!!.workingCapacity).isEqualTo(1)
+      assertThat(rejectedDeactivatedCell.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_TEMP)
     }
   }
 


### PR DESCRIPTION

### Summary

This PR adds a new `inactiveStatus` field to the `LocationDTO` to allow the inactive cells screen to categorise temporarily deactivated cells into three distinct groups. This supports the UI requirement to display inactive cells in separate sections based on their relationship to the official cell certificate.

### Background

The inactive cells screen (supported by `GET /prison/{prisonId}/inactive-cells`) previously returned no information about *why* a cell is inactive relative to its certificate. The screen needs to divide inactive cells into three sections:

1. **Temporary inactive cells** — inactive but the certificate has not been updated to reflect 0 working capacity
2. **Inactive cells with certificate change requests** — inactive with a pending deactivation approval request
3. **Inactive cells with capacity decreased on cell certificate** — the working capacity on the certificate has already been reduced to match the inactive state

### Changes

#### `LocationDto.kt`
- Added a new `inactiveStatus: InactiveStatus?` field to the `Location` DTO. This is `null` when the location is active or when no cell certificate is available (i.e. for prisons that do not require certification approval).
- Added new `InactiveStatus` enum with three values:
    - `INACTIVE_TEMP` — cell is inactive but the certificate working capacity does not yet reflect 0
    - `INACTIVE_PEND_CHANGE_REQ` — cell has a pending deactivation certification approval request
    - `INACTIVE_MATCHING_CELL_CERT` — cell's working capacity matches the cell certificate (i.e. certificate has been updated to 0)

#### `Cell.kt`
- Added `deriveInactiveStatus(cellCertificateLocation)` private method on `Cell` to calculate the appropriate `InactiveStatus`:
    - If the cell has a pending certification approval → `INACTIVE_PEND_CHANGE_REQ`
    - Else if the cell certificate working capacity matches the calculated working capacity → `INACTIVE_MATCHING_CELL_CERT`
    - Otherwise → `INACTIVE_TEMP`
- The `toDto()` method now maps `cellCertificateLocation` to `inactiveStatus` via this method.

#### `LocationService.kt`
- `getResidentialInactiveLocations`: Now checks `isCertificationApprovalRequired` once per request (avoiding repeated calls per cell), and conditionally fetches the cell certificate per location only when required. If certification approval is not required for the prison, the DB lookup is skipped entirely and `inactiveStatus` will be `null`.
- `temporarilyDeactivateLocations`: Extracted `certificationApprovalRequired` as a local variable (previously called inline) and passes the cell certificate to `toDto()` so deactivated locations also carry their `inactiveStatus` in the response.

#### `CertificationApprovalResourceTest.kt`
- Added assertions across all three deactivation approval scenarios (pending, approved, rejected) to verify the correct `inactiveStatus` is returned both on individual location responses and via the `inactive-cells` list endpoint.
- Refactored a duplicated inline deactivation block to use the shared `deactivateLocation()` helper.
- Corrected a minor pre-existing test data typo (`"The cell as been flooded"` → `"The wing is being renovated"`) and removed redundant duplicate request steps.
