### PR TITLE
MAPB-311: Allow filtering non-residential locations by multiple service families

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
@@ -710,15 +710,27 @@ class LocationNonResidentialResource(
     )
     @RequestParam(required = false)
     locationType: List<NonResidentialLocationType>? = null,
-    @Schema(description = "Service Type", example = "ACTIVITIES_APPOINTMENTS", required = false)
-    @Parameter(description = "Filter by service family", example = "ACTIVITIES_APPOINTMENTS", required = false)
-    serviceFamilyType: ServiceFamilyType? = null,
+    @Schema(description = "Filter by given service families", example = "[ACTIVITIES_APPOINTMENTS,ADJUDICATIONS]", required = false)
+    @Parameter(
+      description = "Filter by service family",
+      example = "[ACTIVITIES_APPOINTMENTS,ADJUDICATIONS]",
+      array = ArraySchema(
+        schema = Schema(implementation = ServiceFamilyType::class),
+        arraySchema = Schema(
+          requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+          nullable = true,
+          defaultValue = "null",
+        ),
+      ),
+    )
+    @RequestParam(required = false)
+    serviceFamilyType: List<ServiceFamilyType>? = null,
     @ParameterObject
     @PageableDefault(page = 0, size = 100, sort = ["localName"], direction = Sort.Direction.ASC)
     pageable: Pageable,
   ): NonResidentialSummary = nonResidentialService.getNonResidentialLocationSummaryForPrison(
     prisonId = prisonId,
-    serviceFamilyType = serviceFamilyType,
+    serviceFamilyTypes = serviceFamilyType ?: emptyList(),
     pageable = pageable,
     statuses = status,
     locationTypes = locationType ?: emptyList(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -416,7 +416,7 @@ class NonResidentialService(
   fun getNonResidentialLocationSummaryForPrison(
     prisonId: String,
     statuses: List<LocationStatus> = emptyList(),
-    serviceFamilyType: ServiceFamilyType? = null,
+    serviceFamilyTypes: List<ServiceFamilyType> = emptyList(),
     searchByLocalName: String? = null,
     filterParents: Boolean = false,
     includeBoxes: Boolean = false,
@@ -437,9 +437,9 @@ class NonResidentialService(
         searchByLocalName?.let {
           add(filterByLocalName(it))
         }
-        serviceFamilyType?.let {
-          add(filterByServiceTypes(it.getServiceTypes()))
-          if (!filterParents && !it.editableInParent) {
+        if (serviceFamilyTypes.isNotEmpty()) {
+          add(filterByServiceTypes(serviceFamilyTypes.flatMap { it.getServiceTypes() }.distinct()))
+          if (!filterParents && serviceFamilyTypes.all { !it.editableInParent }) {
             add(filterByIsLeaf())
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
@@ -1904,6 +1904,19 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
       }
 
       @Test
+      fun `can retrieve non-residential locations for multiple service families`() {
+        webTestClient.get()
+          .uri("/locations/non-residential/summary/${wingZ.prisonId}?serviceFamilyType=OFFICIAL_VISITS,ADJUDICATIONS")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.locations.content[?(@.localName == 'Visit Room')]").exists()
+          .jsonPath("$.locations.content[?(@.localName == 'Adjudication Room')]").exists()
+      }
+
+      @Test
       fun `can retrieve a particular page of locations`() {
         webTestClient.get().uri("/locations/non-residential/summary/${wingZ.prisonId}?size=1&page=1")
           .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))


### PR DESCRIPTION
## Summary

The `serviceFamilyType` query param on `GET /locations/non-residential/summary/{prisonId}` only accepted a single value, so the non-residential-locations-ui multi-select service filter returned a 400 error whenever more than one service family was chosen.

- `serviceFamilyType` is now a `List<ServiceFamilyType>`, consistent with the existing `status` and `locationType` array params on the same endpoint.
- Filtering uses the union of the selected families' service types.
- The leaf-level filter is applied only when every selected family is `!editableInParent`, which preserves the existing single-value behaviour exactly.
- Existing single-value callers (and `?serviceFamilyType=A` URLs) are unaffected — they bind to a one-element list.