### PR TITLE
## MAP-3196 Fix N+1 query in with /inactive-cells

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -127,7 +127,7 @@ open class CellCertificateLocation(
   private val localName: String? = null,
 
   @Column(nullable = false)
-  private val pathHierarchy: String,
+  val pathHierarchy: String,
 
   @Column(nullable = false)
   open val level: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateRepository.kt
@@ -43,4 +43,28 @@ interface CellCertificateRepository : JpaRepository<CellCertificate, UUID> {
     nativeQuery = true,
   )
   fun findByPrisonIdAndPathHierarchy(prisonId: String, pathHierarchy: String): CellCertificateLocation?
+
+  @Query(
+    value = """
+        WITH RECURSIVE
+        current_cert AS (SELECT cc.id
+                         FROM cell_certificate cc
+                         WHERE cc.prison_id = :prisonId
+                           AND cc.current = TRUE),
+        tree AS (
+            SELECT ccl.*
+            FROM cell_certificate_location ccl
+                     JOIN current_cert c ON ccl.cell_certificate_id = c.id
+            UNION ALL
+            SELECT child.*
+            FROM cell_certificate_location child
+                     JOIN tree parent
+                          ON child.parent_location_id = parent.id)
+    SELECT *
+    FROM tree
+    WHERE path_hierarchy IN (:pathHierarchies)
+  """,
+    nativeQuery = true,
+  )
+  fun findByPrisonIdAndPathHierarchies(prisonId: String, pathHierarchies: List<String>): List<CellCertificateLocation>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -1608,22 +1608,18 @@ class LocationService(
       )
     }
 
-    return (
-      startLocation?.cellLocations() ?: cellLocationRepository.findAllByPrisonIdAndStatus(
-        prisonId,
-        LocationStatus.INACTIVE,
-      )
-      )
+    val cells = (startLocation?.cellLocations() ?: cellLocationRepository.findAllByPrisonIdAndStatus(prisonId, LocationStatus.INACTIVE))
       .filter { it.isTemporarilyDeactivated() }
-      .map {
-        it.toDto(
-          cellCertificateLocation = if (certificationApprovalRequired) {
-            cellCertificateRepository.findByPrisonIdAndPathHierarchy(it.prisonId, it.getPathHierarchy())
-          } else {
-            null
-          },
-        )
-      }
+
+    val cellCertsMap = if (certificationApprovalRequired) {
+      cellCertificateRepository.findByPrisonIdAndPathHierarchies(prisonId, cells.map { it.getPathHierarchy() })
+        .associateBy { it.pathHierarchy }
+    } else {
+      emptyMap()
+    }
+
+    return cells
+      .map { it.toDto(cellCertificateLocation = cellCertsMap[it.getPathHierarchy()]) }
       .sortedWith(NaturalOrderComparator())
   }
 


### PR DESCRIPTION
### Problem

`getResidentialInactiveLocations` was issuing one SQL query per cell to look up its certificate location:

```kotlin
cellCertificateRepository.findByPrisonIdAndPathHierarchy(it.prisonId, it.getPathHierarchy())
```

For a prison with many temporarily deactivated cells this results in **N+1 queries** — one query to fetch the cells, then one per cell to fetch its certificate. On larger estates this is noticeably slow.

### Solution

Added a new batch repository method `findByPrisonIdAndPathHierarchies` that fetches all required certificate locations in **a single recursive SQL query** using a CTE:

```sql
WITH RECURSIVE
  current_cert AS (
    SELECT cc.id FROM cell_certificate cc
    WHERE cc.prison_id = :prisonId AND cc.current = TRUE
  ),
  tree AS (
    SELECT ccl.* FROM cell_certificate_location ccl
      JOIN current_cert c ON ccl.cell_certificate_id = c.id
    UNION ALL
    SELECT child.* FROM cell_certificate_location child
      JOIN tree parent ON child.parent_location_id = parent.id
  )
SELECT * FROM tree
WHERE path_hierarchy IN (:pathHierarchies)
```

The results are keyed into a map by `pathHierarchy` upfront, then each cell does a simple O(1) map lookup rather than a database round-trip:

```kotlin
val cellCertsMap = cellCertificateRepository
    .findByPrisonIdAndPathHierarchies(prisonId, cells.map { it.getPathHierarchy() })
    .associateBy { it.pathHierarchy }

return cells
    .map { it.toDto(cellCertificateLocation = cellCertsMap[it.getPathHierarchy()]) }
    .sortedWith(NaturalOrderComparator())
```

### Changes

| File | Change |
|---|---|
| `CellCertificateRepository` | Added `findByPrisonIdAndPathHierarchies` — batch fetch via recursive CTE |
| `CellCertificateLocation` | Made `pathHierarchy` field `val` (public) so it can be used as the map key |
| `LocationService` | Replaced per-cell `findByPrisonIdAndPathHierarchy` calls with a single batch fetch + map lookup |

### Query complexity

The recursive CTE walks the certificate location tree once per request regardless of how many cells are being returned. The overall database work goes from **O(N) queries** to **1 query**.
