### PR TITLE
MAPA-111 Capture top-level accommodation-type / used-for impact on certification approval requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CertificationApprovalRequestDto.kt
@@ -144,6 +144,12 @@ data class CertificationApprovalRequestDto(
 
   @param:Schema(description = "Current used-for types on the parent, surfaced for a convert-to-cell approval only when the proposed used-for types differ", required = false)
   val currentUsedForTypes: List<UsedForType>? = null,
+
+  @param:Schema(description = "Resulting (post-change) accommodation types at the top-level location (wing), surfaced only when this change alters the set of accommodation types held above the location being approved", required = false)
+  val topLevelAccommodationTypes: List<AccommodationType>? = null,
+
+  @param:Schema(description = "Resulting (post-change) used-for types at the top-level location (wing), surfaced together with topLevelAccommodationTypes when the change affects the levels above", required = false)
+  val topLevelUsedFor: List<UsedForType>? = null,
 )
 
 @Schema(description = "Request to approve a certification request")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -749,6 +749,24 @@ class Cell(
       null
     }
 
+    // Capture the resulting (post-conversion) accommodation types / used-for at the top-level wing so the UI can warn
+    // that the change affects the levels above. The converting room is not yet a residential cell, so the resulting
+    // set is the wing's current set plus the proposed type; only surfaced when that proposed type is not already held
+    // by the wing (i.e. the wing's set of accommodation types genuinely changes).
+    val topLevel = findTopLevelResidentialLocation()
+    val topLevelAccommodationTypes = topLevel.getAccommodationTypes(includeDraftCells = true)
+    val affectsLevelsAbove = this != topLevel && accommodationType !in topLevelAccommodationTypes
+    val resultingTopLevelAccommodationTypes = if (affectsLevelsAbove) {
+      (topLevelAccommodationTypes + accommodationType).toCsvOrNull()
+    } else {
+      null
+    }
+    val resultingTopLevelUsedFor = if (affectsLevelsAbove) {
+      (topLevel.getUsedForTypes(includeDraftCells = true) + (usedForTypes ?: emptyList())).toCsvOrNull()
+    } else {
+      null
+    }
+
     return addApprovalToLocation(
       ConvertToCellApprovalRequest(
         location = this,
@@ -770,6 +788,8 @@ class Cell(
         currentCellMark = cellMark?.let { this.cellMark },
         inCellSanitation = inCellSanitation,
         currentInCellSanitation = inCellSanitation?.let { this.inCellSanitation },
+        topLevelAccommodationTypes = resultingTopLevelAccommodationTypes,
+        topLevelUsedFor = resultingTopLevelUsedFor,
       ),
     ) as ConvertToCellApprovalRequest
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -198,6 +198,13 @@ open class ResidentialLocation(
       throw LocationDoesNotRequireApprovalException(getKey())
     }
 
+    // When the draft sits below the top-level wing and certifying it changes the set of accommodation types held by
+    // the wing, surface the resulting (post-change) top-level accommodation types / used-for so the UI can warn that
+    // levels above are affected. A brand-new draft wing (this == topLevel) has no level above, so nothing is captured.
+    val topLevel = findTopLevelResidentialLocation()
+    val affectsLevelsAbove = this != topLevel &&
+      topLevel.getAccommodationTypes(includeDraftCells = false) != topLevel.getAccommodationTypes(includeDraftCells = true)
+
     return addApprovalToLocation(
       DraftChangeApprovalRequest(
         location = this,
@@ -206,6 +213,8 @@ open class ResidentialLocation(
         maxCapacityChange = calcMaxCapacity(true) - calcMaxCapacity(),
         workingCapacityChange = calcWorkingCapacity(true) - calcWorkingCapacity(),
         certifiedNormalAccommodationChange = calcCertifiedNormalAccommodation(true) - calcCertifiedNormalAccommodation(),
+        topLevelAccommodationTypes = if (affectsLevelsAbove) topLevel.getAccommodationTypes(includeDraftCells = true).toCsvOrNull() else null,
+        topLevelUsedFor = if (affectsLevelsAbove) topLevel.getUsedForTypes(includeDraftCells = true).toCsvOrNull() else null,
       ),
     ) as DraftChangeApprovalRequest
   }
@@ -331,6 +340,20 @@ open class ResidentialLocation(
 
   fun getAccommodationTypes(): Set<AccommodationType> = cellLocations().filter { isCurrentCellOrNotPermanentlyInactive(it) }
     .map { it.accommodationType }
+    .toSet()
+
+  // Variants that can exclude draft cells, used when working out whether a pending change alters the set of
+  // accommodation types / used-for held above the location being approved (the no-arg getAccommodationTypes()
+  // already includes draft cells, so includeDraftCells = true matches its behaviour).
+  fun getAccommodationTypes(includeDraftCells: Boolean): Set<AccommodationType> = cellLocations()
+    .filter { isCurrentCellOrNotPermanentlyInactive(it) && (includeDraftCells || !it.isDraft()) }
+    .map { it.accommodationType }
+    .toSet()
+
+  fun getUsedForTypes(includeDraftCells: Boolean): Set<UsedForType> = cellLocations()
+    .filter { isCurrentCellOrNotPermanentlyInactive(it) && (includeDraftCells || !it.isDraft()) }
+    .flatMap { it.usedFor }
+    .map { it.usedFor }
     .toSet()
 
   open fun getUsedForValues(): MutableSet<CellUsedFor> = cellLocations().filter { isCurrentCellOrNotPermanentlyInactive(it) }
@@ -944,6 +967,14 @@ fun isCapacityRequired(
   accommodationType: AccommodationType = AccommodationType.NORMAL_ACCOMMODATION,
 ): Boolean = accommodationType == AccommodationType.NORMAL_ACCOMMODATION &&
   (typesToCheck.isEmpty() || typesToCheck.any { !it.affectsCapacity })
+
+// Serialise the top-level accommodation-type / used-for sets captured on a certification approval request,
+// sorted for deterministic output. Returns null for an empty set so the field stays unset.
+@JvmName("accommodationTypesToCsvOrNull")
+fun Collection<AccommodationType>.toCsvOrNull(): String? = sortedBy { it.sequence }.joinToString(",") { it.name }.takeIf { it.isNotEmpty() }
+
+@JvmName("usedForTypesToCsvOrNull")
+fun Collection<UsedForType>.toCsvOrNull(): String? = sortedBy { it.sequence }.joinToString(",") { it.name }.takeIf { it.isNotEmpty() }
 
 enum class ResidentialHousingType(
   val description: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/ConvertToCellApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/ConvertToCellApprovalRequest.kt
@@ -74,6 +74,10 @@ open class ConvertToCellApprovalRequest(
 
   open var currentInCellSanitation: Boolean? = null,
 
+  topLevelAccommodationTypes: String? = null,
+
+  topLevelUsedFor: String? = null,
+
 ) : LocationCertificationApprovalRequest(
   id = id,
   location = location,
@@ -81,6 +85,8 @@ open class ConvertToCellApprovalRequest(
   requestedBy = requestedBy,
   requestedDate = requestedDate,
   reasonForChange = reasonForChange,
+  topLevelAccommodationTypes = topLevelAccommodationTypes,
+  topLevelUsedFor = topLevelUsedFor,
 ) {
   fun getSpecialistCellTypesFromPendingList(): List<SpecialistCellType> = specialistCellTypes
     ?.split(",")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/DraftChangeApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/DraftChangeApprovalRequest.kt
@@ -17,6 +17,8 @@ open class DraftChangeApprovalRequest(
   certifiedNormalAccommodationChange: Int,
   workingCapacityChange: Int,
   maxCapacityChange: Int,
+  topLevelAccommodationTypes: String? = null,
+  topLevelUsedFor: String? = null,
 ) : LocationCertificationApprovalRequest(
   id = id,
   location = location,
@@ -27,6 +29,8 @@ open class DraftChangeApprovalRequest(
   certifiedNormalAccommodationChange = certifiedNormalAccommodationChange,
   workingCapacityChange = workingCapacityChange,
   maxCapacityChange = maxCapacityChange,
+  topLevelAccommodationTypes = topLevelAccommodationTypes,
+  topLevelUsedFor = topLevelUsedFor,
 ) {
 
   override fun getApprovalType() = ApprovalType.DRAFT

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/LocationCertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/LocationCertificationApprovalRequest.kt
@@ -8,8 +8,10 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import org.hibernate.annotations.SortNatural
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.AccommodationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.UsedForType
 import java.time.Clock
 import java.time.LocalDateTime
 import java.util.SortedSet
@@ -38,6 +40,16 @@ abstract class LocationCertificationApprovalRequest(
   @Column(nullable = false)
   open var maxCapacityChange: Int = 0,
 
+  // Resulting (post-change) accommodation types / used-for at the top-level location (wing). Populated only when this
+  // change alters the set of accommodation types held above the location being approved (see Cell
+  // .requestApprovalForConvertToCell and ResidentialLocation.requestApprovalForDraftLocation); null means the levels
+  // above are unaffected. Stored as a comma-separated list, mirroring currentAccommodationTypes.
+  @Column(name = "top_level_accommodation_types", nullable = true)
+  open var topLevelAccommodationTypes: String? = null,
+
+  @Column(name = "top_level_used_for_types", nullable = true)
+  open var topLevelUsedFor: String? = null,
+
   @SortNatural
   @OneToMany(fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinColumn(name = "certification_approval_request_id", nullable = false)
@@ -59,12 +71,26 @@ abstract class LocationCertificationApprovalRequest(
     workingCapacityChange = workingCapacityChange,
     maxCapacityChange = maxCapacityChange,
     certificateId = cellCertificateId,
+    topLevelAccommodationTypes = getTopLevelAccommodationTypesFromList().takeIf { it.isNotEmpty() },
+    topLevelUsedFor = getTopLevelUsedForFromList().takeIf { it.isNotEmpty() },
     locations = if (showLocations) {
       locations.filter { it.pathHierarchy == location.getPathHierarchy() }.map { it.toDto() }
     } else {
       null
     },
   )
+
+  fun getTopLevelAccommodationTypesFromList(): List<AccommodationType> = topLevelAccommodationTypes
+    ?.split(",")
+    ?.filter { it.isNotBlank() }
+    ?.map { AccommodationType.valueOf(it.trim()) }
+    ?: emptyList()
+
+  fun getTopLevelUsedForFromList(): List<UsedForType> = topLevelUsedFor
+    ?.split(",")
+    ?.filter { it.isNotBlank() }
+    ?.map { UsedForType.valueOf(it.trim()) }
+    ?: emptyList()
 
   fun generateLocationHierarchy(): CertificationApprovalRequestLocation = location.toCertificationApprovalRequestLocation(
     includeDraftOrPending = getApprovalType().hasPendingValues,

--- a/src/main/resources/db/migration/V1_94__top_level_accommodation_types_on_approval_request.sql
+++ b/src/main/resources/db/migration/V1_94__top_level_accommodation_types_on_approval_request.sql
@@ -1,0 +1,4 @@
+-- Resulting (post-change) top-level (wing) accommodation types / used-for, captured on a certification approval
+-- request when the change alters the set of accommodation types held by the wing above the location being approved.
+ALTER TABLE certification_approval_request ADD COLUMN top_level_accommodation_types VARCHAR(255);
+ALTER TABLE certification_approval_request ADD COLUMN top_level_used_for_types VARCHAR(255);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -112,6 +112,10 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.locations).isNotNull
       assertThat(pendingApproval.locations).hasSize(1)
 
+      // The draft IS the top-level wing (nothing above it), so no top-level impact is recorded.
+      assertThat(pendingApproval.topLevelAccommodationTypes).isNull()
+      assertThat(pendingApproval.topLevelUsedFor).isNull()
+
       // Approve the request to generate a cell certificate
       val approvedRequest = webTestClient.put().uri("/certification/location/approve")
         .headers(setAuthorisation(user = EXPECTED_USERNAME, roles = listOf("ROLE_LOCATION_CERTIFICATION")))
@@ -185,6 +189,45 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(activeApprovedNewWing.status).isEqualTo(DerivedLocationStatus.ACTIVE)
       assertThat(activeApprovedNewWing.inactiveStatus).isNull()
       assertThat(activeApprovedNewWing.deactivatedReason).isNull()
+    }
+
+    @Test
+    fun `draft cell below an existing wing surfaces the resulting top-level accommodation types`() {
+      // Leeds wing A is certified and every cell is NORMAL_ACCOMMODATION. Add a DRAFT CARE_AND_SEPARATION cell beneath
+      // an existing landing so that, once approved, the wing above will span two accommodation types.
+      val landingA1 = leedsWing.findSubLocations().first { it.getKey() == "LEI-A-1" }
+
+      webTestClient.post().uri("/locations/create-cells")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          createCellInitialisationRequest(
+            prisonId = "LEI",
+            parentLocation = landingA1.id,
+            startingCellNumber = 10,
+            accommodationType = AccommodationType.CARE_AND_SEPARATION,
+          ).copy(newLevelAboveCells = null),
+        )
+        .exchange()
+        .expectStatus().isCreated
+
+      val draftCell = repository.findOneByKey("LEI-A-1-010")!!
+
+      val pendingApproval = webTestClient.put().uri("/certification/location/request-approval")
+        .headers(setAuthorisation(user = EXPECTED_USERNAME, roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(LocationApprovalRequest(locationId = draftCell.id!!)))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<CertificationApprovalRequestDto>()
+        .returnResult().responseBody!!
+
+      assertThat(pendingApproval.approvalType).isEqualTo(ApprovalType.DRAFT)
+      // The draft sits below the top-level wing, which currently only holds NORMAL_ACCOMMODATION; certifying the
+      // CARE_AND_SEPARATION cell changes the set of accommodation types held above it, so the resulting (post-change)
+      // top-level accommodation types are surfaced.
+      assertThat(pendingApproval.topLevelAccommodationTypes)
+        .containsExactlyInAnyOrder(AccommodationType.NORMAL_ACCOMMODATION, AccommodationType.CARE_AND_SEPARATION)
     }
   }
 
@@ -3655,6 +3698,11 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(approval.currentAccommodationTypes).isNull()
       assertThat(approval.currentUsedForTypes).isNull()
 
+      // The wing's cells are all NORMAL_ACCOMMODATION and the proposed type matches, so the levels above
+      // are unaffected and no top-level impact is surfaced.
+      assertThat(approval.topLevelAccommodationTypes).isNull()
+      assertThat(approval.topLevelUsedFor).isNull()
+
       // A converted room has no current capacity, so the change is "None -> new".
       assertThat(approval.locations!![0].currentWorkingCapacity).isEqualTo(0)
       assertThat(approval.locations[0].currentMaxCapacity).isEqualTo(0)
@@ -3680,6 +3728,12 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(approval.currentAccommodationTypes).containsExactly(AccommodationType.NORMAL_ACCOMMODATION)
       // Used-for still matches the parent, so it is not surfaced.
       assertThat(approval.currentUsedForTypes).isNull()
+
+      // The wing above only holds NORMAL_ACCOMMODATION today, so the proposed CARE_AND_SEPARATION changes the set of
+      // accommodation types held above the cell: the resulting (post-change) top-level values are surfaced.
+      assertThat(approval.topLevelAccommodationTypes)
+        .containsExactlyInAnyOrder(AccommodationType.NORMAL_ACCOMMODATION, AccommodationType.CARE_AND_SEPARATION)
+      assertThat(approval.topLevelUsedFor).contains(UsedForType.STANDARD_ACCOMMODATION)
     }
 
     @Test
@@ -3697,6 +3751,11 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(approval.currentAccommodationTypes).isNull()
       // The parent's current used-for is surfaced because a proposed used-for is not held by it.
       assertThat(approval.currentUsedForTypes).containsExactly(UsedForType.STANDARD_ACCOMMODATION)
+
+      // The proposed accommodation type matches the wing, so the levels above are not flagged even though the
+      // proposed used-for differs (the top-level impact is gated on the accommodation-type set changing).
+      assertThat(approval.topLevelAccommodationTypes).isNull()
+      assertThat(approval.topLevelUsedFor).isNull()
     }
 
     @Test


### PR DESCRIPTION
MAPA-111 Capture top-level accommodation-type / used-for impact on certification approval requests

## Why

When an approval changes a cell's accommodation type, the **top-level** location (the WING — the highest-level
location with no parent) above it can end up holding a *different set* of accommodation types than before. For
example, converting a room to a `CARE_AND_SEPARATION` cell while every other cell on the wing is
`NORMAL_ACCOMMODATION` means the wing (and the landings between) now span two accommodation types.

Previously a `ConvertToCellApprovalRequest` only captured the **immediate parent's** current values
(`currentAccommodationTypes` / `currentUsedForTypes`). There was nothing to tell the user that their change ripples up
to affect the levels above the location being approved.

## What

Two new fields are added to the shared base entity `LocationCertificationApprovalRequest`, so they apply to both the
DRAFT and CONVERT_ROOM_TO_CELL approvals (the only two approval types that change accommodation type):

- `topLevelAccommodationTypes` — the **resulting (post-change)** set of accommodation types at the top-level wing.
- `topLevelUsedFor` — the **resulting (post-change)** set of used-for types at the top-level wing.

They are populated **only when**:
- the resulting top-level accommodation-type set **differs** from the pre-request set, **and**
- the location seeking approval sits **below** the top level (i.e. there is genuinely a parent above being affected).

A brand-new draft wing — where the location being approved *is* the top level — leaves both fields null, since there
is no level above it to flag. Both fields are populated together, gated on the accommodation-type set changing.

## Changes

- **Migration** `V1_94__top_level_accommodation_types_on_approval_request.sql` — adds
  `top_level_accommodation_types` / `top_level_used_for_types` columns to `certification_approval_request`.
- **`LocationCertificationApprovalRequest`** — new CSV columns, parse helpers, and `toDto` wiring (inherited by both
  subclasses). Values forwarded through the `DraftChangeApprovalRequest` and `ConvertToCellApprovalRequest`
  constructors.
- **`CertificationApprovalRequestDto`** — two new nullable list fields with OpenAPI schema descriptions.
- **`ResidentialLocation`** — new `getAccommodationTypes(includeDraftCells)` / `getUsedForTypes(includeDraftCells)`
  helpers and `toCsvOrNull()` serialisers; `requestApprovalForDraftLocation` computes the top-level impact by
  comparing the wing's accommodation types with vs. without the draft cells.
- **`Cell`** — `requestApprovalForConvertToCell` computes the resulting top-level set as
  `currentTopLevelTypes ∪ {proposedType}`, gated on the proposed type not already being held above.

## Tests

`CertificationApprovalResourceTest`:
- Convert-to-cell to `CARE_AND_SEPARATION` → surfaces the resulting `[NORMAL_ACCOMMODATION, CARE_AND_SEPARATION]`
  plus `topLevelUsedFor`.
- Convert-to-cell matching the wing (`NORMAL_ACCOMMODATION`), and the used-for-only-differs case → both fields null.
- Draft whole wing → both fields null (the wing is itself the top level).
- New draft `CARE_AND_SEPARATION` cell added below an existing certified wing → surfaces the resulting
  `[NORMAL_ACCOMMODATION, CARE_AND_SEPARATION]`.

