### PR TITLE
MAPA-96 Preserve unrelated locations on cell certificate approval

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDto.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.UsedForType
 import java.time.LocalDateTime
 import java.util.UUID
+import kotlin.collections.forEach
 
 @Schema(description = "Cell Certificate")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -48,7 +49,25 @@ data class CellCertificateDto(
 
   @param:Schema(description = "Locations in the certificate", required = true)
   val locations: List<CellCertificateLocationDto>? = null,
-)
+) {
+  fun findLocationInCertificate(pathHierarchy: String) = findAllLocations().firstOrNull { it.pathHierarchy == pathHierarchy }
+
+  private fun findAllLocations(): List<CellCertificateLocationDto> {
+    val subLocations = mutableListOf<CellCertificateLocationDto>()
+
+    fun traverse(location: CellCertificateLocationDto) {
+      subLocations.add(location)
+      if (location.subLocations != null) {
+        for (childLocation in location.subLocations) {
+          traverse(childLocation)
+        }
+      }
+    }
+
+    locations?.forEach { traverse(it) }
+    return subLocations
+  }
+}
 
 @Schema(description = "Cell Certificate Location")
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -85,6 +85,22 @@ open class CellCertificate(
 ) {
   override fun toString(): String = "CellCertificate(prisonId='$prisonId', certificationApprovalRequest=$certificationApprovalRequest, current=$current)"
 
+  fun findLocationInCertificate(pathHierarchy: String) = findAllLocations().firstOrNull { it.pathHierarchy == pathHierarchy }
+
+  private fun findAllLocations(): List<CellCertificateLocation> {
+    val subLocations = mutableListOf<CellCertificateLocation>()
+
+    fun traverse(location: CellCertificateLocation) {
+      subLocations.add(location)
+      for (childLocation in location.subLocations) {
+        traverse(childLocation)
+      }
+    }
+
+    locations.forEach { traverse(it) }
+    return subLocations
+  }
+
   fun markAsNotCurrent() {
     current = false
   }
@@ -161,7 +177,7 @@ open class CellCertificateLocation(
   @OneToMany(fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinColumn(name = "parent_location_id")
   @SortNatural
-  private val subLocations: SortedSet<CellCertificateLocation> = sortedSetOf(),
+  val subLocations: SortedSet<CellCertificateLocation> = sortedSetOf(),
 
 ) : Comparable<CellCertificateLocation> {
 
@@ -206,4 +222,21 @@ open class CellCertificateLocation(
   private fun getUsedForTypesFromList(): List<UsedForType>? = usedForTypes?.split(",")?.map { UsedForType.valueOf(it.trim()) }
 
   private fun getAccommodationTypesFromList(): List<AccommodationType>? = accommodationTypes?.split(",")?.map { AccommodationType.valueOf(it.trim()) }
+
+  fun clone(subLocations: SortedSet<CellCertificateLocation>): CellCertificateLocation = CellCertificateLocation(
+    pathHierarchy = pathHierarchy,
+    locationCode = locationCode,
+    locationType = locationType,
+    cellMark = cellMark,
+    localName = localName,
+    level = level,
+    certifiedNormalAccommodation = certifiedNormalAccommodation,
+    workingCapacity = workingCapacity,
+    maxCapacity = maxCapacity,
+    inCellSanitation = inCellSanitation,
+    specialistCellTypes = specialistCellTypes,
+    accommodationTypes = accommodationTypes,
+    usedForTypes = usedForTypes,
+    subLocations = subLocations,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -500,54 +500,54 @@ open class ResidentialLocation(
     return this
   }
 
-  fun toCellCertificateLocation(approvalRequest: CertificationApprovalRequest): CellCertificateLocation {
+  fun toCellCertificateLocation(approvalRequest: CertificationApprovalRequest, currentCellCertificate: CellCertificate?): CellCertificateLocation {
     val subLocations: List<CellCertificateLocation> = getResidentialLocationsBelowThisLevel()
       .filter { !it.isDraft() && (it.isStructural() || it.isCell() || it.isConvertedCell()) }
-      .map { it.toCellCertificateLocation(approvalRequest) }
+      .map { it.toCellCertificateLocation(approvalRequest, currentCellCertificate) }
 
-    return CellCertificateLocation(
-      locationType = locationType,
-      locationCode = getLocationCode(),
-      pathHierarchy = getPathHierarchy(),
-      localName = localName?.capitalizeWords(),
-      cellMark = if (this is Cell) {
-        getDoorCellMark()
-      } else {
-        null
-      },
-      level = getLevel(),
-      inCellSanitation = if (this is Cell) {
-        getSanitationOfCell()
-      } else {
-        null
-      },
-      maxCapacity = calcMaxCapacity(),
-      workingCapacity = if (draftApprovalLocationIsPartOfHierarchy(approvalRequest)) {
-        getWorkingCapacityIgnoringInactiveStatus()
-      } else {
-        calcWorkingCapacity()
-      },
-      certifiedNormalAccommodation = calcCertifiedNormalAccommodation(),
-      usedForTypes = getUsedForValuesAsCSV(),
-      accommodationTypes = getAccommodationTypesAsCSV(),
-      specialistCellTypes = getSpecialistCellTypesAsCSV(),
-      convertedCellType = if (this is Cell && isConvertedCell()) {
-        convertedCellType
-      } else {
-        null
-      },
-      subLocations = subLocations.toSortedSet(),
-    )
+    val locationInExistingCertificate = currentCellCertificate?.findLocationInCertificate(getPathHierarchy())
+    if (approvalLocationIsPartOfHierarchy(approvalRequest) || locationInExistingCertificate == null) {
+      return CellCertificateLocation(
+        locationType = locationType,
+        locationCode = getLocationCode(),
+        pathHierarchy = getPathHierarchy(),
+        localName = localName?.capitalizeWords(),
+        cellMark = if (this is Cell) {
+          getDoorCellMark()
+        } else {
+          null
+        },
+        level = getLevel(),
+        inCellSanitation = if (this is Cell) {
+          getSanitationOfCell()
+        } else {
+          null
+        },
+        maxCapacity = calcMaxCapacity(),
+        workingCapacity = if (approvalRequest is DraftChangeApprovalRequest) {
+          getWorkingCapacityIgnoringInactiveStatus()
+        } else {
+          calcWorkingCapacity()
+        },
+        certifiedNormalAccommodation = calcCertifiedNormalAccommodation(),
+        usedForTypes = getUsedForValuesAsCSV(),
+        accommodationTypes = getAccommodationTypesAsCSV(),
+        specialistCellTypes = getSpecialistCellTypesAsCSV(),
+        convertedCellType = if (this is Cell && isConvertedCell()) {
+          convertedCellType
+        } else {
+          null
+        },
+        subLocations = subLocations.toSortedSet(),
+      )
+    } else {
+      return locationInExistingCertificate.clone(subLocations.toSortedSet())
+    }
   }
 
-  private fun draftApprovalLocationIsPartOfHierarchy(approvalRequest: CertificationApprovalRequest): Boolean = if (approvalRequest.getApprovalType() == ApprovalType.DRAFT) {
-    val locationRequest = approvalRequest as? DraftChangeApprovalRequest
-    locationRequest?.location?.let { location ->
-      isInHierarchy(location) || findLocation(location.getKey()) != null
-    } ?: false
-  } else {
-    false
-  }
+  fun approvalLocationIsPartOfHierarchy(approvalRequest: CertificationApprovalRequest) = (approvalRequest as? LocationCertificationApprovalRequest)?.location?.let { location ->
+    isInHierarchy(location) || findLocation(location.getKey()) != null
+  } ?: false
 
   fun toCertificationApprovalRequestLocation(includeDraftOrPending: Boolean = false, reactivation: Boolean = false, deactivation: Boolean = false): CertificationApprovalRequestLocation {
     val subLocations: List<CertificationApprovalRequestLocation> = getResidentialLocationsBelowThisLevel()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -30,8 +30,7 @@ class CellCertificateService(
     approvalRequest: CertificationApprovalRequest,
     signedOperationCapacity: Int,
   ): CellCertificateDto {
-    // Mark any existing current certificates as not current
-    cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(approvalRequest.prisonId)?.markAsNotCurrent()
+    val currentCellCertificate = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(approvalRequest.prisonId)
 
     // Create the cell certificate
     val cellCertificate = cellCertificateRepository.saveAndFlush(
@@ -44,7 +43,7 @@ class CellCertificateService(
         locations = residentialLocationRepository.findAllByPrisonIdAndParentIsNull(approvalRequest.prisonId)
           .filter { !it.isPermanentlyDeactivated() && !it.isDraft() && it.isStructural() }
           .map {
-            it.toCellCertificateLocation(approvalRequest)
+            it.toCellCertificateLocation(approvalRequest, currentCellCertificate)
           }.toSortedSet(),
       ).apply {
         totalWorkingCapacity = locations.sumOf { it.workingCapacity ?: 0 }
@@ -52,6 +51,8 @@ class CellCertificateService(
         totalCertifiedNormalAccommodation = locations.sumOf { it.certifiedNormalAccommodation ?: 0 }
       },
     )
+    // Mark any existing current certificates as not current
+    currentCellCertificate?.markAsNotCurrent()
 
     log.info("Created cell certificate for prison ${approvalRequest.prisonId} with ID ${cellCertificate.id}")
     return cellCertificate.toDto()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import org.springframework.test.json.JsonCompareMode
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ApproveCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Capacity
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellMarkChangeRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellSanitationChangeRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
@@ -46,63 +46,8 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change capacity a location and request approval`() {
-      // will return a prisoner for each location under the Leeds wing
-      leedsWing.findAllLeafLocations().forEach {
-        prisonerSearchMockServer.stubSearchByLocations(
-          leedsWing.prisonId,
-          listOf(it.getPathHierarchy()),
-          true,
-        )
-      }
       val firstCell = leedsWing.findAllLeafLocations().first()
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
-        .header("Content-Type", "application/json")
-        .bodyValue(
-          jsonString(
-            CapacityChangeRequest(
-              workingCapacity = 1,
-              maxCapacity = 1,
-              certifiedNormalAccommodation = 1,
-            ),
-          ),
-        )
-        .exchange()
-        .expectStatus().isOk
-        .expectBody().json(
-          // language=json
-          """
-              {
-                "id": "${firstCell.id}",
-                "prisonId": "${firstCell.prisonId}",
-                "pathHierarchy": "${firstCell.getPathHierarchy()}",
-                "locationType": "CELL",
-                "capacity": {
-                  "maxCapacity": 2,
-                  "workingCapacity": 1,
-                  "certifiedNormalAccommodation": 1
-                },
-                "pendingChanges": {
-                  "maxCapacity": 1,
-                  "workingCapacity": 1,
-                  "certifiedNormalAccommodation": 1
-                },
-                "active": true,
-                "key": "${firstCell.getKey()}"
-              }
-          """,
-          JsonCompareMode.LENIENT,
-        )
-
-      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
-
-      val capacityChangedLocation = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!
+      val capacityChangedLocation = updateCapacity(cellInLeeds = firstCell.getPathHierarchy(), workingCapacity = 1, maxCapacity = 1, cna = 1, temporaryWorkingCapacityChange = false)
 
       assertThat(capacityChangedLocation.status).isEqualTo(DerivedLocationStatus.LOCKED_ACTIVE)
       assertThat(capacityChangedLocation.pendingApprovalRequestId).isNotNull
@@ -200,39 +145,8 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change capacity a location and request approval but be stopped by an addition prisoners being moved in`() {
-      // will return a prisoner for each location under the Leeds wing
-      leedsWing.findAllLeafLocations().forEach {
-        prisonerSearchMockServer.stubSearchByLocations(
-          leedsWing.prisonId,
-          listOf(it.getPathHierarchy()),
-          true,
-        )
-      }
       val firstCell = leedsWing.findAllLeafLocations().first()
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
-        .header("Content-Type", "application/json")
-        .bodyValue(
-          jsonString(
-            CapacityChangeRequest(
-              workingCapacity = 1,
-              maxCapacity = 1,
-              certifiedNormalAccommodation = 1,
-            ),
-          ),
-        )
-        .exchange()
-        .expectStatus().isOk
-
-      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
-
-      val pendingApprovalRequestId = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!.pendingApprovalRequestId!!
+      val pendingApprovalRequestId = updateCapacity(cellInLeeds = firstCell.getPathHierarchy(), workingCapacity = 1, maxCapacity = 1, cna = 1, temporaryWorkingCapacityChange = false).pendingApprovalRequestId!!
 
       prisonerSearchMockServer.resetAll()
       prisonerSearchMockServer.stubSearchByLocations(
@@ -277,39 +191,11 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change capacity a location and request withdrawal`() {
-      // will return a prisoner for each location under the Leeds wing
-      leedsWing.findAllLeafLocations().forEach {
-        prisonerSearchMockServer.stubSearchByLocations(
-          leedsWing.prisonId,
-          listOf(it.getPathHierarchy()),
-          true,
-        )
-      }
-      val firstCell = leedsWing.findAllLeafLocations().first()
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
-        .header("Content-Type", "application/json")
-        .bodyValue(
-          jsonString(
-            CapacityChangeRequest(
-              workingCapacity = 1,
-              maxCapacity = 1,
-              certifiedNormalAccommodation = 1,
-            ),
-          ),
-        )
-        .exchange()
-        .expectStatus().isOk
-
-      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
-
-      val pendingApprovalRequestId = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!.pendingApprovalRequestId!!
+      val firstCell = updateCapacity(
+        workingCapacity = 1,
+        maxCapacity = 1,
+        temporaryWorkingCapacityChange = false,
+      )
 
       val withdrawnRequest = webTestClient.put().uri("/certification/location/withdraw")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
@@ -317,7 +203,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         .bodyValue(
           jsonString(
             WithdrawCertificationRequestDto(
-              approvalRequestReference = pendingApprovalRequestId,
+              approvalRequestReference = firstCell.pendingApprovalRequestId!!,
               comments = "Do not approve this capacity change, it is not correct.",
             ),
           ),
@@ -347,15 +233,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change just working capacity a location and not require a request approval`() {
-      val firstCell = temporaryUpdateWorkingCapacity()
-
-      val capacityChangedLocation = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!
+      val capacityChangedLocation = updateCapacity()
 
       assertThat(capacityChangedLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
       assertThat(capacityChangedLocation.pendingApprovalRequestId).isNull()
@@ -367,51 +245,69 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change a working capacity to match a capacity on a certificate`() {
-      val firstCell = temporaryUpdateWorkingCapacity()
+      val firstCell = updateCapacity(workingCapacity = 2, maxCapacity = 2, temporaryWorkingCapacityChange = true)
+      assertThat(firstCell.pendingChanges).isNull()
+
       // Now reflect on the cert the same values
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+      val updatedCell = updateCapacity(workingCapacity = 2, maxCapacity = 2, temporaryWorkingCapacityChange = false)
+      assertThat(updatedCell.pendingChanges?.workingCapacity).isEqualTo(2)
+      assertThat(updatedCell.pendingChanges?.maxCapacity).isEqualTo(2)
+    }
+
+    @Test
+    fun `can change a working capacity to match a capacity on a certificate but not update existing temporary capacity changes`() {
+      // existing temp change on cell A-1-001
+      updateCapacity(cellInLeeds = "A-1-001", workingCapacity = 2, maxCapacity = 2, temporaryWorkingCapacityChange = true)
+
+      val oldCertificate = webTestClient.get().uri("/cell-certificates//prison/LEI/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      assertThat(oldCertificate.findLocationInCertificate("A-1-001")!!.workingCapacity).isEqualTo(1)
+      assertThat(oldCertificate.findLocationInCertificate("A-1-002")!!.workingCapacity).isEqualTo(1)
+
+      // change a different cell and request approval
+      val cellForApproval = updateCapacity(cellInLeeds = "A-1-002", workingCapacity = 2, maxCapacity = 2, cna = 1, temporaryWorkingCapacityChange = false)
+
+      val approvedRequest = webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
         .header("Content-Type", "application/json")
         .bodyValue(
           jsonString(
-            CapacityChangeRequest(
-              workingCapacity = 2,
-              maxCapacity = 2,
-              certifiedNormalAccommodation = 1,
+            ApproveCertificationRequestDto(
+              approvalRequestReference = cellForApproval.pendingApprovalRequestId!!,
             ),
           ),
         )
         .exchange()
         .expectStatus().isOk
-        .expectBody().json(
-          // language=json
-          """
-              {
-                "id": "${firstCell.id}",
-                "prisonId": "${firstCell.prisonId}",
-                "pathHierarchy": "${firstCell.getPathHierarchy()}",
-                "locationType": "CELL",
-                "capacity": {
-                  "maxCapacity": 2,
-                  "workingCapacity": 2,
-                  "certifiedNormalAccommodation": 1
-                },
-                "pendingChanges": {
-                  "maxCapacity": 2,
-                  "workingCapacity": 2,
-                  "certifiedNormalAccommodation": 1
-                },
-                "active": true,
-                "key": "${firstCell.getKey()}"
-              }
-          """,
-          JsonCompareMode.LENIENT,
-        )
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
 
-      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
+      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isEqualTo(3)
+      getDomainEvents(3)
+
+      val certificate = webTestClient.get().uri("/cell-certificates//prison/LEI/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      assertThat(certificate.findLocationInCertificate("A-1-001")!!.workingCapacity).isEqualTo(1)
+      assertThat(certificate.findLocationInCertificate("A-1-002")!!.workingCapacity).isEqualTo(2)
     }
 
-    private fun temporaryUpdateWorkingCapacity(workingCapacity: Int = 2): uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location {
+    private fun updateCapacity(
+      cellInLeeds: String? = null,
+      workingCapacity: Int = 2,
+      maxCapacity: Int = 2,
+      temporaryWorkingCapacityChange: Boolean = true,
+      cna: Int = 1,
+    ): Location {
       // will return a prisoner for each location under the Leeds wing
       leedsWing.findAllLeafLocations().forEach {
         prisonerSearchMockServer.stubSearchByLocations(
@@ -420,49 +316,42 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
           true,
         )
       }
-      val firstCell = leedsWing.findAllLeafLocations().first()
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
+      val cellToChange = cellInLeeds?.let { cellPath -> leedsWing.findLocation("LEI-$cellPath") } ?: leedsWing.findAllLeafLocations().first()
+      webTestClient.put().uri("/locations/${cellToChange.id}/capacity")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           jsonString(
             CapacityChangeRequest(
               workingCapacity = workingCapacity,
-              maxCapacity = 2,
-              certifiedNormalAccommodation = 1,
-              temporaryWorkingCapacityChange = true,
+              maxCapacity = maxCapacity,
+              certifiedNormalAccommodation = cna,
+              temporaryWorkingCapacityChange = temporaryWorkingCapacityChange,
             ),
           ),
         )
         .exchange()
         .expectStatus().isOk
-        .expectBody().json(
-          // language=json
-          """
-                  {
-                    "id": "${firstCell.id}",
-                    "prisonId": "${firstCell.prisonId}",
-                    "pathHierarchy": "${firstCell.getPathHierarchy()}",
-                    "locationType": "CELL",
-                    "capacity": {
-                      "maxCapacity": 2,
-                      "workingCapacity": 2,
-                      "certifiedNormalAccommodation": 1
-                    },
-                    "active": true,
-                    "key": "${firstCell.getKey()}"
-                  }
-              """,
-          JsonCompareMode.LENIENT,
-        )
 
-      getDomainEvents(3).let {
-        assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
-          "location.inside.prison.amended" to firstCell.getKey(),
-          *firstCell.getParentLocations().map { "location.inside.prison.amended" to it.getKey() }.toTypedArray(),
-        )
+      if (temporaryWorkingCapacityChange) {
+        getDomainEvents(3).let {
+          assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
+            "location.inside.prison.amended" to cellToChange.getKey(),
+            *cellToChange.getParentLocations().map { location -> "location.inside.prison.amended" to location.getKey() }
+              .toTypedArray(),
+          )
+        }
+      } else {
+        assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
       }
-      return firstCell
+
+      return webTestClient.get().uri("/locations/${cellToChange.id}?includeCurrentCertificate=true")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
     }
   }
 


### PR DESCRIPTION

## Summary

When a cell certificate change is approved, the newly created certificate was rebuilt from the **current** state of every location in the prison. This meant that any location whose live state had drifted from the previous certificate — for example, a cell whose working capacity had been temporarily reduced and which was therefore deliberately *not* included in the approval request — would silently have that drifted state baked into the new certificate.

This fix ensures that only locations that are part of the approval request's hierarchy contribute fresh values to the new certificate. Every other location is copied verbatim from the previous current certificate, so unrelated temporary changes are preserved (i.e. left out of the certified state) until they are themselves submitted for approval.

## Problem

The certificate-generation flow walked every top-level residential location in the prison and called `toCellCertificateLocation(...)` on each one, recursively building a snapshot. Inside that method, the new snapshot always used live values from the JPA entity (`calcWorkingCapacity()`, `calcMaxCapacity()`, etc.).

Concrete failure mode:

1. Cell `A-1-001` has its working capacity temporarily reduced from `2 → 1` (no approval required — this is a temporary working-capacity change).
2. The current cell certificate still records `A-1-001` at working capacity `2`, which is correct — the temporary change should not appear on the certificate.
3. A separate, **unrelated** change is made to cell `A-1-002` and submitted for approval.
4. When that approval is granted, the new certificate is generated from live state. `A-1-001` is now picked up at working capacity `1`, and the temporary change is incorrectly promoted into the certified record.

## Fix

`ResidentialLocation.toCellCertificateLocation(...)` now also receives the previous current `CellCertificate`. For each location it visits:

- If the location **is** part of the approval request's hierarchy (or there is no matching entry in the existing certificate), the new snapshot is built from live values as before.
- Otherwise, the entry from the previous certificate is cloned and reattached to the new tree, preserving sub-location structure.

Supporting changes:

- `CellCertificate.findLocationInCertificate(pathHierarchy)` and a private `findAllLocations()` traverse the certificate's location tree to look up an existing entry by path.
- `CellCertificateLocation.clone(subLocations)` produces a deep-ish copy that swaps in the freshly computed sub-locations (which themselves recursively follow the same preserve-or-rebuild rule).
- `draftApprovalLocationIsPartOfHierarchy(...)` (which previously only handled `DRAFT` approval types) has been renamed and generalised to `approvalLocationIsPartOfHierarchy(...)`, working against any `LocationCertificationApprovalRequest`. The temporary-working-capacity-ignoring branch in the snapshot still applies for `DraftChangeApprovalRequest`.
- In `CellCertificateService.createCellCertificate(...)`, the previous current certificate is now resolved **before** the new one is built (so it can be passed in) and only marked as not-current **after** the new one is saved. The transactional outcome is unchanged.
- `CellCertificateDto` gains a matching `findLocationInCertificate(...)` helper to support assertions in tests.

## Tests

`CertificationApprovalResourceTest` has been refactored to use a shared `updateCapacity(...)` helper that consolidates the prisoner-search stubbing, capacity PUT, optional domain-event assertions, and final location read. The existing tests have been ported onto it, and a new test has been added:

`can change a working capacity to match a capacity on a certificate but not update existing temporary capacity changes`

This:

1. Applies a temporary working-capacity change to `A-1-001` (cert still shows `2`).
2. Asserts the current certificate has both `A-1-001` and `A-1-002` at working capacity `1` (the original certified state).
3. Applies a non-temporary capacity change to `A-1-002` and approves it.
4. Asserts the new current certificate has `A-1-001` still at `1` (preserved from the previous certificate) and `A-1-002` updated to `2`.

## Test plan

- [x] `./gradlew test` passes locally
- [x] `CertificationApprovalResourceTest` passes, including the new preservation test
- [ ] Manual check: apply a temporary working-capacity change to one cell, then submit & approve an unrelated capacity change on another cell; confirm the temporary change does not leak onto the new certificate
- [ ] Manual check: approving a change whose hierarchy **does** include a location still updates that location's values on the certificate
