### PR TITLE
MAP-3208 Allow updating deactivation details for inactive locations and sending for cell certificate alignment 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -728,9 +728,10 @@ abstract class Location(
     proposedReactivationDate: LocalDate? = null,
     userOrSystemInContext: String,
     deactivatedLocations: MutableSet<Location>? = null,
+    updatedLocations: MutableSet<Location>? = null,
     requestApproval: Boolean = false,
     reasonForChange: String? = null,
-  ): Boolean {
+  ) {
     var dataChanged = false
 
     if (!isPermanentlyDeactivated()) {
@@ -798,6 +799,7 @@ abstract class Location(
         this.deactivatedDate = deactivatedDate
         this.deactivatedBy = userOrSystemInContext
         log.info("Temporarily Deactivated Location [${getKey()}]")
+        deactivatedLocations?.add(this)
       }
 
       if (dataChanged) {
@@ -807,31 +809,28 @@ abstract class Location(
         this.planetFmReference = planetFmReference
         this.updatedBy = userOrSystemInContext
         this.whenUpdated = amendedDate
-        deactivatedLocations?.add(this)
+        log.info("Deactivated Location updated [${getKey()}]")
+        updatedLocations?.add(this)
       }
 
       if (this is ResidentialLocation) {
         findSubLocations().filterIsInstance<ResidentialLocation>().forEach { location ->
           if (!location.isResidentialRoomOrConvertedCell()) {
-            if (location.temporarilyDeactivate(
-                deactivatedReason = deactivatedReason,
-                deactivatedDate = deactivatedDate,
-                deactivationReasonDescription = deactivationReasonDescription,
-                linkedTransaction = linkedTransaction,
-                planetFmReference = planetFmReference,
-                proposedReactivationDate = proposedReactivationDate,
-                userOrSystemInContext = userOrSystemInContext,
-                deactivatedLocations = deactivatedLocations,
-              )
-            ) {
-              dataChanged = true
-            }
+            location.temporarilyDeactivate(
+              deactivatedReason = deactivatedReason,
+              deactivatedDate = deactivatedDate,
+              deactivationReasonDescription = deactivationReasonDescription,
+              linkedTransaction = linkedTransaction,
+              planetFmReference = planetFmReference,
+              proposedReactivationDate = proposedReactivationDate,
+              userOrSystemInContext = userOrSystemInContext,
+              deactivatedLocations = deactivatedLocations,
+              updatedLocations = updatedLocations,
+            )
           }
         }
       }
     }
-
-    return dataChanged
   }
 
   open fun update(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -57,7 +57,6 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.Locatio
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.ResidentialLocationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.SignedOperationCapacityRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.validateCapacity
-import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.AlreadyDeactivatedLocationException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ApprovalRequestRequiresReasonForChangeException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.BulkPermanentDeactivationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CapacityException
@@ -982,8 +981,6 @@ class LocationService(
 
   @Transactional
   fun deactivateLocations(locationsToDeactivate: DeactivateLocationsRequest): Map<InternalLocationDomainEventType, List<LocationDTO>> {
-    val deactivatedLocations = mutableSetOf<Location>()
-
     val prisonId = locationsToDeactivate.locations.entries.firstOrNull()?.key?.let { id ->
       locationRepository.findById(id)
         .orElseThrow { LocationNotFoundException(id.toString()) }.prisonId
@@ -998,15 +995,14 @@ class LocationService(
     )
 
     val certificationApprovalRequired = activePrisonService.isCertificationApprovalRequired(prisonId)
-    val approvalRequired =
-      locationsToDeactivate.requiresApproval && certificationApprovalRequired
+    val approvalRequired = locationsToDeactivate.requiresApproval && certificationApprovalRequired
+
+    val deactivatedLocations = mutableSetOf<Location>()
+    val updatedLocations = mutableSetOf<Location>()
+
     locationsToDeactivate.locations.forEach { (id, deactivationDetail) ->
       val locationToDeactivate = locationRepository.findById(id)
         .orElseThrow { LocationNotFoundException(id.toString()) }
-
-      if (locationToDeactivate.isTemporarilyDeactivated()) {
-        throw AlreadyDeactivatedLocationException(locationToDeactivate.getKey())
-      }
 
       checkForPrisonersInLocation(locationToDeactivate)
 
@@ -1020,6 +1016,7 @@ class LocationService(
             throw ApprovalRequestRequiresReasonForChangeException(locationToDeactivate.getKey())
           }
 
+          log.info("Requesting certification approval for deactivation of location [${locationToDeactivate.getKey()}]")
           val approvalRequest = locationToDeactivate.requestApprovalForDeactivation(
             requestedDate = linkedTransaction.txStartTime,
             requestedBy = linkedTransaction.transactionInvokedBy,
@@ -1043,38 +1040,46 @@ class LocationService(
           approvalRequest.refreshCapacities()
         }
 
-        if (locationToDeactivate.temporarilyDeactivate(
-            deactivatedReason = deactivationReason,
-            deactivatedDate = now(clock),
-            deactivationReasonDescription = deactivationReasonDescription,
-            planetFmReference = planetFmReference,
-            proposedReactivationDate = proposedReactivationDate,
-            userOrSystemInContext = transactionInvokedBy,
-            deactivatedLocations = deactivatedLocations,
-            linkedTransaction = linkedTransaction,
-            requestApproval = approvalRequired,
-            reasonForChange = locationsToDeactivate.reasonForChange,
-          )
-        ) {
-          deactivatedLocations.forEach {
-            sharedLocationService.trackLocationUpdate(it, "Temporarily Deactivated Location")
-          }
-        }
+        locationToDeactivate.temporarilyDeactivate(
+          deactivatedReason = deactivationReason,
+          deactivatedDate = now(clock),
+          deactivationReasonDescription = deactivationReasonDescription,
+          planetFmReference = planetFmReference,
+          proposedReactivationDate = proposedReactivationDate,
+          userOrSystemInContext = transactionInvokedBy,
+          deactivatedLocations = deactivatedLocations,
+          updatedLocations = updatedLocations,
+          linkedTransaction = linkedTransaction,
+          requestApproval = approvalRequired,
+          reasonForChange = locationsToDeactivate.reasonForChange,
+        )
+
+        locationRepository.saveAndFlush(locationToDeactivate)
       }
     }
 
-    locationRepository.saveAllAndFlush(deactivatedLocations)
+    deactivatedLocations.forEach {
+      sharedLocationService.trackLocationUpdate(it, "Temporarily Deactivated Location")
+    }
+    updatedLocations.forEach {
+      sharedLocationService.trackLocationUpdate(it, "Updated Deactivated Location")
+    }
+
     val deactivatedLocationsDto = deactivatedLocations.map {
       it.toDto(
         cellCertificateLocation = cellCertificateRepository.findByPrisonIdAndPathHierarchy(it.prisonId, it.getPathHierarchy()).takeIf { certificationApprovalRequired },
       )
     }.toSet()
+
+    val updatedLocationsDto = deactivatedLocations.flatMap { deactivatedLoc ->
+      deactivatedLoc.getParentLocations().map { it.toDto() }
+    }.toSet()
+      .plus(updatedLocations.map { it.toDto() })
+      .minus(deactivatedLocationsDto)
+
+    log.info("Deactivated ${deactivatedLocationsDto.size} locations and updated ${updatedLocationsDto.size} locations")
     return mapOf(
-      InternalLocationDomainEventType.LOCATION_AMENDED to deactivatedLocations.flatMap { deactivatedLoc ->
-        deactivatedLoc.getParentLocations().map { it.toDto() }
-      }.toSet().minus(
-        deactivatedLocationsDto,
-      ).toList(),
+      InternalLocationDomainEventType.LOCATION_AMENDED to updatedLocationsDto.toList(),
       InternalLocationDomainEventType.LOCATION_DEACTIVATED to deactivatedLocationsDto.toList(),
     ).also {
       linkedTransaction.txEndTime = now(clock)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.Ap
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.ReactivationLocationsApprovalRequest
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @WithMockAuthUser(username = EXPECTED_USERNAME)
@@ -566,15 +567,13 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
     fun `can deactivate a cell and request approval`() {
       val firstCell = leedsWing.findAllLeafLocations().first() as Cell
       val reasonForChange = "The cell has been flooded"
-      deactivateLocation(firstCell, true, reasonForChange)
-
-      val deactivatedLocation = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!
+      val deactivatedLocation = deactivateLocation(
+        firstCell,
+        DeactivatedReason.MOTHBALLED,
+        planetFmReference = "11111",
+        requiresApproval = true,
+        reasonForChange = reasonForChange,
+      )
 
       assertThat(deactivatedLocation.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
       assertThat(deactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
@@ -583,17 +582,6 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(deactivatedLocation.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_PEND_CHANGE_REQ)
 
       val pendingApprovalRequestId = deactivatedLocation.pendingApprovalRequestId!!
-
-      val parentResults = firstCell.getParentLocations().associate {
-        it.getKey() to "location.inside.prison.amended"
-      }
-      val results = mapOf(firstCell.getKey() to "location.inside.prison.deactivated") + parentResults
-
-      getDomainEvents(results.size).let { messages ->
-        assertThat(messages.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
-          *results.map { it.value to it.key }.toTypedArray(),
-        )
-      }
 
       val pendingApproval = webTestClient.get().uri("/certification/request-approvals/$pendingApprovalRequestId")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
@@ -680,17 +668,47 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
     }
 
     @Test
+    fun `can change cell cert capacity for deactivated cell`() {
+      val firstCell = leedsWing.findAllLeafLocations().first() as Cell
+      var deactivatedLocation = deactivateLocation(firstCell, deactivatedReason = DeactivatedReason.DAMAGED)
+
+      assertThat(deactivatedLocation.status).isEqualTo(DerivedLocationStatus.INACTIVE)
+      assertThat(deactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.DAMAGED)
+      assertThat(deactivatedLocation.planetFmReference).isNull()
+      assertThat(deactivatedLocation.proposedReactivationDate).isNull()
+      assertThat(deactivatedLocation.pendingApprovalRequestId).isNull()
+      assertThat(deactivatedLocation.lastDeactivationReasonForChange).isNull()
+      assertThat(deactivatedLocation.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_TEMP)
+
+      val proposedReactivationDate = LocalDateTime.now(clock).plusMonths(1).toLocalDate()
+      deactivatedLocation = deactivateLocation(
+        firstCell,
+        DeactivatedReason.MOTHBALLED,
+        planetFmReference = "2343434",
+        proposedReactivationDate = proposedReactivationDate,
+        requiresApproval = true,
+        reasonForChange = "apply to certificate",
+      )
+
+      assertThat(deactivatedLocation.pendingApprovalRequestId).isNotNull
+      assertThat(deactivatedLocation.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
+      assertThat(deactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
+      assertThat(deactivatedLocation.planetFmReference).isEqualTo("2343434")
+      assertThat(deactivatedLocation.proposedReactivationDate).isEqualTo(proposedReactivationDate)
+      assertThat(deactivatedLocation.lastDeactivationReasonForChange).isEqualTo("apply to certificate")
+      assertThat(deactivatedLocation.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_PEND_CHANGE_REQ)
+    }
+
+    @Test
     fun `can deactivate a wing and sublocations and request approval`() {
       val now = LocalDateTime.now(clock)
-      deactivateLocation(leedsWing, true, reasonForChange = "The wing is being renovated")
-
-      val deactivatedLocation = webTestClient.get().uri("/locations/${leedsWing.id}")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!
+      val deactivatedLocation = deactivateLocation(
+        leedsWing,
+        DeactivatedReason.MOTHBALLED,
+        planetFmReference = "11111",
+        requiresApproval = true,
+        reasonForChange = "The wing is being renovated",
+      )
 
       assertThat(deactivatedLocation.status).isEqualTo(DerivedLocationStatus.LOCKED_INACTIVE)
       assertThat(deactivatedLocation.deactivatedReason).isEqualTo(DeactivatedReason.MOTHBALLED)
@@ -955,7 +973,12 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
     @Test
     fun `can request to reactivate a cell and then approve`() {
       val firstCell = leedsWing.findAllLeafLocations().first() as Cell
-      deactivateLocation(firstCell, reasonForChange = "The wing has been flooded")
+      deactivateLocation(
+        firstCell,
+        deactivatedReason = DeactivatedReason.MOTHBALLED,
+        planetFmReference = "11111",
+        reasonForChange = "The wing has been flooded",
+      )
       webTestClient.put().uri("/certification/location/reactivation-request-approval")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
@@ -1083,7 +1106,12 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can request to reactivate a wing with cascade and then approve`() {
-      deactivateLocation(leedsWing, reasonForChange = "The wing has been flooded")
+      deactivateLocation(
+        leedsWing,
+        deactivatedReason = DeactivatedReason.MOTHBALLED,
+        planetFmReference = "11111",
+        reasonForChange = "The wing has been flooded",
+      )
       webTestClient.put().uri("/certification/location/reactivation-request-approval")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
@@ -1188,7 +1216,12 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can request to reactivate a wing explicitly and then approve`() {
-      deactivateLocation(leedsWing, reasonForChange = "The wing has been flooded")
+      deactivateLocation(
+        leedsWing,
+        deactivatedReason = DeactivatedReason.MOTHBALLED,
+        planetFmReference = "11111",
+        reasonForChange = "The wing has been flooded",
+      )
       webTestClient.put().uri("/certification/location/reactivation-request-approval")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
@@ -1340,7 +1373,12 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can request to reactivate a locations explicitly and then reject`() {
-      deactivateLocation(leedsWing, reasonForChange = "The wing has been flooded")
+      deactivateLocation(
+        leedsWing,
+        deactivatedReason = DeactivatedReason.MOTHBALLED,
+        planetFmReference = "11111",
+        reasonForChange = "The wing has been flooded",
+      )
       webTestClient.put().uri("/certification/location/reactivation-request-approval")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
@@ -1757,11 +1795,12 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
   private fun deactivateLocation(
     location: ResidentialLocation,
+    deactivatedReason: DeactivatedReason,
+    proposedReactivationDate: LocalDate? = null,
+    planetFmReference: String? = null,
     requiresApproval: Boolean = false,
-    reasonForChange: String,
-  ) {
-    val now = LocalDateTime.now(clock)
-    val proposedReactivationDate = now.plusMonths(1).toLocalDate()
+    reasonForChange: String? = null,
+  ): Location {
     prisonerSearchMockServer.stubSearchByLocations(
       location.prisonId,
       location.findAllLeafLocations().map { it.getPathHierarchy() },
@@ -1776,9 +1815,9 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
           TemporaryDeactivationLocationRequest(
             requiresApproval = requiresApproval,
             reasonForChange = reasonForChange,
-            deactivationReason = DeactivatedReason.MOTHBALLED,
+            deactivationReason = deactivatedReason,
             proposedReactivationDate = proposedReactivationDate,
-            planetFmReference = "11111",
+            planetFmReference = planetFmReference,
           ),
         ),
       )
@@ -1795,5 +1834,13 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
           .containsExactlyInAnyOrder(*expectedEvents.toTypedArray())
       }
     }
+
+    return webTestClient.get().uri("/locations/${location.id}?includeCurrentCertificate=true")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+      .header("Content-Type", "application/json")
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<Location>()
+      .returnResult().responseBody!!
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResourceIntTest.kt
@@ -1381,7 +1381,7 @@ class LocationResourceIntTest : CommonDataTestBase() {
             "location.inside.prison.deactivated" to "MDI-Z",
             "location.inside.prison.deactivated" to "MDI-Z-1",
             "location.inside.prison.deactivated" to "MDI-Z-2",
-            "location.inside.prison.deactivated" to "MDI-Z-1-001",
+            "location.inside.prison.amended" to "MDI-Z-1-001",
             "location.inside.prison.deactivated" to "MDI-Z-1-002",
           )
         }


### PR DESCRIPTION

## Description
This PR enhances the location deactivation flow by allowing updates to already inactive locations. Previously, attempting to deactivate an already deactivated location would result in an `AlreadyDeactivatedLocationException`. Now, this restriction is lifted to allow updating specific deactivation details, such as the `deactivatedReason`, `planetFmReference`, and `proposedReactivationDate`.

Furthermore, this change enables aligning a deactivated location with the cell certificate. If a location is off-cert inactive but its deactivation hasn't been mirrored to the cell certificate, sending it for approval will now bring them into alignment upon approval.

## Changes Included
* **`Location.kt`**: Modified `temporarilyDeactivate` to track already deactivated locations that receive updates via a new `updatedLocations` set parameter.
* **`LocationService.kt`**:
    * Removed the `AlreadyDeactivatedLocationException` check to permit updating an inactive location.
    * Captures and tracks `updatedLocations` separately from newly `deactivatedLocations`.
    * Triggers domain events (`LOCATION_AMENDED`) for updated locations and `LOCATION_DEACTIVATED` for newly deactivated ones.
* **`CertificationApprovalResourceTest.kt`**:
    * Updated the `deactivateLocation` test helper to support new signature parameters and return the modified `Location` object.
    * Added a new test `can change cell cert capacity for deactivated cell` which confirms that an already deactivated cell can be updated and an approval request can be correctly generated to mirror the change against the certificate.
    * Refactored various tests to use the updated `deactivateLocation` helper function.

## Motivation and Context
The ability to amend deactivation details is essential when information (like a `planetFmReference` or an expected reactivation date) becomes available after the initial deactivation. Allowing the change to trigger a certification approval request brings the location's off-cert status into alignment with the cell certificate smoothly, preventing discrepancies in the system.