### PR TITLE
MAPA-103: Specialist cell type changes require approval when cert approval is active  

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDto.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.UsedForType
 import java.time.LocalDateTime
 import java.util.UUID
+import kotlin.collections.forEach
 
 @Schema(description = "Cell Certificate")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -48,7 +49,25 @@ data class CellCertificateDto(
 
   @param:Schema(description = "Locations in the certificate", required = true)
   val locations: List<CellCertificateLocationDto>? = null,
-)
+) {
+  fun findLocationInCertificate(pathHierarchy: String) = findAllLocations().firstOrNull { it.pathHierarchy == pathHierarchy }
+
+  private fun findAllLocations(): List<CellCertificateLocationDto> {
+    val subLocations = mutableListOf<CellCertificateLocationDto>()
+
+    fun traverse(location: CellCertificateLocationDto) {
+      subLocations.add(location)
+      if (location.subLocations != null) {
+        for (childLocation in location.subLocations) {
+          traverse(childLocation)
+        }
+      }
+    }
+
+    locations?.forEach { traverse(it) }
+    return subLocations
+  }
+}
 
 @Schema(description = "Cell Certificate Location")
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestDto.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.InternalLocationDomainEventType
@@ -110,6 +111,12 @@ data class CertificationApprovalRequestDto(
 
   @param:Schema(description = "Planet FM reference number", example = "2323/45M", required = false)
   val planetFmReference: String? = null,
+
+  @param:Schema(description = "Proposed new specialist cell types for this approval", required = false)
+  val specialistCellTypes: Set<SpecialistCellType>? = null,
+
+  @param:Schema(description = "Current specialist cell types before this approval", required = false)
+  val currentSpecialistCellTypes: Set<SpecialistCellType>? = null,
 )
 
 @Schema(description = "Request to approve a certification request")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CreateEntireWingRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CreateEntireWingRequest.kt
@@ -66,7 +66,13 @@ data class CreateEntireWingRequest(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun toEntity(createdBy: String, clock: Clock, linkedTransaction: LinkedTransaction, createInDraft: Boolean = false): ResidentialLocation {
+  fun toEntity(
+    createdBy: String,
+    clock: Clock,
+    linkedTransaction: LinkedTransaction,
+    createInDraft: Boolean = false,
+    specialistCellType: SpecialistCellType? = null,
+  ): ResidentialLocation {
     val status = if (createInDraft) LocationStatus.DRAFT else LocationStatus.ACTIVE
     val wing = ResidentialLocation(
       prisonId = prisonId,
@@ -175,7 +181,7 @@ data class CreateEntireWingRequest(
           certifiedCell = status != LocationStatus.DRAFT,
         ).apply {
           addUsedFor(UsedForType.STANDARD_ACCOMMODATION, createdBy, clock, linkedTransaction = linkedTransaction)
-          addSpecialistCellType(SpecialistCellType.ESCAPE_LIST, linkedTransaction = linkedTransaction, userOrSystemInContext = createdBy, clock = clock)
+          specialistCellType?.let { addSpecialistCellType(it, linkedTransaction = linkedTransaction, userOrSystemInContext = createdBy, clock = clock) }
           leaf.addChildLocation(this)
 
           addHistory(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.Ce
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.DraftChangeApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.LocationCertificationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.SanitationChangeApprovalRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.SpecialistCellTypeChangeApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ChangesCannotBeMadeWithoutCertificationApprovalException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationResidentialResource.AllowedAccommodationTypeForConversion
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PendingApprovalAlreadyExistsException
@@ -650,6 +651,32 @@ class Cell(
         currentInCellSanitation = inCellSanitation,
       ),
     ) as SanitationChangeApprovalRequest
+  }
+
+  fun requestApprovalForSpecialistCellTypeChange(
+    requestedDate: LocalDateTime,
+    requestedBy: String,
+    newSpecialistCellTypes: Set<SpecialistCellType>,
+    workingCapacity: Int,
+    maxCapacity: Int,
+    certifiedNormalAccommodation: Int,
+    reasonForChange: String?,
+  ): SpecialistCellTypeChangeApprovalRequest {
+    if (hasPendingCertificationApproval()) {
+      throw PendingApprovalAlreadyExistsException(getKey())
+    }
+    return addApprovalToLocation(
+      SpecialistCellTypeChangeApprovalRequest(
+        location = this,
+        requestedBy = requestedBy,
+        requestedDate = requestedDate,
+        reasonForChange = reasonForChange,
+        specialistCellTypes = newSpecialistCellTypes.joinToString(",") { it.name },
+        workingCapacity = workingCapacity,
+        maxCapacity = maxCapacity,
+        certifiedNormalAccommodation = certifiedNormalAccommodation,
+      ),
+    ) as SpecialistCellTypeChangeApprovalRequest
   }
 
   override fun toDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -164,7 +164,7 @@ open class CellCertificateLocation(
   @Enumerated(EnumType.STRING)
   private val locationType: LocationType,
 
-  open val specialistCellTypes: String? = null,
+  open var specialistCellTypes: String? = null,
 
   private val usedForTypes: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -85,6 +85,22 @@ open class CellCertificate(
 ) {
   override fun toString(): String = "CellCertificate(prisonId='$prisonId', certificationApprovalRequest=$certificationApprovalRequest, current=$current)"
 
+  fun findLocationInCertificate(pathHierarchy: String) = findAllLocations().firstOrNull { it.pathHierarchy == pathHierarchy }
+
+  private fun findAllLocations(): List<CellCertificateLocation> {
+    val subLocations = mutableListOf<CellCertificateLocation>()
+
+    fun traverse(location: CellCertificateLocation) {
+      subLocations.add(location)
+      for (childLocation in location.subLocations) {
+        traverse(childLocation)
+      }
+    }
+
+    locations.forEach { traverse(it) }
+    return subLocations
+  }
+
   fun markAsNotCurrent() {
     current = false
   }
@@ -161,7 +177,7 @@ open class CellCertificateLocation(
   @OneToMany(fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinColumn(name = "parent_location_id")
   @SortNatural
-  private val subLocations: SortedSet<CellCertificateLocation> = sortedSetOf(),
+  val subLocations: SortedSet<CellCertificateLocation> = sortedSetOf(),
 
 ) : Comparable<CellCertificateLocation> {
 
@@ -206,4 +222,21 @@ open class CellCertificateLocation(
   private fun getUsedForTypesFromList(): List<UsedForType>? = usedForTypes?.split(",")?.map { UsedForType.valueOf(it.trim()) }
 
   private fun getAccommodationTypesFromList(): List<AccommodationType>? = accommodationTypes?.split(",")?.map { AccommodationType.valueOf(it.trim()) }
+
+  fun clone(subLocations: SortedSet<CellCertificateLocation>): CellCertificateLocation = CellCertificateLocation(
+    pathHierarchy = pathHierarchy,
+    locationCode = locationCode,
+    locationType = locationType,
+    cellMark = cellMark,
+    localName = localName,
+    level = level,
+    certifiedNormalAccommodation = certifiedNormalAccommodation,
+    workingCapacity = workingCapacity,
+    maxCapacity = maxCapacity,
+    inCellSanitation = inCellSanitation,
+    specialistCellTypes = specialistCellTypes,
+    accommodationTypes = accommodationTypes,
+    usedForTypes = usedForTypes,
+    subLocations = subLocations,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -500,54 +500,54 @@ open class ResidentialLocation(
     return this
   }
 
-  fun toCellCertificateLocation(approvalRequest: CertificationApprovalRequest): CellCertificateLocation {
+  fun toCellCertificateLocation(approvalRequest: CertificationApprovalRequest, currentCellCertificate: CellCertificate?): CellCertificateLocation {
     val subLocations: List<CellCertificateLocation> = getResidentialLocationsBelowThisLevel()
       .filter { !it.isDraft() && (it.isStructural() || it.isCell() || it.isConvertedCell()) }
-      .map { it.toCellCertificateLocation(approvalRequest) }
+      .map { it.toCellCertificateLocation(approvalRequest, currentCellCertificate) }
 
-    return CellCertificateLocation(
-      locationType = locationType,
-      locationCode = getLocationCode(),
-      pathHierarchy = getPathHierarchy(),
-      localName = localName?.capitalizeWords(),
-      cellMark = if (this is Cell) {
-        getDoorCellMark()
-      } else {
-        null
-      },
-      level = getLevel(),
-      inCellSanitation = if (this is Cell) {
-        getSanitationOfCell()
-      } else {
-        null
-      },
-      maxCapacity = calcMaxCapacity(),
-      workingCapacity = if (draftApprovalLocationIsPartOfHierarchy(approvalRequest)) {
-        getWorkingCapacityIgnoringInactiveStatus()
-      } else {
-        calcWorkingCapacity()
-      },
-      certifiedNormalAccommodation = calcCertifiedNormalAccommodation(),
-      usedForTypes = getUsedForValuesAsCSV(),
-      accommodationTypes = getAccommodationTypesAsCSV(),
-      specialistCellTypes = getSpecialistCellTypesAsCSV(),
-      convertedCellType = if (this is Cell && isConvertedCell()) {
-        convertedCellType
-      } else {
-        null
-      },
-      subLocations = subLocations.toSortedSet(),
-    )
+    val locationInExistingCertificate = currentCellCertificate?.findLocationInCertificate(getPathHierarchy())
+    if (approvalLocationIsPartOfHierarchy(approvalRequest) || locationInExistingCertificate == null) {
+      return CellCertificateLocation(
+        locationType = locationType,
+        locationCode = getLocationCode(),
+        pathHierarchy = getPathHierarchy(),
+        localName = localName?.capitalizeWords(),
+        cellMark = if (this is Cell) {
+          getDoorCellMark()
+        } else {
+          null
+        },
+        level = getLevel(),
+        inCellSanitation = if (this is Cell) {
+          getSanitationOfCell()
+        } else {
+          null
+        },
+        maxCapacity = calcMaxCapacity(),
+        workingCapacity = if (approvalRequest is DraftChangeApprovalRequest) {
+          getWorkingCapacityIgnoringInactiveStatus()
+        } else {
+          calcWorkingCapacity()
+        },
+        certifiedNormalAccommodation = calcCertifiedNormalAccommodation(),
+        usedForTypes = getUsedForValuesAsCSV(),
+        accommodationTypes = getAccommodationTypesAsCSV(),
+        specialistCellTypes = getSpecialistCellTypesAsCSV(),
+        convertedCellType = if (this is Cell && isConvertedCell()) {
+          convertedCellType
+        } else {
+          null
+        },
+        subLocations = subLocations.toSortedSet(),
+      )
+    } else {
+      return locationInExistingCertificate.clone(subLocations.toSortedSet())
+    }
   }
 
-  private fun draftApprovalLocationIsPartOfHierarchy(approvalRequest: CertificationApprovalRequest): Boolean = if (approvalRequest.getApprovalType() == ApprovalType.DRAFT) {
-    val locationRequest = approvalRequest as? DraftChangeApprovalRequest
-    locationRequest?.location?.let { location ->
-      isInHierarchy(location) || findLocation(location.getKey()) != null
-    } ?: false
-  } else {
-    false
-  }
+  fun approvalLocationIsPartOfHierarchy(approvalRequest: CertificationApprovalRequest) = (approvalRequest as? LocationCertificationApprovalRequest)?.location?.let { location ->
+    isInHierarchy(location) || findLocation(location.getKey()) != null
+  } ?: false
 
   fun toCertificationApprovalRequestLocation(includeDraftOrPending: Boolean = false, reactivation: Boolean = false, deactivation: Boolean = false): CertificationApprovalRequestLocation {
     val subLocations: List<CertificationApprovalRequestLocation> = getResidentialLocationsBelowThisLevel()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequest.kt
@@ -177,5 +177,6 @@ enum class ApprovalType(
   CELL_SANITATION(true),
   REACTIVATION,
   CAPACITY_CHANGE(true),
+  SPECIALIST_CELL_TYPE(true),
   PRISON_BASELINE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/SpecialistCellTypeChangeApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/SpecialistCellTypeChangeApprovalRequest.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest
+
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@DiscriminatorValue("SPECIALIST_CELL_TYPE")
+open class SpecialistCellTypeChangeApprovalRequest(
+  id: UUID? = null,
+  location: Cell,
+  requestedBy: String,
+  requestedDate: LocalDateTime,
+  reasonForChange: String? = null,
+
+  @Column(name = "pending_specialist_cell_types", nullable = true)
+  open var specialistCellTypes: String,
+
+  @Column(nullable = true)
+  open var workingCapacity: Int,
+
+  @Column(nullable = true)
+  open var maxCapacity: Int,
+
+  @Column(nullable = true)
+  open var certifiedNormalAccommodation: Int,
+
+) : LocationCertificationApprovalRequest(
+  id = id,
+  location = location,
+  locationKey = location.getKey(),
+  requestedBy = requestedBy,
+  requestedDate = requestedDate,
+  reasonForChange = reasonForChange,
+) {
+  fun getSpecialistCellTypesFromPendingList(): List<SpecialistCellType> = specialistCellTypes
+    .split(",")
+    .filter { it.isNotBlank() }
+    .map { SpecialistCellType.valueOf(it.trim()) }
+
+  override fun toDto(showLocations: Boolean, cellCertificateId: UUID?) = super.toDto(showLocations, cellCertificateId).copy(
+    specialistCellTypes = getSpecialistCellTypesFromPendingList().toSet(),
+    currentSpecialistCellTypes = getTopLevelLocation()?.getSpecialistCellTypesFromList()?.toSet(),
+    workingCapacity = workingCapacity,
+    maxCapacity = maxCapacity,
+    certifiedNormalAccommodation = certifiedNormalAccommodation,
+  )
+
+  override fun getApprovalType() = ApprovalType.SPECIALIST_CELL_TYPE
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
@@ -580,6 +580,36 @@ class ApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(SpecialistCellTypeChangesRequireCertificationApprovalException::class)
+  fun handleSpecialistCellTypeChangesRequireCertificationApprovalException(e: SpecialistCellTypeChangesRequireCertificationApprovalException): ResponseEntity<ErrorResponse> {
+    log.debug("Specialist cell type changes require certification approval: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          errorCode = ErrorCode.SpecialistCellTypeChangesRequireCertificationApproval,
+          userMessage = "Adding or removing specialist cell types that affect capacity requires certification approval: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(SpecialistCellTypeChangesDoNotRequireApprovalException::class)
+  fun handleSpecialistCellTypeChangesDoNotRequireApprovalException(e: SpecialistCellTypeChangesDoNotRequireApprovalException): ResponseEntity<ErrorResponse> {
+    log.debug("Specialist cell type changes do not require approval: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          errorCode = ErrorCode.SpecialistCellTypeChangesRequireCertificationApproval,
+          userMessage = "This specialist cell type change does not require approval: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
   @ExceptionHandler(ApprovalRequiredAboveThisLevelException::class)
   fun handleApprovalRequiredAboveThisLevelException(e: ApprovalRequiredAboveThisLevelException): ResponseEntity<ErrorResponse> {
     log.debug("Approval request at wrong level: {}", e.message)
@@ -661,3 +691,5 @@ class ApprovalRequiredAboveThisLevelException(key: String, parentKey: String) : 
 class LocationCannotBeCreatedWithPendingApprovalException(key: String) : Exception("Location $key cannot be created")
 class ApprovalRequestRequiresReasonForChangeException(key: String) : Exception("Approval request for $key requires a reason for change")
 class ChangesCannotBeMadeWithoutCertificationApprovalException(key: String) : Exception("Changes cannot be made to $key without certification approval")
+class SpecialistCellTypeChangesRequireCertificationApprovalException(key: String) : Exception("Adding or removing specialist cell types that affect capacity for $key requires certification approval - use the specialist cell type change approval endpoint")
+class SpecialistCellTypeChangesDoNotRequireApprovalException(key: String) : Exception("The specialist cell type change for $key does not require approval - the count of capacity-affecting specialist cell types is not changing")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApprovalRequestResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApprovalRequestResource.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.service.InternalLocati
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.ReactivationLocationsApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.SignedOpCapApprovalRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.SpecialistCellTypeApprovalRequest
 import java.util.*
 
 @RestController
@@ -160,6 +161,45 @@ class ApprovalRequestResource(
     signedOpCapApprovalRequest: SignedOpCapApprovalRequest,
   ): CertificationApprovalRequestDto = approvalRequestService.requestSignedOpCapApproval(
     signedOpCapApprovalRequest,
+  )
+
+  @PutMapping("/location/specialist-cell-type-change")
+  @Operation(
+    summary = "Requests approval for a specialist cell type change on a cell, including associated capacity changes",
+    description = "Requires role LOCATION_CERTIFICATION. Use this endpoint when adding or removing specialist cell types that affect capacity (affectsCapacity=true). Changes to non-capacity-affecting types or swaps between capacity-affecting types do not require approval and should use the direct specialist-cell-types endpoint.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns the approval request",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid Request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the LOCATION_CERTIFICATION role.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Location not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun requestSpecialistCellTypeChangeApproval(
+    @RequestBody
+    @Validated
+    specialistCellTypeApprovalRequest: SpecialistCellTypeApprovalRequest,
+  ): CertificationApprovalRequestDto = approvalRequestService.requestSpecialistCellTypeChangeApproval(
+    specialistCellTypeApprovalRequest,
   )
 
   @PutMapping("/location/approve")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
@@ -41,4 +41,5 @@ enum class ErrorCode(val errorCode: Int) {
   DuplicateCellMarkAtSameLevel(132),
   ApprovalRequestRequiresReasonForChange(133),
   ChangesCannotBeMadeWithoutCertificationApproval(134),
+  SpecialistCellTypeChangesRequireCertificationApproval(135),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalDecisionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalDecisionService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Capacity
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.RejectCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.WithdrawCertificationRequestDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
@@ -21,6 +22,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.Ce
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.LocationCertificationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.PrisonBaselineApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ReactivationApprovalRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.SpecialistCellTypeChangeApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CertificationApprovalRequestRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.ResidentialLocationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.SignedOperationCapacityRepository
@@ -134,6 +136,10 @@ class ApprovalDecisionService(
       handleCapacityChange(approvalRequest, linkedTransaction)
     }
 
+    is SpecialistCellTypeChangeApprovalRequest -> {
+      handleSpecialistCellTypeChange(approvalRequest, linkedTransaction)
+    }
+
     else -> {
       null
     }
@@ -165,6 +171,42 @@ class ApprovalDecisionService(
 
     return mapOf(
       InternalLocationDomainEventType.LOCATION_AMENDED to listOf(approvalRequest.location.toDto(includeParent = true)),
+    )
+  }
+
+  private fun handleSpecialistCellTypeChange(
+    approvalRequest: SpecialistCellTypeChangeApprovalRequest,
+    linkedTransaction: LinkedTransaction,
+  ): Map<InternalLocationDomainEventType, List<LocationDTO>> {
+    val cell = approvalRequest.location as Cell
+    val prisoners = prisonerLocationService.prisonersInLocations(cell)
+    val newMaxCap = approvalRequest.maxCapacity
+    if (newMaxCap < prisoners.size) {
+      throw CapacityException(
+        cell.getKey(),
+        "Max capacity ($newMaxCap) cannot be decreased below current cell occupancy (${prisoners.size})",
+        ErrorCode.MaxCapacityCannotBeBelowOccupancyLevel,
+      )
+    }
+
+    cell.updateSpecialistCellTypes(
+      approvalRequest.getSpecialistCellTypesFromPendingList().toSet(),
+      approvalRequest.requestedBy,
+      clock,
+      linkedTransaction,
+    )
+
+    cell.setCapacity(
+      maxCapacity = approvalRequest.maxCapacity,
+      workingCapacity = approvalRequest.workingCapacity,
+      certifiedNormalAccommodation = approvalRequest.certifiedNormalAccommodation,
+      userOrSystemInContext = approvalRequest.requestedBy,
+      amendedDate = linkedTransaction.txStartTime,
+      linkedTransaction = linkedTransaction,
+    )
+
+    return mapOf(
+      InternalLocationDomainEventType.LOCATION_AMENDED to listOf(cell.toDto(includeParent = true)),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
@@ -9,11 +9,13 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.InactiveStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequestLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ReactivationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellLocationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CertificationApprovalRequestRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.ResidentialLocationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.SignedOperationCapacityRepository
@@ -23,6 +25,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationCanno
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationDoesNotRequireApprovalException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PendingApprovalAlreadyExistsException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.SpecialistCellTypeChangesDoNotRequireApprovalException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.ApprovalDecisionService.Companion.log
 import java.time.Clock
 import java.time.LocalDateTime.now
@@ -35,6 +38,7 @@ import kotlin.collections.component2
 class ApprovalRequestService(
   private val certificationApprovalRequestRepository: CertificationApprovalRequestRepository,
   private val residentialLocationRepository: ResidentialLocationRepository,
+  private val cellLocationRepository: CellLocationRepository,
   private val signedOperationCapacityRepository: SignedOperationCapacityRepository,
   private val signedOperationCapacityService: SignedOperationCapacityService,
   private val activePrisonService: ActivePrisonService,
@@ -240,6 +244,58 @@ class ApprovalRequestService(
       linkedTransaction.txEndTime = now(clock)
     }
   }
+
+  fun requestSpecialistCellTypeChangeApproval(request: SpecialistCellTypeApprovalRequest): CertificationApprovalRequestDto {
+    val cell = cellLocationRepository.findById(request.locationId)
+      .orElseThrow { LocationNotFoundException(request.locationId.toString()) }
+
+    val approvalRequired = activePrisonService.isCertificationApprovalRequired(cell.prisonId)
+    if (!approvalRequired) {
+      throw LocationDoesNotRequireApprovalException("Certification approval not required for location ${cell.getKey()}")
+    }
+
+    val currentNumSpecialistTypes = cell.getSpecialistCellTypesForCell().count { it.affectsCapacity }
+    val newNumSpecialistTypes = request.specialistCellTypes.count { it.affectsCapacity }
+    if (currentNumSpecialistTypes == newNumSpecialistTypes) {
+      throw SpecialistCellTypeChangesDoNotRequireApprovalException(cell.getKey())
+    }
+
+    val linkedTransaction = sharedLocationService.createLinkedTransaction(
+      prisonId = cell.prisonId,
+      type = TransactionType.APPROVE_CERTIFICATION_REQUEST,
+      detail = "Requesting specialist cell type change approval for location ${cell.getKey()}",
+    )
+    val username = sharedLocationService.getUsername()
+    val now = now(clock)
+
+    val approvalRequest = certificationApprovalRequestRepository.save(
+      cell.requestApprovalForSpecialistCellTypeChange(
+        requestedDate = now,
+        requestedBy = username,
+        newSpecialistCellTypes = request.specialistCellTypes,
+        workingCapacity = request.workingCapacity,
+        maxCapacity = request.maxCapacity,
+        certifiedNormalAccommodation = request.certifiedNormalAccommodation,
+        reasonForChange = request.reasonForChange,
+      ),
+    )
+
+    telemetryClient.trackEvent(
+      "specialist-cell-type-change-approval-requested",
+      mapOf(
+        "id" to approvalRequest.id.toString(),
+        "locationKey" to cell.getKey(),
+        "requestedBy" to username,
+        "approvalRequestId" to approvalRequest.id.toString(),
+      ),
+      null,
+    )
+
+    log.info("Specialist cell type change approval requested (${approvalRequest.id}) for location ${cell.getKey()} by $username")
+    return approvalRequest.toDto(showLocations = true).also {
+      linkedTransaction.txEndTime = now(clock)
+    }
+  }
 }
 
 @Schema(description = "Request to approve a location or set of locations and cells below it")
@@ -295,4 +351,26 @@ data class SignedOpCapApprovalRequest(
 
   @param:Schema(description = "Explanation of why the signed op cap is changing", example = "The size of the prison has changed", required = true)
   val reasonForChange: String,
+)
+
+@Schema(description = "Request to approve a specialist cell type change for a cell, including associated capacity changes")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class SpecialistCellTypeApprovalRequest(
+  @param:Schema(description = "The cell location Id requiring approval for specialist cell type change", example = "2475f250-434a-4257-afe7-b911f1773a4d", required = true)
+  val locationId: UUID,
+
+  @param:Schema(description = "The new set of specialist cell types for the cell", example = "[\"BIOHAZARD_DIRTY_PROTEST\"]", required = true)
+  val specialistCellTypes: Set<SpecialistCellType>,
+
+  @param:Schema(description = "New working capacity for the cell (0 is valid for specialist cells)", example = "0", required = true)
+  val workingCapacity: Int,
+
+  @param:Schema(description = "New maximum capacity for the cell", example = "1", required = true)
+  val maxCapacity: Int,
+
+  @param:Schema(description = "New certified normal accommodation value", example = "0", required = true)
+  val certifiedNormalAccommodation: Int,
+
+  @param:Schema(description = "Explanation of why the specialist cell type is changing", required = false)
+  val reasonForChange: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -30,8 +30,7 @@ class CellCertificateService(
     approvalRequest: CertificationApprovalRequest,
     signedOperationCapacity: Int,
   ): CellCertificateDto {
-    // Mark any existing current certificates as not current
-    cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(approvalRequest.prisonId)?.markAsNotCurrent()
+    val currentCellCertificate = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(approvalRequest.prisonId)
 
     // Create the cell certificate
     val cellCertificate = cellCertificateRepository.saveAndFlush(
@@ -44,7 +43,7 @@ class CellCertificateService(
         locations = residentialLocationRepository.findAllByPrisonIdAndParentIsNull(approvalRequest.prisonId)
           .filter { !it.isPermanentlyDeactivated() && !it.isDraft() && it.isStructural() }
           .map {
-            it.toCellCertificateLocation(approvalRequest)
+            it.toCellCertificateLocation(approvalRequest, currentCellCertificate)
           }.toSortedSet(),
       ).apply {
         totalWorkingCapacity = locations.sumOf { it.workingCapacity ?: 0 }
@@ -52,6 +51,8 @@ class CellCertificateService(
         totalCertifiedNormalAccommodation = locations.sumOf { it.certifiedNormalAccommodation ?: 0 }
       },
     )
+    // Mark any existing current certificates as not current
+    currentCellCertificate?.markAsNotCurrent()
 
     log.info("Created cell certificate for prison ${approvalRequest.prisonId} with ID ${cellCertificate.id}")
     return cellCertificate.toDto()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.CellCertificate
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateRepository
@@ -70,5 +71,12 @@ class CellCertificateService(
     val cellCertificate = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(prisonId)
       ?: throw CurrentCellCertificateNotFoundException(prisonId)
     return cellCertificate.toDto(showLocations = true)
+  }
+
+  fun updateSpecialistCellTypesInCurrentCertificate(cell: Cell) {
+    val currentCert = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(cell.prisonId) ?: return
+    currentCert.findLocationInCertificate(cell.getPathHierarchy())?.let { certLocation ->
+      certLocation.specialistCellTypes = cell.getSpecialistCellTypesAsCSV()
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -890,9 +890,9 @@ class LocationService(
 
     val certificationApprovalRequired = activePrisonService.isCertificationApprovalRequired(cell.prisonId)
     if (certificationApprovalRequired) {
-      val currentCapacityCount = cell.getSpecialistCellTypesForCell().count { it.affectsCapacity }
-      val newCapacityCount = specialistCellTypes.count { it.affectsCapacity }
-      if (currentCapacityCount != newCapacityCount) {
+      val currentNumSpecialistTypes = cell.getSpecialistCellTypesForCell().count { it.affectsCapacity }
+      val newNumSpecialistTypes = specialistCellTypes.count { it.affectsCapacity }
+      if (currentNumSpecialistTypes != newNumSpecialistTypes) {
         throw SpecialistCellTypeChangesRequireCertificationApprovalException(cell.getKey())
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -78,6 +78,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PendingApprov
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PermanentlyDeactivatedUpdateNotAllowedException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ReactivateLocationsRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ReasonForDeactivationMustBeProvidedException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.SpecialistCellTypeChangesRequireCertificationApprovalException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.UpdateCapacityRequest
 import java.lang.Boolean.TRUE
 import java.time.Clock
@@ -105,6 +106,7 @@ class LocationService(
   private val telemetryClient: TelemetryClient,
   private val locationGroupFromPropertiesService: LocationGroupFromPropertiesService,
   private val activePrisonService: ActivePrisonService,
+  private val cellCertificateService: CellCertificateService,
   @param:Qualifier("residentialGroups") private val groupsProperties: Properties,
 ) {
   companion object {
@@ -888,7 +890,11 @@ class LocationService(
 
     val certificationApprovalRequired = activePrisonService.isCertificationApprovalRequired(cell.prisonId)
     if (certificationApprovalRequired) {
-      throw ChangesCannotBeMadeWithoutCertificationApprovalException(cell.getKey())
+      val currentCapacityCount = cell.getSpecialistCellTypesForCell().count { it.affectsCapacity }
+      val newCapacityCount = specialistCellTypes.count { it.affectsCapacity }
+      if (currentCapacityCount != newCapacityCount) {
+        throw SpecialistCellTypeChangesRequireCertificationApprovalException(cell.getKey())
+      }
     }
 
     // Check that the workingCapacity is not set to 0 for normal accommodations when removing the specialist cell types
@@ -913,6 +919,10 @@ class LocationService(
       linkedTransaction,
     )
     log.info("Updated specialist cell types = $specialistCellTypes")
+
+    if (certificationApprovalRequired) {
+      cellCertificateService.updateSpecialistCellTypesInCurrentCertificate(cell)
+    }
 
     telemetryClient.trackEvent(
       "Specialist cell types updated",

--- a/src/main/resources/db/migration/V1_89__specialist_cell_type_approval.sql
+++ b/src/main/resources/db/migration/V1_89__specialist_cell_type_approval.sql
@@ -1,0 +1,1 @@
+ALTER TABLE certification_approval_request ADD COLUMN pending_specialist_cell_types VARCHAR(300);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/CommonDataTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/CommonDataTestBase.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SignedOperationCap
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.VirtualResidentialLocation
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellLocationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CertificationApprovalRequestRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LinkedTransactionRepository
@@ -58,6 +59,9 @@ class CommonDataTestBase : SqsIntegrationTestBase() {
   lateinit var signedOperationCapacityRepository: SignedOperationCapacityRepository
 
   @Autowired
+  lateinit var cellCertificateRepository: CellCertificateRepository
+
+  @Autowired
   lateinit var linkedTransactionRepository: LinkedTransactionRepository
   lateinit var cell1: Cell
   lateinit var cell2: Cell
@@ -86,7 +90,7 @@ class CommonDataTestBase : SqsIntegrationTestBase() {
     repository.deleteAll()
     configurationRepository.deleteAll()
     signedOperationCapacityRepository.deleteAll()
-
+    cellCertificateRepository.deleteAll()
     signedOperationCapacityRepository.saveAllAndFlush(
       listOf(
         SignedOperationCapacity(prisonId = "MDI", signedOperationCapacity = 200, whenUpdated = LocalDateTime.now(clock), updatedBy = SYSTEM_USERNAME),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApprovalRequestResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApprovalRequestResourceTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonData
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.EXPECTED_USERNAME
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationApprovalRequest
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
@@ -39,7 +40,6 @@ class ApprovalRequestResourceTest : CommonDataTestBase() {
         numberOfSpurs = 0,
         wingDescription = "Wing G",
       ).toEntity(
-        createInDraft = true,
         createdBy = "TEST_USER",
         clock = clock,
         linkedTransaction = linkedTransactionRepository.saveAndFlush(
@@ -51,6 +51,8 @@ class ApprovalRequestResourceTest : CommonDataTestBase() {
             txStartTime = LocalDateTime.now(clock).minusDays(1),
           ),
         ),
+        createInDraft = true,
+        specialistCellType = SpecialistCellType.ESCAPE_LIST,
       ),
     )
     approvalRequestId = getApprovalRequestId("LEI-G")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
@@ -17,8 +17,8 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.EXPECTED_U
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationService
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
@@ -34,12 +34,8 @@ class CellCertificateResourceTest(@param:Autowired private val locationService: 
   private lateinit var cellCertificateId: UUID
   private lateinit var mWing: ResidentialLocation
 
-  @Autowired
-  lateinit var cellCertificateRepository: CellCertificateRepository
-
   @BeforeEach
   override fun setUp() {
-    cellCertificateRepository.deleteAll()
     super.setUp()
 
     // Create a new wing in Leeds prison
@@ -54,7 +50,6 @@ class CellCertificateResourceTest(@param:Autowired private val locationService: 
         defaultMaxCapacity = 2,
         wingDescription = "Wing M",
       ).toEntity(
-        createInDraft = true,
         createdBy = EXPECTED_USERNAME,
         clock = clock,
         linkedTransaction = linkedTransactionRepository.saveAndFlush(
@@ -66,6 +61,8 @@ class CellCertificateResourceTest(@param:Autowired private val locationService: 
             txStartTime = LocalDateTime.now(clock).minusDays(1),
           ),
         ),
+        createInDraft = true,
+        specialistCellType = SpecialistCellType.ESCAPE_LIST,
       ),
     )
 
@@ -301,7 +298,6 @@ class CellCertificateResourceTest(@param:Autowired private val locationService: 
         .jsonPath("$.locations[0].workingCapacity").isEqualTo(6)
         .jsonPath("$.locations[0].accommodationTypes[0]").isEqualTo("NORMAL_ACCOMMODATION")
         .jsonPath("$.locations[0].usedFor[0]").isEqualTo("STANDARD_ACCOMMODATION")
-        .jsonPath("$.locations[0].specialistCellTypes[0]").isEqualTo("ESCAPE_LIST")
         .jsonPath("$.locations[0].subLocations.length()").isEqualTo(2)
         .jsonPath("$.locations[0].subLocations[0].subLocations.length()").isEqualTo(3)
         .jsonPath("$.locations[0].subLocations[0].subLocations[0].workingCapacity").isEqualTo(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import org.springframework.test.json.JsonCompareMode
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ApproveCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Capacity
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellMarkChangeRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellSanitationChangeRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
@@ -46,63 +46,8 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change capacity a location and request approval`() {
-      // will return a prisoner for each location under the Leeds wing
-      leedsWing.findAllLeafLocations().forEach {
-        prisonerSearchMockServer.stubSearchByLocations(
-          leedsWing.prisonId,
-          listOf(it.getPathHierarchy()),
-          true,
-        )
-      }
       val firstCell = leedsWing.findAllLeafLocations().first()
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
-        .header("Content-Type", "application/json")
-        .bodyValue(
-          jsonString(
-            CapacityChangeRequest(
-              workingCapacity = 1,
-              maxCapacity = 1,
-              certifiedNormalAccommodation = 1,
-            ),
-          ),
-        )
-        .exchange()
-        .expectStatus().isOk
-        .expectBody().json(
-          // language=json
-          """
-              {
-                "id": "${firstCell.id}",
-                "prisonId": "${firstCell.prisonId}",
-                "pathHierarchy": "${firstCell.getPathHierarchy()}",
-                "locationType": "CELL",
-                "capacity": {
-                  "maxCapacity": 2,
-                  "workingCapacity": 1,
-                  "certifiedNormalAccommodation": 1
-                },
-                "pendingChanges": {
-                  "maxCapacity": 1,
-                  "workingCapacity": 1,
-                  "certifiedNormalAccommodation": 1
-                },
-                "active": true,
-                "key": "${firstCell.getKey()}"
-              }
-          """,
-          JsonCompareMode.LENIENT,
-        )
-
-      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
-
-      val capacityChangedLocation = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!
+      val capacityChangedLocation = updateCapacity(cellInLeeds = firstCell.getPathHierarchy(), workingCapacity = 1, maxCapacity = 1, cna = 1, temporaryWorkingCapacityChange = false)
 
       assertThat(capacityChangedLocation.status).isEqualTo(DerivedLocationStatus.LOCKED_ACTIVE)
       assertThat(capacityChangedLocation.pendingApprovalRequestId).isNotNull
@@ -200,39 +145,8 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change capacity a location and request approval but be stopped by an addition prisoners being moved in`() {
-      // will return a prisoner for each location under the Leeds wing
-      leedsWing.findAllLeafLocations().forEach {
-        prisonerSearchMockServer.stubSearchByLocations(
-          leedsWing.prisonId,
-          listOf(it.getPathHierarchy()),
-          true,
-        )
-      }
       val firstCell = leedsWing.findAllLeafLocations().first()
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
-        .header("Content-Type", "application/json")
-        .bodyValue(
-          jsonString(
-            CapacityChangeRequest(
-              workingCapacity = 1,
-              maxCapacity = 1,
-              certifiedNormalAccommodation = 1,
-            ),
-          ),
-        )
-        .exchange()
-        .expectStatus().isOk
-
-      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
-
-      val pendingApprovalRequestId = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!.pendingApprovalRequestId!!
+      val pendingApprovalRequestId = updateCapacity(cellInLeeds = firstCell.getPathHierarchy(), workingCapacity = 1, maxCapacity = 1, cna = 1, temporaryWorkingCapacityChange = false).pendingApprovalRequestId!!
 
       prisonerSearchMockServer.resetAll()
       prisonerSearchMockServer.stubSearchByLocations(
@@ -277,39 +191,11 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change capacity a location and request withdrawal`() {
-      // will return a prisoner for each location under the Leeds wing
-      leedsWing.findAllLeafLocations().forEach {
-        prisonerSearchMockServer.stubSearchByLocations(
-          leedsWing.prisonId,
-          listOf(it.getPathHierarchy()),
-          true,
-        )
-      }
-      val firstCell = leedsWing.findAllLeafLocations().first()
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
-        .header("Content-Type", "application/json")
-        .bodyValue(
-          jsonString(
-            CapacityChangeRequest(
-              workingCapacity = 1,
-              maxCapacity = 1,
-              certifiedNormalAccommodation = 1,
-            ),
-          ),
-        )
-        .exchange()
-        .expectStatus().isOk
-
-      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
-
-      val pendingApprovalRequestId = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!.pendingApprovalRequestId!!
+      val firstCell = updateCapacity(
+        workingCapacity = 1,
+        maxCapacity = 1,
+        temporaryWorkingCapacityChange = false,
+      )
 
       val withdrawnRequest = webTestClient.put().uri("/certification/location/withdraw")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
@@ -317,7 +203,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         .bodyValue(
           jsonString(
             WithdrawCertificationRequestDto(
-              approvalRequestReference = pendingApprovalRequestId,
+              approvalRequestReference = firstCell.pendingApprovalRequestId!!,
               comments = "Do not approve this capacity change, it is not correct.",
             ),
           ),
@@ -347,15 +233,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change just working capacity a location and not require a request approval`() {
-      val firstCell = temporaryUpdateWorkingCapacity()
-
-      val capacityChangedLocation = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
-        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
-        .header("Content-Type", "application/json")
-        .exchange()
-        .expectStatus().isOk
-        .expectBody<Location>()
-        .returnResult().responseBody!!
+      val capacityChangedLocation = updateCapacity()
 
       assertThat(capacityChangedLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
       assertThat(capacityChangedLocation.pendingApprovalRequestId).isNull()
@@ -367,51 +245,69 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
     @Test
     fun `can change a working capacity to match a capacity on a certificate`() {
-      val firstCell = temporaryUpdateWorkingCapacity()
+      val firstCell = updateCapacity(workingCapacity = 2, maxCapacity = 2, temporaryWorkingCapacityChange = true)
+      assertThat(firstCell.pendingChanges).isNull()
+
       // Now reflect on the cert the same values
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+      val updatedCell = updateCapacity(workingCapacity = 2, maxCapacity = 2, temporaryWorkingCapacityChange = false)
+      assertThat(updatedCell.pendingChanges?.workingCapacity).isEqualTo(2)
+      assertThat(updatedCell.pendingChanges?.maxCapacity).isEqualTo(2)
+    }
+
+    @Test
+    fun `can change a working capacity to match a capacity on a certificate but not update existing temporary capacity changes`() {
+      // existing temp change on cell A-1-001
+      updateCapacity(cellInLeeds = "A-1-001", workingCapacity = 2, maxCapacity = 2, temporaryWorkingCapacityChange = true)
+
+      val oldCertificate = webTestClient.get().uri("/cell-certificates//prison/LEI/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      assertThat(oldCertificate.findLocationInCertificate("A-1-001")!!.workingCapacity).isEqualTo(1)
+      assertThat(oldCertificate.findLocationInCertificate("A-1-002")!!.workingCapacity).isEqualTo(1)
+
+      // change a different cell and request approval
+      val cellForApproval = updateCapacity(cellInLeeds = "A-1-002", workingCapacity = 2, maxCapacity = 2, cna = 1, temporaryWorkingCapacityChange = false)
+
+      val approvedRequest = webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
         .header("Content-Type", "application/json")
         .bodyValue(
           jsonString(
-            CapacityChangeRequest(
-              workingCapacity = 2,
-              maxCapacity = 2,
-              certifiedNormalAccommodation = 1,
+            ApproveCertificationRequestDto(
+              approvalRequestReference = cellForApproval.pendingApprovalRequestId!!,
             ),
           ),
         )
         .exchange()
         .expectStatus().isOk
-        .expectBody().json(
-          // language=json
-          """
-              {
-                "id": "${firstCell.id}",
-                "prisonId": "${firstCell.prisonId}",
-                "pathHierarchy": "${firstCell.getPathHierarchy()}",
-                "locationType": "CELL",
-                "capacity": {
-                  "maxCapacity": 2,
-                  "workingCapacity": 2,
-                  "certifiedNormalAccommodation": 1
-                },
-                "pendingChanges": {
-                  "maxCapacity": 2,
-                  "workingCapacity": 2,
-                  "certifiedNormalAccommodation": 1
-                },
-                "active": true,
-                "key": "${firstCell.getKey()}"
-              }
-          """,
-          JsonCompareMode.LENIENT,
-        )
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
 
-      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
+      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isEqualTo(3)
+      getDomainEvents(3)
+
+      val certificate = webTestClient.get().uri("/cell-certificates//prison/LEI/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      assertThat(certificate.findLocationInCertificate("A-1-001")!!.workingCapacity).isEqualTo(1)
+      assertThat(certificate.findLocationInCertificate("A-1-002")!!.workingCapacity).isEqualTo(2)
     }
 
-    private fun temporaryUpdateWorkingCapacity(workingCapacity: Int = 2): uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location {
+    private fun updateCapacity(
+      cellInLeeds: String? = null,
+      workingCapacity: Int = 2,
+      maxCapacity: Int = 2,
+      temporaryWorkingCapacityChange: Boolean = true,
+      cna: Int = 1,
+    ): Location {
       // will return a prisoner for each location under the Leeds wing
       leedsWing.findAllLeafLocations().forEach {
         prisonerSearchMockServer.stubSearchByLocations(
@@ -420,49 +316,42 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
           true,
         )
       }
-      val firstCell = leedsWing.findAllLeafLocations().first()
-      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
+      val cellToChange = cellInLeeds?.let { cellPath -> leedsWing.findLocation("LEI-$cellPath") } ?: leedsWing.findAllLeafLocations().first()
+      webTestClient.put().uri("/locations/${cellToChange.id}/capacity")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
         .header("Content-Type", "application/json")
         .bodyValue(
           jsonString(
             CapacityChangeRequest(
               workingCapacity = workingCapacity,
-              maxCapacity = 2,
-              certifiedNormalAccommodation = 1,
-              temporaryWorkingCapacityChange = true,
+              maxCapacity = maxCapacity,
+              certifiedNormalAccommodation = cna,
+              temporaryWorkingCapacityChange = temporaryWorkingCapacityChange,
             ),
           ),
         )
         .exchange()
         .expectStatus().isOk
-        .expectBody().json(
-          // language=json
-          """
-                  {
-                    "id": "${firstCell.id}",
-                    "prisonId": "${firstCell.prisonId}",
-                    "pathHierarchy": "${firstCell.getPathHierarchy()}",
-                    "locationType": "CELL",
-                    "capacity": {
-                      "maxCapacity": 2,
-                      "workingCapacity": 2,
-                      "certifiedNormalAccommodation": 1
-                    },
-                    "active": true,
-                    "key": "${firstCell.getKey()}"
-                  }
-              """,
-          JsonCompareMode.LENIENT,
-        )
 
-      getDomainEvents(3).let {
-        assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
-          "location.inside.prison.amended" to firstCell.getKey(),
-          *firstCell.getParentLocations().map { "location.inside.prison.amended" to it.getKey() }.toTypedArray(),
-        )
+      if (temporaryWorkingCapacityChange) {
+        getDomainEvents(3).let {
+          assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
+            "location.inside.prison.amended" to cellToChange.getKey(),
+            *cellToChange.getParentLocations().map { location -> "location.inside.prison.amended" to location.getKey() }
+              .toTypedArray(),
+          )
+        }
+      } else {
+        assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
       }
-      return firstCell
+
+      return webTestClient.get().uri("/locations/${cellToChange.id}?includeCurrentCertificate=true")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.Ap
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.ReactivationLocationsApprovalRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.SpecialistCellTypeApprovalRequest
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -2195,5 +2196,437 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       .expectStatus().isOk
       .expectBody<Location>()
       .returnResult().responseBody!!
+  }
+
+  @DisplayName("PUT /certification/location/specialist-cell-type-change")
+  @Nested
+  inner class SpecialistCellTypeTest {
+
+    private fun firstLeedsCell(): Cell {
+      val cell = leedsWing.findAllLeafLocations().first() as Cell
+      cell.specialistCellTypes.clear()
+      cellRepository.save(cell)
+      return cell
+    }
+
+    private fun requestSpecialistCellTypeApproval(
+      cell: Cell,
+      specialistCellTypes: Set<SpecialistCellType>,
+      workingCapacity: Int = 0,
+      maxCapacity: Int = 1,
+      certifiedNormalAccommodation: Int = 0,
+    ): CertificationApprovalRequestDto = webTestClient.put().uri("/certification/location/specialist-cell-type-change")
+      .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        jsonString(
+          SpecialistCellTypeApprovalRequest(
+            locationId = cell.id!!,
+            specialistCellTypes = specialistCellTypes,
+            workingCapacity = workingCapacity,
+            maxCapacity = maxCapacity,
+            certifiedNormalAccommodation = certifiedNormalAccommodation,
+          ),
+        ),
+      )
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<CertificationApprovalRequestDto>()
+      .returnResult().responseBody!!
+
+    private fun approveRequest(approvalRequestId: java.util.UUID): CertificationApprovalRequestDto = webTestClient.put().uri("/certification/location/approve")
+      .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+      .header("Content-Type", "application/json")
+      .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = approvalRequestId)))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<CertificationApprovalRequestDto>()
+      .returnResult().responseBody!!
+
+    @Test
+    fun `when cert approval required, adding a capacity-affecting specialist cell type via direct endpoint is rejected`() {
+      val cell = firstLeedsCell()
+
+      webTestClient.put().uri("/locations/${cell.id}/specialist-cell-types")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(setOf(SpecialistCellType.BIOHAZARD_DIRTY_PROTEST)))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(135)
+    }
+
+    @Test
+    fun `when cert approval required, removing a capacity-affecting specialist cell type via direct endpoint is rejected`() {
+      val cell = firstLeedsCell()
+
+      // First add the type via the approval flow
+      val pendingApproval = requestSpecialistCellTypeApproval(cell, setOf(SpecialistCellType.CSU))
+      assertThat(pendingApproval.approvalType).isEqualTo(ApprovalType.SPECIALIST_CELL_TYPE)
+
+      prisonerSearchMockServer.stubSearchByLocations(
+        leedsWing.prisonId,
+        listOf(cell.getPathHierarchy()),
+        false,
+      )
+
+      approveRequest(pendingApproval.id)
+      getDomainEvents(3)
+
+      val freshCell = cellRepository.findById(cell.id!!).get()
+
+      // Now try to remove it via direct endpoint
+      webTestClient.put().uri("/locations/${freshCell.id}/specialist-cell-types")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(emptySet<SpecialistCellType>()))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(135)
+    }
+
+    @Test
+    fun `when cert approval required, swapping capacity-affecting types (same count) via direct endpoint is allowed and updates cert`() {
+      val cell = firstLeedsCell()
+
+      // First give cell a capacity-affecting type via approval
+      val pendingApproval = requestSpecialistCellTypeApproval(cell, setOf(SpecialistCellType.BIOHAZARD_DIRTY_PROTEST))
+
+      prisonerSearchMockServer.stubSearchByLocations(
+        leedsWing.prisonId,
+        listOf(cell.getPathHierarchy()),
+        false,
+      )
+
+      approveRequest(pendingApproval.id)
+      getDomainEvents(3)
+
+      // Swap to a different capacity-affecting type via direct endpoint
+      val result = webTestClient.put().uri("/locations/${cell.id}/specialist-cell-types")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(setOf(SpecialistCellType.CSU)))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(result.specialistCellTypes).containsExactlyInAnyOrder(SpecialistCellType.CSU)
+
+      // Verify the current cert was updated in-place
+      val currentCert = webTestClient.get().uri("/cell-certificates/prison/${cell.prisonId}/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      val cellInCert = currentCert.findLocationInCertificate(cell.getPathHierarchy())
+      assertThat(cellInCert).isNotNull
+      assertThat(cellInCert?.specialistCellTypes).containsExactlyInAnyOrder(SpecialistCellType.CSU)
+
+      getDomainEvents(1)
+    }
+
+    @Test
+    fun `when cert approval required, adding a non-capacity-affecting type via direct endpoint is allowed and updates cert`() {
+      val cell = firstLeedsCell()
+
+      webTestClient.put().uri("/locations/${cell.id}/specialist-cell-types")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(setOf(SpecialistCellType.ACCESSIBLE_CELL)))
+        .exchange()
+        .expectStatus().isOk
+
+      // Verify cert updated
+      val currentCert = webTestClient.get().uri("/cell-certificates/prison/${cell.prisonId}/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      val cellInCert = currentCert.findLocationInCertificate(cell.getPathHierarchy())
+      assertThat(cellInCert?.specialistCellTypes).containsExactlyInAnyOrder(SpecialistCellType.ACCESSIBLE_CELL)
+
+      getDomainEvents(1)
+    }
+
+    @Test
+    fun `can request approval to add a capacity-affecting specialist cell type`() {
+      val cell = firstLeedsCell()
+
+      val pendingApproval = requestSpecialistCellTypeApproval(
+        cell = cell,
+        specialistCellTypes = setOf(SpecialistCellType.BIOHAZARD_DIRTY_PROTEST, SpecialistCellType.ACCESSIBLE_CELL),
+        workingCapacity = 0,
+        maxCapacity = 1,
+        certifiedNormalAccommodation = 0,
+      )
+
+      assertThat(pendingApproval.approvalType).isEqualTo(ApprovalType.SPECIALIST_CELL_TYPE)
+      assertThat(pendingApproval.status).isEqualTo(ApprovalRequestStatus.PENDING)
+      assertThat(pendingApproval.locationId).isEqualTo(cell.id)
+      assertThat(pendingApproval.prisonId).isEqualTo(cell.prisonId)
+      assertThat(pendingApproval.locationKey).isEqualTo(cell.getKey())
+      assertThat(pendingApproval.workingCapacity).isEqualTo(0)
+      assertThat(pendingApproval.maxCapacity).isEqualTo(1)
+      assertThat(pendingApproval.certifiedNormalAccommodation).isEqualTo(0)
+      assertThat(pendingApproval.specialistCellTypes).containsExactlyInAnyOrder(
+        SpecialistCellType.BIOHAZARD_DIRTY_PROTEST,
+        SpecialistCellType.ACCESSIBLE_CELL,
+      )
+      // currentSpecialistCellTypes reflects the cell's state before this approval
+      assertThat(pendingApproval.currentSpecialistCellTypes).isNull()
+      assertThat(pendingApproval.locations).hasSize(1)
+
+      // The cell should now be locked
+      val lockedCell = webTestClient.get().uri("/locations/${cell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(lockedCell.status).isEqualTo(DerivedLocationStatus.LOCKED_ACTIVE)
+      assertThat(lockedCell.pendingApprovalRequestId).isEqualTo(pendingApproval.id)
+    }
+
+    @Test
+    fun `cannot approve a specialist cell type change request when a prisoner is in the cell`() {
+      val cell = firstLeedsCell()
+      val pendingApproval = requestSpecialistCellTypeApproval(
+        cell = cell,
+        specialistCellTypes = setOf(SpecialistCellType.DRY),
+        workingCapacity = 0,
+        maxCapacity = 0,
+        certifiedNormalAccommodation = 0,
+      )
+
+      prisonerSearchMockServer.stubSearchByLocations(
+        leedsWing.prisonId,
+        listOf(cell.getPathHierarchy()),
+        true,
+      )
+
+      assertThat(
+        webTestClient.put().uri("/certification/location/approve")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingApproval.id)))
+          .exchange()
+          .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
+          .expectBody<ErrorResponse>()
+          .returnResult().responseBody!!.errorCode,
+      ).isEqualTo(ErrorCode.MaxCapacityCannotBeBelowOccupancyLevel.errorCode)
+    }
+
+    @Test
+    fun `can approve a specialist cell type change request`() {
+      val cell = firstLeedsCell()
+      val pendingApproval = requestSpecialistCellTypeApproval(
+        cell = cell,
+        specialistCellTypes = setOf(SpecialistCellType.DRY),
+        workingCapacity = 0,
+        maxCapacity = 1,
+        certifiedNormalAccommodation = 0,
+      )
+
+      prisonerSearchMockServer.stubSearchByLocations(
+        leedsWing.prisonId,
+        listOf(cell.getPathHierarchy()),
+        false,
+      )
+
+      val approved = approveRequest(pendingApproval.id)
+
+      assertThat(approved.approvalType).isEqualTo(ApprovalType.SPECIALIST_CELL_TYPE)
+      assertThat(approved.status).isEqualTo(ApprovalRequestStatus.APPROVED)
+
+      getDomainEvents(3).let {
+        assertThat(it.map { msg -> msg.eventType to msg.additionalInformation?.key }).containsExactlyInAnyOrder(
+          "location.inside.prison.amended" to cell.getKey(),
+          *cell.getParentLocations().map { parent -> "location.inside.prison.amended" to parent.getKey() }.toTypedArray(),
+        )
+      }
+
+      // Verify the cell has been updated
+      val updatedCell = webTestClient.get().uri("/locations/${cell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(updatedCell.specialistCellTypes).containsExactlyInAnyOrder(SpecialistCellType.DRY)
+      assertThat(updatedCell.capacity?.workingCapacity).isEqualTo(0)
+      assertThat(updatedCell.capacity?.maxCapacity).isEqualTo(1)
+      assertThat(updatedCell.status).isEqualTo(DerivedLocationStatus.ACTIVE)
+      assertThat(updatedCell.pendingApprovalRequestId).isNull()
+    }
+
+    @Test
+    fun `can reject a specialist cell type change request`() {
+      val cell = firstLeedsCell()
+      val pendingApproval = requestSpecialistCellTypeApproval(
+        cell = cell,
+        specialistCellTypes = setOf(SpecialistCellType.CONSTANT_SUPERVISION),
+        workingCapacity = 0,
+        maxCapacity = 1,
+        certifiedNormalAccommodation = 0,
+      )
+
+      webTestClient.put().uri("/certification/location/reject")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(RejectCertificationRequestDto(approvalRequestReference = pendingApproval.id, comments = "Not approved")))
+        .exchange()
+        .expectStatus().isOk
+
+      // Cell should be unchanged (no specialist types, no capacity change)
+      val cell2 = webTestClient.get().uri("/locations/${cell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(cell2.specialistCellTypes).isNullOrEmpty()
+      assertThat(cell2.capacity?.workingCapacity).isEqualTo(1)
+      assertThat(cell2.capacity?.maxCapacity).isEqualTo(2)
+      assertThat(cell2.pendingApprovalRequestId).isNull()
+    }
+
+    @Test
+    fun `can withdraw a specialist cell type change request`() {
+      val cell = firstLeedsCell()
+      val pendingApproval = requestSpecialistCellTypeApproval(
+        cell = cell,
+        specialistCellTypes = setOf(SpecialistCellType.UNFURNISHED),
+        workingCapacity = 0,
+        maxCapacity = 1,
+        certifiedNormalAccommodation = 0,
+      )
+
+      webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(WithdrawCertificationRequestDto(approvalRequestReference = pendingApproval.id, comments = "No longer needed")))
+        .exchange()
+        .expectStatus().isOk
+
+      val unlockedCell = webTestClient.get().uri("/locations/${cell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(unlockedCell.specialistCellTypes).isNullOrEmpty()
+      assertThat(unlockedCell.pendingApprovalRequestId).isNull()
+    }
+
+    @Test
+    fun `cannot create a second specialist cell type approval when one is pending`() {
+      val cell = firstLeedsCell()
+      requestSpecialistCellTypeApproval(cell, setOf(SpecialistCellType.CSU))
+
+      webTestClient.put().uri("/certification/location/specialist-cell-type-change")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            SpecialistCellTypeApprovalRequest(
+              locationId = cell.id!!,
+              specialistCellTypes = setOf(SpecialistCellType.DRY),
+              workingCapacity = 0,
+              maxCapacity = 1,
+              certifiedNormalAccommodation = 0,
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.CONFLICT)
+    }
+
+    @Test
+    fun `approval endpoint rejects change that does not require approval (same capacity-affecting count)`() {
+      val cell = firstLeedsCell()
+
+      // First add CSU via approval
+      val pending = requestSpecialistCellTypeApproval(cell, setOf(SpecialistCellType.CSU))
+
+      prisonerSearchMockServer.stubSearchByLocations(
+        leedsWing.prisonId,
+        listOf(cell.getPathHierarchy()),
+        false,
+      )
+
+      approveRequest(pending.id)
+      getDomainEvents(3)
+
+      // Now try to use the approval endpoint to swap CSU → BIOHAZARD (count stays at 1, doesn't need approval)
+      webTestClient.put().uri("/certification/location/specialist-cell-type-change")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            SpecialistCellTypeApprovalRequest(
+              locationId = cell.id!!,
+              specialistCellTypes = setOf(SpecialistCellType.BIOHAZARD_DIRTY_PROTEST),
+              workingCapacity = 0,
+              maxCapacity = 1,
+              certifiedNormalAccommodation = 0,
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isBadRequest
+    }
+
+    @Test
+    fun `cert approval not required, when adding a non specialist cell type`() {
+      val cell = firstLeedsCell()
+      webTestClient.put().uri("/locations/${cell.id}/specialist-cell-types")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(setOf(SpecialistCellType.ACCESSIBLE_CELL, SpecialistCellType.CAT_A)))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+        .also { result ->
+          assertThat(result.specialistCellTypes).containsExactlyInAnyOrder(
+            SpecialistCellType.ACCESSIBLE_CELL,
+            SpecialistCellType.CAT_A,
+          )
+        }
+
+      getDomainEvents(1)
+    }
+
+    @Test
+    fun `when cert approval not required, adding capacity-affecting specialist cell types via direct endpoint is allowed`() {
+      // cell1 is in MDI which does not have certificationApprovalRequired=true
+      webTestClient.put().uri("/locations/${cell1.id}/specialist-cell-types")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(setOf(SpecialistCellType.BIOHAZARD_DIRTY_PROTEST, SpecialistCellType.ACCESSIBLE_CELL)))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+        .also { result ->
+          assertThat(result.specialistCellTypes).containsExactlyInAnyOrder(
+            SpecialistCellType.BIOHAZARD_DIRTY_PROTEST,
+            SpecialistCellType.ACCESSIBLE_CELL,
+          )
+        }
+
+      getDomainEvents(1)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.DerivedLocationSta
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.InactiveStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.RejectCertificationRequestDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.SignedOperationCapacityDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.TemporaryDeactivationLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.WithdrawCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
@@ -32,16 +33,19 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.Ap
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.ReactivationLocationsApprovalRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.SignedOpCapApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.SpecialistCellTypeApprovalRequest
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 @WithMockAuthUser(username = EXPECTED_USERNAME)
 class CertificationApprovalResourceTest : CommonDataTestBase() {
 
   @BeforeEach
   fun beforeEach() {
+    super.setUp()
     baselinePrison(leedsWing.prisonId)
   }
 
@@ -62,7 +66,6 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
           defaultMaxCapacity = 2,
           wingDescription = "Wing Y",
         ).toEntity(
-          createInDraft = true,
           createdBy = EXPECTED_USERNAME,
           clock = clock,
           linkedTransaction = linkedTransactionRepository.saveAndFlush(
@@ -74,6 +77,8 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
               txStartTime = LocalDateTime.now(clock).minusDays(1),
             ),
           ),
+          createInDraft = true,
+          specialistCellType = SpecialistCellType.ESCAPE_LIST,
         ),
       )
 
@@ -368,6 +373,48 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(approvedCapacityLocation.pendingApprovalRequestId).isNull()
       assertThat(approvedCapacityLocation.currentCellCertificate).isNotNull
       assertThat(approvedCapacityLocation.currentCellCertificate!!.maxCapacity).isEqualTo(2)
+    }
+
+    @Test
+    fun `can change capacity a location and reject`() {
+      val firstCell = updateCapacity(
+        workingCapacity = 1,
+        maxCapacity = 1,
+        temporaryWorkingCapacityChange = false,
+      )
+
+      val rejectedRequest = webTestClient.put().uri("/certification/location/reject")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            RejectCertificationRequestDto(
+              approvalRequestReference = firstCell.pendingApprovalRequestId!!,
+              comments = "Capacity change not authorised.",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(rejectedRequest.certificateId).isNull()
+      assertThat(rejectedRequest.status).isEqualTo(ApprovalRequestStatus.REJECTED)
+      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
+
+      val rejectedCapacityLocation = webTestClient.get().uri("/locations/${firstCell.id}?includeCurrentCertificate=true")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(rejectedCapacityLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
+      assertThat(rejectedCapacityLocation.pendingApprovalRequestId).isNull()
+      assertThat(rejectedCapacityLocation.currentCellCertificate).isNotNull
+      assertThat(rejectedCapacityLocation.currentCellCertificate!!.maxCapacity).isEqualTo(2)
     }
 
     @Test
@@ -1336,9 +1383,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.locations[0].workingCapacity).isEqualTo(1)
       assertThat(pendingApproval.locations[0].maxCapacity).isEqualTo(2)
       assertThat(pendingApproval.locations[0].certifiedNormalAccommodation).isEqualTo(1)
-      assertThat(pendingApproval.locations[0].currentSpecialistCellTypes).containsExactlyInAnyOrder(
-        SpecialistCellType.ESCAPE_LIST,
-      )
+      assertThat(pendingApproval.locations[0].currentSpecialistCellTypes).isNull()
       assertThat(pendingApproval.locations[0].specialistCellTypes).containsExactlyInAnyOrder(
         SpecialistCellType.SAFE_CELL,
         SpecialistCellType.CONSTANT_SUPERVISION,
@@ -1465,10 +1510,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.locations[0].certifiedNormalAccommodation).isEqualTo(6)
       assertThat(pendingApproval.locations[0].subLocations).hasSize(2)
       assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations).hasSize(3)
-      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).containsExactlyInAnyOrder(
-        SpecialistCellType.ESCAPE_LIST,
-      )
-
+      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).isNull()
       val approvedRequest = webTestClient.put().uri("/certification/location/approve")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
         .header("Content-Type", "application/json")
@@ -1514,7 +1556,6 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         .jsonPath("$.locations[0].subLocations[0].subLocations[0].maxCapacity").isEqualTo(2)
         .jsonPath("$.locations[0].subLocations[1].subLocations[0].workingCapacity").isEqualTo(1)
         .jsonPath("$.locations[0].subLocations[1].subLocations[0].maxCapacity").isEqualTo(2)
-        .jsonPath("$.locations[0].subLocations[1].subLocations[0].specialistCellTypes").isEqualTo("ESCAPE_LIST")
     }
 
     @Test
@@ -1599,16 +1640,10 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.locations[0].workingCapacity).isEqualTo(12)
       assertThat(pendingApproval.locations[0].maxCapacity).isEqualTo(12)
       assertThat(pendingApproval.locations[0].certifiedNormalAccommodation).isEqualTo(12)
-      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).containsExactlyInAnyOrder(
-        SpecialistCellType.ESCAPE_LIST,
-      )
+      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).isNull()
       assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.specialistCellTypes).isEmpty()
-      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(1)?.currentSpecialistCellTypes).containsExactlyInAnyOrder(
-        SpecialistCellType.ESCAPE_LIST,
-      )
-      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(1)?.specialistCellTypes).containsExactlyInAnyOrder(
-        SpecialistCellType.ESCAPE_LIST,
-      )
+      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(1)?.currentSpecialistCellTypes).isNull()
+      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(1)?.specialistCellTypes).isNull()
       assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(2)?.specialistCellTypes).containsExactlyInAnyOrder(
         SpecialistCellType.SAFE_CELL,
         SpecialistCellType.CONSTANT_SUPERVISION,
@@ -1766,6 +1801,80 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(rejectedDeactivatedCell.currentCellCertificate).isNotNull
       assertThat(rejectedDeactivatedCell.currentCellCertificate!!.workingCapacity).isEqualTo(0)
       assertThat(rejectedDeactivatedCell.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_MATCHING_CELL_CERT)
+    }
+
+    @Test
+    fun `can withdraw a reactivation approval request`() {
+      deactivateLocation(
+        leedsWing,
+        deactivatedReason = DeactivatedReason.MOTHBALLED,
+        planetFmReference = "11111",
+        reasonForChange = "The wing has been flooded",
+        requiresApproval = true,
+        approveDeactivation = true,
+      )
+
+      webTestClient.put().uri("/certification/location/reactivation-request-approval")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            ReactivationLocationsApprovalRequest(
+              topLevelLocationId = leedsWing.id!!,
+              cellReactivationChanges = leedsWing.cellLocations().associate {
+                it.id!! to CellReactivationDetail(
+                  capacity = Capacity(
+                    workingCapacity = 2,
+                    maxCapacity = 2,
+                    certifiedNormalAccommodation = 2,
+                  ),
+                )
+              },
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+
+      val pendingApprovalRequestId = webTestClient.get().uri("/locations/${leedsWing.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!.pendingApprovalRequestId!!
+
+      val withdrawnRequest = webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            WithdrawCertificationRequestDto(
+              approvalRequestReference = pendingApprovalRequestId,
+              comments = "Reactivation not needed yet",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(withdrawnRequest.certificateId).isNull()
+      assertThat(withdrawnRequest.status).isEqualTo(ApprovalRequestStatus.WITHDRAWN)
+      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
+
+      val withdrawnLocation = webTestClient.get().uri("/locations/${leedsWing.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(withdrawnLocation.status).isEqualTo(DerivedLocationStatus.INACTIVE)
+      assertThat(withdrawnLocation.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_MATCHING_CELL_CERT)
+      assertThat(withdrawnLocation.pendingApprovalRequestId).isNull()
     }
   }
 
@@ -1948,6 +2057,83 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(rejectedLocation.cellMark).isEqualTo(cellToUpdate.cellMark)
       assertThat(rejectedLocation.pendingChanges).isNull()
       assertThat(rejectedLocation.pendingApprovalRequestId).isNull()
+
+      val currentCertAfterReject = webTestClient.get().uri("/cell-certificates/prison/LEI/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      val cellInCertAfterReject = currentCertAfterReject.findLocationInCertificate(cellToUpdate.getPathHierarchy())
+      assertThat(cellInCertAfterReject?.cellMark).isEqualTo(cellToUpdate.cellMark)
+    }
+
+    @Test
+    fun `can change a cell mark on a location and withdraw approval`() {
+      val cellToUpdate = leedsWing.findAllLeafLocations().first() as Cell
+      val pendingCell = webTestClient.put().uri("/locations/residential/${cellToUpdate.id}/cell-mark-change")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            CellMarkChangeRequest(
+              reasonForChange = "The door number is wrong",
+              cellMark = "CM-001",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(pendingCell.status).isEqualTo(DerivedLocationStatus.LOCKED_ACTIVE)
+      assertThat(pendingCell.pendingApprovalRequestId).isNotNull
+      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
+
+      val withdrawnRequest = webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            WithdrawCertificationRequestDto(
+              approvalRequestReference = pendingCell.pendingApprovalRequestId!!,
+              comments = "Cell mark change no longer needed",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(withdrawnRequest.certificateId).isNull()
+      assertThat(withdrawnRequest.status).isEqualTo(ApprovalRequestStatus.WITHDRAWN)
+      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
+
+      val withdrawnLocation = webTestClient.get().uri("/locations/${cellToUpdate.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(withdrawnLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
+      assertThat(withdrawnLocation.cellMark).isEqualTo(cellToUpdate.cellMark)
+      assertThat(withdrawnLocation.pendingChanges).isNull()
+      assertThat(withdrawnLocation.pendingApprovalRequestId).isNull()
+
+      val currentCertAfterWithdraw = webTestClient.get().uri("/cell-certificates/prison/LEI/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      val cellInCertAfterWithdraw = currentCertAfterWithdraw.findLocationInCertificate(cellToUpdate.getPathHierarchy())
+      assertThat(cellInCertAfterWithdraw?.cellMark).isEqualTo(cellToUpdate.cellMark)
     }
   }
 
@@ -2098,6 +2284,83 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(rejectedLocation.inCellSanitation).isEqualTo(true)
       assertThat(rejectedLocation.pendingChanges).isNull()
       assertThat(rejectedLocation.pendingApprovalRequestId).isNull()
+
+      val currentCertAfterReject = webTestClient.get().uri("/cell-certificates/prison/LEI/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      val cellInCertAfterReject = currentCertAfterReject.findLocationInCertificate(cellToUpdate.getPathHierarchy())
+      assertThat(cellInCertAfterReject?.inCellSanitation).isEqualTo(true)
+    }
+
+    @Test
+    fun `can change a cell sanitation on a location and withdraw approval`() {
+      val cellToUpdate = leedsWing.findAllLeafLocations().first() as Cell
+      val pendingCell = webTestClient.put().uri("/locations/residential/${cellToUpdate.id}/cell-sanitation-change")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            CellSanitationChangeRequest(
+              reasonForChange = "The toilet is old",
+              inCellSanitation = false,
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(pendingCell.status).isEqualTo(DerivedLocationStatus.LOCKED_ACTIVE)
+      val pendingApprovalRequestId = pendingCell.pendingApprovalRequestId!!
+      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
+
+      val withdrawnRequest = webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            WithdrawCertificationRequestDto(
+              approvalRequestReference = pendingApprovalRequestId,
+              comments = "Sanitation change no longer required",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(withdrawnRequest.certificateId).isNull()
+      assertThat(withdrawnRequest.status).isEqualTo(ApprovalRequestStatus.WITHDRAWN)
+      assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero
+
+      val withdrawnLocation = webTestClient.get().uri("/locations/${cellToUpdate.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(withdrawnLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
+      assertThat(withdrawnLocation.inCellSanitation).isEqualTo(true)
+      assertThat(withdrawnLocation.pendingChanges).isNull()
+      assertThat(withdrawnLocation.pendingApprovalRequestId).isNull()
+
+      val currentCertAfterWithdraw = webTestClient.get().uri("/cell-certificates/prison/LEI/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      val cellInCertAfterWithdraw = currentCertAfterWithdraw.findLocationInCertificate(cellToUpdate.getPathHierarchy())
+      assertThat(cellInCertAfterWithdraw?.inCellSanitation).isEqualTo(true)
     }
   }
 
@@ -2202,12 +2465,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
   @Nested
   inner class SpecialistCellTypeTest {
 
-    private fun firstLeedsCell(): Cell {
-      val cell = leedsWing.findAllLeafLocations().first() as Cell
-      cell.specialistCellTypes.clear()
-      cellRepository.save(cell)
-      return cell
-    }
+    private fun firstLeedsCell(): Cell = leedsWing.findAllLeafLocations().first() as Cell
 
     private fun requestSpecialistCellTypeApproval(
       cell: Cell,
@@ -2453,6 +2711,16 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         )
       }
 
+      webTestClient.get().uri("/cell-certificates/${approved.certificateId}")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.current").isEqualTo(true)
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].specialistCellTypes").isEqualTo(listOf("DRY"))
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].workingCapacity").isEqualTo(0)
+        .jsonPath("$.locations[0].subLocations[0].subLocations[0].maxCapacity").isEqualTo(1)
+
       // Verify the cell has been updated
       val updatedCell = webTestClient.get().uri("/locations/${cell.id}")
         .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
@@ -2498,6 +2766,19 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(cell2.capacity?.workingCapacity).isEqualTo(1)
       assertThat(cell2.capacity?.maxCapacity).isEqualTo(2)
       assertThat(cell2.pendingApprovalRequestId).isNull()
+
+      val currentCertAfterReject = webTestClient.get().uri("/cell-certificates/prison/${cell.prisonId}/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      val cellInCertAfterReject = currentCertAfterReject.findLocationInCertificate(cell.getPathHierarchy())
+      assertThat(cellInCertAfterReject).isNotNull
+      assertThat(cellInCertAfterReject?.specialistCellTypes).isNullOrEmpty()
+      assertThat(cellInCertAfterReject?.workingCapacity).isEqualTo(1)
+      assertThat(cellInCertAfterReject?.maxCapacity).isEqualTo(2)
     }
 
     @Test
@@ -2527,6 +2808,19 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
 
       assertThat(unlockedCell.specialistCellTypes).isNullOrEmpty()
       assertThat(unlockedCell.pendingApprovalRequestId).isNull()
+
+      val currentCertAfterWithdraw = webTestClient.get().uri("/cell-certificates/prison/${cell.prisonId}/current")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CellCertificateDto>()
+        .returnResult().responseBody!!
+
+      val cellInCertAfterWithdraw = currentCertAfterWithdraw.findLocationInCertificate(cell.getPathHierarchy())
+      assertThat(cellInCertAfterWithdraw).isNotNull
+      assertThat(cellInCertAfterWithdraw?.specialistCellTypes).isNullOrEmpty()
+      assertThat(cellInCertAfterWithdraw?.workingCapacity).isEqualTo(1)
+      assertThat(cellInCertAfterWithdraw?.maxCapacity).isEqualTo(2)
     }
 
     @Test
@@ -2627,6 +2921,345 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         }
 
       getDomainEvents(1)
+    }
+  }
+
+  @DisplayName("PUT /certification/prison/signed-op-cap-change")
+  @Nested
+  inner class SignedOpCapApprovalTest {
+
+    private fun requestSignedOpCapChange(newCapacity: Int = 10): CertificationApprovalRequestDto = webTestClient.put().uri("/certification/prison/signed-op-cap-change")
+      .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        jsonString(
+          SignedOpCapApprovalRequest(
+            prisonId = "LEI",
+            signedOperationalCapacity = newCapacity,
+            reasonForChange = "Prison capacity has increased",
+          ),
+        ),
+      )
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<CertificationApprovalRequestDto>()
+      .returnResult().responseBody!!
+
+    private fun getSignedOpCap(): Int = webTestClient.get().uri("/signed-op-cap/LEI")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<SignedOperationCapacityDto>()
+      .returnResult().responseBody!!.signedOperationCapacity
+
+    @Test
+    fun `can request a signed op cap change approval`() {
+      val pendingApproval = requestSignedOpCapChange(newCapacity = 10)
+
+      assertThat(pendingApproval.approvalType).isEqualTo(ApprovalType.SIGNED_OP_CAP)
+      assertThat(pendingApproval.status).isEqualTo(ApprovalRequestStatus.PENDING)
+      assertThat(pendingApproval.prisonId).isEqualTo("LEI")
+      assertThat(pendingApproval.currentSignedOperationCapacity).isEqualTo(12)
+      assertThat(pendingApproval.signedOperationCapacityChange).isEqualTo(-2)
+      assertThat(getSignedOpCap()).isEqualTo(12)
+    }
+
+    @Test
+    fun `can approve a signed op cap change`() {
+      val pendingApproval = requestSignedOpCapChange(newCapacity = 10)
+
+      val approvedRequest = webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            ApproveCertificationRequestDto(
+              approvalRequestReference = pendingApproval.id,
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(approvedRequest.status).isEqualTo(ApprovalRequestStatus.APPROVED)
+      assertThat(approvedRequest.approvalType).isEqualTo(ApprovalType.SIGNED_OP_CAP)
+      assertThat(getSignedOpCap()).isEqualTo(10)
+    }
+
+    @Test
+    fun `can reject a signed op cap change`() {
+      val pendingApproval = requestSignedOpCapChange(newCapacity = 10)
+
+      val rejectedRequest = webTestClient.put().uri("/certification/location/reject")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            RejectCertificationRequestDto(
+              approvalRequestReference = pendingApproval.id,
+              comments = "Capacity increase not approved",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(rejectedRequest.certificateId).isNull()
+      assertThat(rejectedRequest.status).isEqualTo(ApprovalRequestStatus.REJECTED)
+      assertThat(getSignedOpCap()).isEqualTo(12)
+    }
+
+    @Test
+    fun `can withdraw a signed op cap change`() {
+      val pendingApproval = requestSignedOpCapChange(newCapacity = 10)
+
+      val withdrawnRequest = webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            WithdrawCertificationRequestDto(
+              approvalRequestReference = pendingApproval.id,
+              comments = "Capacity change request withdrawn",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(withdrawnRequest.certificateId).isNull()
+      assertThat(withdrawnRequest.status).isEqualTo(ApprovalRequestStatus.WITHDRAWN)
+      assertThat(getSignedOpCap()).isEqualTo(12)
+    }
+  }
+
+  @DisplayName("Decision endpoint error scenarios")
+  @Nested
+  inner class DecisionErrorScenariosTest {
+
+    private fun createPendingCapacityChangeRequest(): UUID {
+      leedsWing.findAllLeafLocations().forEach { cell ->
+        prisonerSearchMockServer.stubSearchByLocations(
+          leedsWing.prisonId,
+          listOf(cell.getPathHierarchy()),
+          true,
+        )
+      }
+      val firstCell = leedsWing.findAllLeafLocations().first()
+      webTestClient.put().uri("/locations/${firstCell.id}/capacity")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            CapacityChangeRequest(
+              workingCapacity = 1,
+              maxCapacity = 1,
+              certifiedNormalAccommodation = 1,
+              temporaryWorkingCapacityChange = false,
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+
+      return webTestClient.get().uri("/locations/${firstCell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!.pendingApprovalRequestId!!
+    }
+
+    @Test
+    fun `approve returns 404 for a non-existent approval request`() {
+      webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = UUID.randomUUID())))
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotFound.errorCode)
+    }
+
+    @Test
+    fun `reject returns 404 for a non-existent approval request`() {
+      webTestClient.put().uri("/certification/location/reject")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(RejectCertificationRequestDto(approvalRequestReference = UUID.randomUUID(), comments = "test")))
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotFound.errorCode)
+    }
+
+    @Test
+    fun `withdraw returns 404 for a non-existent approval request`() {
+      webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(WithdrawCertificationRequestDto(approvalRequestReference = UUID.randomUUID(), comments = "test")))
+        .exchange()
+        .expectStatus().isNotFound
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotFound.errorCode)
+    }
+
+    @Test
+    fun `approve returns 400 when the approval request is already approved`() {
+      val pendingId = createPendingCapacityChangeRequest()
+
+      webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingId)))
+        .exchange()
+        .expectStatus().isOk
+      getDomainEvents(3)
+
+      webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingId)))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotInPendingStatus.errorCode)
+    }
+
+    @Test
+    fun `approve returns 400 when the approval request is already rejected`() {
+      val pendingId = createPendingCapacityChangeRequest()
+
+      webTestClient.put().uri("/certification/location/reject")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(RejectCertificationRequestDto(approvalRequestReference = pendingId, comments = "rejected")))
+        .exchange()
+        .expectStatus().isOk
+
+      webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingId)))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotInPendingStatus.errorCode)
+    }
+
+    @Test
+    fun `approve returns 400 when the approval request is already withdrawn`() {
+      val pendingId = createPendingCapacityChangeRequest()
+
+      webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(WithdrawCertificationRequestDto(approvalRequestReference = pendingId, comments = "withdrawn")))
+        .exchange()
+        .expectStatus().isOk
+
+      webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingId)))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotInPendingStatus.errorCode)
+    }
+
+    @Test
+    fun `reject returns 400 when the approval request is already rejected`() {
+      val pendingId = createPendingCapacityChangeRequest()
+
+      webTestClient.put().uri("/certification/location/reject")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(RejectCertificationRequestDto(approvalRequestReference = pendingId, comments = "rejected")))
+        .exchange()
+        .expectStatus().isOk
+
+      webTestClient.put().uri("/certification/location/reject")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(RejectCertificationRequestDto(approvalRequestReference = pendingId, comments = "rejected again")))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotInPendingStatus.errorCode)
+    }
+
+    @Test
+    fun `reject returns 400 when the approval request is already approved`() {
+      val pendingId = createPendingCapacityChangeRequest()
+
+      webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingId)))
+        .exchange()
+        .expectStatus().isOk
+      getDomainEvents(3)
+
+      webTestClient.put().uri("/certification/location/reject")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(RejectCertificationRequestDto(approvalRequestReference = pendingId, comments = "rejected")))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotInPendingStatus.errorCode)
+    }
+
+    @Test
+    fun `withdraw returns 400 when the approval request is already withdrawn`() {
+      val pendingId = createPendingCapacityChangeRequest()
+
+      webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(WithdrawCertificationRequestDto(approvalRequestReference = pendingId, comments = "withdrawn")))
+        .exchange()
+        .expectStatus().isOk
+
+      webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(WithdrawCertificationRequestDto(approvalRequestReference = pendingId, comments = "withdrawn again")))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotInPendingStatus.errorCode)
+    }
+
+    @Test
+    fun `withdraw returns 400 when the approval request is already approved`() {
+      val pendingId = createPendingCapacityChangeRequest()
+
+      webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingId)))
+        .exchange()
+        .expectStatus().isOk
+      getDomainEvents(3)
+
+      webTestClient.put().uri("/certification/location/withdraw")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(WithdrawCertificationRequestDto(approvalRequestReference = pendingId, comments = "withdrawn")))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.ApprovalRequestNotInPendingStatus.errorCode)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationResourceTest.kt
@@ -24,7 +24,6 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationService
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.SignedOpCapApprovalRequest
@@ -40,12 +39,8 @@ class CertificationResourceTest(@param:Autowired private val locationService: Lo
   private lateinit var mWing: ResidentialLocation
   private lateinit var aCell: Cell
 
-  @Autowired
-  lateinit var cellCertificateRepository: CellCertificateRepository
-
   @BeforeEach
   override fun setUp() {
-    cellCertificateRepository.deleteAll()
     super.setUp()
 
     webTestClient.put().uri("/prison-configuration/${wingZ.prisonId}/certification-approval-required/ACTIVE")
@@ -101,7 +96,6 @@ class CertificationResourceTest(@param:Autowired private val locationService: Lo
         defaultCNA = 1,
         wingDescription = "Wing M",
       ).toEntity(
-        createInDraft = true,
         createdBy = EXPECTED_USERNAME,
         clock = clock,
         linkedTransaction = linkedTransactionRepository.saveAndFlush(
@@ -113,6 +107,7 @@ class CertificationResourceTest(@param:Autowired private val locationService: Lo
             txStartTime = LocalDateTime.now(clock).minusDays(1),
           ),
         ),
+        createInDraft = true,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
@@ -49,7 +49,6 @@ class DraftLocationResourceTest : CommonDataTestBase() {
         numberOfSpurs = 0,
         wingDescription = "Wing G",
       ).toEntity(
-        createInDraft = true,
         createdBy = "TEST_USER",
         clock = clock,
         linkedTransaction = linkedTransactionRepository.saveAndFlush(
@@ -61,6 +60,8 @@ class DraftLocationResourceTest : CommonDataTestBase() {
             txStartTime = LocalDateTime.now(clock).minusDays(1),
           ),
         ),
+        createInDraft = true,
+        specialistCellType = SpecialistCellType.ESCAPE_LIST,
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationServiceTest.kt
@@ -58,6 +58,7 @@ class LocationServiceTest {
   private val authenticationHolder: HmppsAuthenticationHolder = mock()
   private val locationGroupFromPropertiesService: LocationGroupFromPropertiesService = mock()
   private val activePrisonService: ActivePrisonService = mock()
+  private val cellCertificateService: CellCertificateService = mock()
   private val prisonConfigurationRepository: PrisonConfigurationRepository = mock()
   private val groupsProperties: Properties = mock()
 
@@ -76,6 +77,7 @@ class LocationServiceTest {
     telemetryClient,
     locationGroupFromPropertiesService,
     activePrisonService,
+    cellCertificateService,
     groupsProperties,
   )
 


### PR DESCRIPTION
## Overview

When a prison operates with certification approval required (`certificationApprovalRequired = true`),
changes to specialist cell types that affect capacity now go through the same approval workflow used
for capacity changes, deactivation, reactivation, cell mark, and sanitation changes.

## Business rules

| Change | Prison has cert approval? | Outcome |
|---|---|---|
| Add/remove a **non-capacity-affecting** type (`affectsCapacity=false`) | Yes or No | Allowed directly; cert updated in-place |
| Swap capacity-affecting types (same count, different types) | Yes or No | Allowed directly; cert updated in-place |
| Add a **capacity-affecting** type (count increases) | No | Allowed directly |
| Add a **capacity-affecting** type (count increases) | Yes | Rejected — must use approval endpoint |
| Remove a **capacity-affecting** type (count decreases) | No | Allowed directly |
| Remove a **capacity-affecting** type (count decreases) | Yes | Rejected — must use approval endpoint |

The decision logic compares `count { it.affectsCapacity }` before and after. If that count changes
and the prison requires cert approval, the direct endpoint returns 400 and the caller must use the
new approval endpoint instead.

Capacity-affecting specialist cell types: `BIOHAZARD_DIRTY_PROTEST`, `CSU`,
`CONSTANT_SUPERVISION`, `DRY`, `UNFURNISHED`.

## Database migration

**`V1_89__specialist_cell_type_approval.sql`**

Adds a `pending_specialist_cell_types VARCHAR(300)` column to `certification_approval_request` to
store the proposed set of types (comma-separated enum names) for the new approval subtype.

The capacity columns (`working_capacity`, `max_capacity`, `certified_normal_accommodation`) were
already present from an earlier migration and are reused.

## New entity

**`SpecialistCellTypeChangeApprovalRequest`** — a new JPA entity in
`jpa/approvalrequest/`, discriminator value `SPECIALIST_CELL_TYPE`, extending
`LocationCertificationApprovalRequest`.

Fields:
- `specialistCellTypes: String` — comma-separated proposed specialist cell type names, stored in
  `pending_specialist_cell_types`
- `workingCapacity`, `maxCapacity`, `certifiedNormalAccommodation` — the target capacity values to
  apply alongside the type change on approval, reusing existing columns

Helper `getSpecialistCellTypesFromPendingList()` parses the CSV back to a `List<SpecialistCellType>`.

`toDto()` extends the base DTO with `specialistCellTypes` (proposed) and `currentSpecialistCellTypes`
(current state from the approval location snapshot).

## Changes to existing files

### `ApprovalType` enum (`CertificationApprovalRequest.kt`)
Added `SPECIALIST_CELL_TYPE(hasPendingValues = true)`. `hasPendingValues = true` means the
approval snapshot is generated with draft/pending changes included, consistent with other
capacity-altering approval types.

### `CellCertificate.kt`
Changed `specialistCellTypes` on `CellCertificateLocation` from `val` to `var` so it can be
updated in-place when a non-approval specialist cell type change is applied directly.

### `CellCertificateService`
Added `updateSpecialistCellTypesInCurrentCertificate(cell: Cell)`. Finds the current live
certificate for the cell's prison and updates the `specialistCellTypes` column for that cell's
entry in the certificate. Called after any direct (non-approval) update to specialist cell types
when cert approval is active.

### `LocationService.updateSpecialistCellTypes`
Previously, any specialist cell type change on a prison with cert approval enabled threw
`ChangesCannotBeMadeWithoutCertificationApprovalException`. Now it:
1. Compares the count of capacity-affecting types before and after.
2. If the count changes, throws the new `SpecialistCellTypeChangesRequireCertificationApprovalException`.
3. If the count stays the same (swap or non-capacity change), allows the update.
4. After a successful update, calls `cellCertificateService.updateSpecialistCellTypesInCurrentCertificate`
   to keep the live certificate in sync.

`CellCertificateService` is injected into `LocationService` via constructor.

### `Cell.kt`
Added `requestApprovalForSpecialistCellTypeChange(...)`, following the same pattern as
`requestApprovalForCapacityChange`, `requestApprovalForCellMarkChange`, etc. Guards against a
pending approval already existing, then constructs and registers a
`SpecialistCellTypeChangeApprovalRequest` via `addApprovalToLocation`.

### `ApprovalDecisionService`
Added a `is SpecialistCellTypeChangeApprovalRequest` branch in `handleComplexApprovalProcesses`.
The new `handleSpecialistCellTypeChange` method:
1. Checks that `maxCapacity` is not below current cell occupancy (same guard as capacity change).
2. Calls `cell.updateSpecialistCellTypes(...)` with the approved types.
3. Calls `cell.setCapacity(...)` with the approved capacity values.
4. Returns `LOCATION_AMENDED` for the cell (including parent), triggering domain event publishing.

### `ApprovalRequestService`
Added `requestSpecialistCellTypeChangeApproval(request: SpecialistCellTypeApprovalRequest)`:
1. Loads the cell by `locationId`.
2. Validates that the prison requires cert approval.
3. Validates that the proposed change actually requires approval (capacity-affecting count must
   differ; returns 400 if not).
4. Creates a linked transaction, calls `cell.requestApprovalForSpecialistCellTypeChange(...)`,
   saves via repository, emits a telemetry event, and returns the DTO.

Also added `CellLocationRepository` to the service constructor (needed to load `Cell` directly
rather than as `ResidentialLocation`).

Added `SpecialistCellTypeApprovalRequest` data class at the bottom of the file with fields:
`locationId`, `specialistCellTypes`, `workingCapacity`, `maxCapacity`,
`certifiedNormalAccommodation`, and optional `reasonForChange`.

### `ApprovalRequestResource`
Added `PUT /certification/location/specialist-cell-type-change` endpoint wired to
`approvalRequestService.requestSpecialistCellTypeChangeApproval`. Secured with
`ROLE_LOCATION_CERTIFICATION` (inherited from the controller-level `@PreAuthorize`). Includes
full OpenAPI documentation.

### `ErrorCode`
Added `SpecialistCellTypeChangesRequireCertificationApproval(135)`.

### `ApiExceptionHandler`
Added two new exception classes and handlers:
- `SpecialistCellTypeChangesRequireCertificationApprovalException` → HTTP 400, error code 135.
  Returned when the direct endpoint is called for a capacity-affecting type count change on a
  prison with cert approval enabled.
- `SpecialistCellTypeChangesDoNotRequireApprovalException` → HTTP 400, error code 135. Returned
  when the approval endpoint is called for a change that does not require approval (i.e. the
  capacity-affecting type count is unchanged).

### `CertificationApprovalRequestDto`
Added two nullable fields: `specialistCellTypes: Set<SpecialistCellType>?` (proposed types) and
`currentSpecialistCellTypes: Set<SpecialistCellType>?` (current types at time of request).

## Tests

`CertificationApprovalResourceTest` — new inner class `SpecialistCellTypeTest` with integration
tests covering:

1. Calling the direct endpoint to add a capacity-affecting type on a cert-approval prison → 400
2. Calling the direct endpoint to remove a capacity-affecting type on a cert-approval prison → 400
3. Swapping capacity-affecting types (same count) via direct endpoint → 200, cert updated in-place
4. Adding/removing non-capacity-affecting types via direct endpoint → 200, cert updated in-place
5. Requesting approval to add a capacity-affecting type → 200, approval DTO contains proposed
   types, current types, and new capacity values; cell is locked pending approval
6. Approving a specialist cell type change → 200, cell has new specialist types and new capacity,
   domain events published, new certificate generated
7. Rejecting a specialist cell type change → 200, cell unchanged, approval marked rejected
8. Withdrawing a specialist cell type change → 200, cell unchanged, approval marked withdrawn
9. Attempting to create a second approval when one is already pending → 400
10. Direct endpoint with no cert approval required → 200 (existing behaviour unchanged, no
    approval check applied)

`LocationServiceTest` — added `CellCertificateService` mock to the `LocationService` constructor
call to reflect the new dependency.
