### PR TITLE
fix: Allow used for update without cell cert change approval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ sonar-project.properties
 
 #Helm
 **/Chart.lock
+
+#Synk
+.snyk

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -724,10 +724,6 @@ class LocationService(
       throw PendingApprovalOnLocationCannotBeUpdatedException(residentialLocation.getKey())
     }
 
-    if (activePrisonService.isCertificationApprovalRequired(residentialLocation.prisonId) && !residentialLocation.isDraft()) {
-      throw ApprovalRequestRequiresReasonForChangeException(residentialLocation.getKey())
-    }
-
     val linkedTransaction = sharedLocationService.createLinkedTransaction(
       prisonId = residentialLocation.prisonId,
       TransactionType.LOCATION_UPDATE,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationTransformResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationTransformResourceTest.kt
@@ -406,6 +406,48 @@ class LocationTransformResourceTest : CommonDataTestBase() {
             JsonCompareMode.LENIENT,
           )
       }
+
+      @Test
+      fun `can update Use for type to a value successfully when cert approval is enabled for prison`() {
+        val expectedUsedFor = setOf(UsedForType.PERSONALITY_DISORDER)
+
+        val result = webTestClient.put().uri("/locations/${leedsWing.id}/used-for-type")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(setOf(UsedForType.PERSONALITY_DISORDER)))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody<LocationTest>()
+          .returnResult().responseBody!!
+
+        assertThat(result.usedFor == expectedUsedFor)
+
+        val landingZ1 = result.findByPathHierarchy("A-1")!!
+        assertThat(landingZ1.usedFor == expectedUsedFor)
+
+        val cellZ1001 = result.findByPathHierarchy("A-1-001")!!
+        assertThat(cellZ1001.usedFor == expectedUsedFor)
+
+        val cellZ1002 = result.findByPathHierarchy("A-1-002")!!
+        assertThat(cellZ1002.usedFor == expectedUsedFor)
+
+        val landingZ2 = result.findByPathHierarchy("A-2")!!
+        assertThat(landingZ2.usedFor!!.isEmpty())
+
+        val cellVisit = result.findByPathHierarchy("A-VISIT")
+        assertThat(cellVisit == null)
+
+        getDomainEvents(6).let {
+          assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
+            "location.inside.prison.amended" to "LEI-A-1-001",
+            "location.inside.prison.amended" to "LEI-A-1-002",
+            "location.inside.prison.amended" to "LEI-A-1-003",
+            "location.inside.prison.amended" to "LEI-A-1",
+            "location.inside.prison.amended" to "LEI-A-2",
+            "location.inside.prison.amended" to "LEI-A",
+          )
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Updates to the usedFor value of a cell should not require a cell cert change request.

MAP-3204