### PR TITLE
MAPA-112 Tidy-up: correct request TransactionType and avoid duplicate baseline certificate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
@@ -74,7 +74,7 @@ class ApprovalRequestService(
 
     val linkedTransaction = sharedLocationService.createLinkedTransaction(
       prisonId = location.prisonId,
-      type = TransactionType.APPROVE_CERTIFICATION_REQUEST,
+      type = TransactionType.REQUEST_CERTIFICATION_APPROVAL,
       detail = "Requesting approval for location ${location.getKey()}",
     )
     val now = now(clock)
@@ -105,7 +105,7 @@ class ApprovalRequestService(
 
     val linkedTransaction = sharedLocationService.createLinkedTransaction(
       prisonId = topLevelLocation.prisonId,
-      type = TransactionType.APPROVE_CERTIFICATION_REQUEST,
+      type = TransactionType.REQUEST_CERTIFICATION_APPROVAL,
       detail = "Requesting reactivation approval for location ${topLevelLocation.getKey()}",
     )
 
@@ -223,7 +223,7 @@ class ApprovalRequestService(
     val linkedTransaction = sharedLocationService.createLinkedTransaction(
       prisonId = requestToApprove.prisonId,
       detail = "Requesting approval for signed op cap change for ${requestToApprove.prisonId}",
-      type = TransactionType.APPROVE_CERTIFICATION_REQUEST,
+      type = TransactionType.REQUEST_CERTIFICATION_APPROVAL,
     )
     val now = now(clock)
     val username = sharedLocationService.getUsername()
@@ -264,7 +264,7 @@ class ApprovalRequestService(
 
     val linkedTransaction = sharedLocationService.createLinkedTransaction(
       prisonId = cell.prisonId,
-      type = TransactionType.APPROVE_CERTIFICATION_REQUEST,
+      type = TransactionType.REQUEST_CERTIFICATION_APPROVAL,
       detail = "Requesting specialist cell type change approval for location ${cell.getKey()}",
     )
     val username = sharedLocationService.getUsername()
@@ -327,7 +327,7 @@ class ApprovalRequestService(
 
     val linkedTransaction = sharedLocationService.createLinkedTransaction(
       prisonId = location.prisonId,
-      type = TransactionType.APPROVE_CERTIFICATION_REQUEST,
+      type = TransactionType.REQUEST_CERTIFICATION_APPROVAL,
       detail = "Requesting permanent deactivation approval for location ${location.getKey()}",
     )
     val username = sharedLocationService.getUsername()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -73,6 +73,8 @@ class CellCertificateService(
     return cellCertificate.toDto(showLocations = true)
   }
 
+  fun hasCurrentCellCertificate(prisonId: String): Boolean = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(prisonId) != null
+
   fun updateSpecialistCellTypesInCurrentCertificate(cell: Cell) {
     val currentCert = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(cell.prisonId) ?: return
     currentCert.findLocationInCertificate(cell.getPathHierarchy())?.let { certLocation ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -833,7 +833,7 @@ class LocationService(
           )
           trackingTx = linkedTransaction ?: sharedLocationService.createLinkedTransaction(
             prisonId = locCapChange.prisonId,
-            type = TransactionType.APPROVE_CERTIFICATION_REQUEST,
+            type = TransactionType.REQUEST_CERTIFICATION_APPROVAL,
             detail = "Capacity request change for ${locCapChange.getKey()} w/c changing from ${locCapChange.calcWorkingCapacity()} to $workingCapacity, max capacity changing from ${locCapChange.capacity?.maxCapacity} to $maxCapacity and CNA changing from ${locCapChange.capacity?.certifiedNormalAccommodation} to $cna",
           )
           val approvalRequest = locCapChange.requestApprovalForCapacityChange(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonConfigurationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonConfigurationService.kt
@@ -23,6 +23,7 @@ class PrisonConfigurationService(
   private val linkedTransactionRepository: LinkedTransactionRepository,
   private val authenticationHolder: HmppsAuthenticationHolder,
   private val approvalDecisionService: ApprovalDecisionService,
+  private val cellCertificateService: CellCertificateService,
   private val clock: Clock,
   private val telemetryClient: TelemetryClient,
 ) {
@@ -126,7 +127,7 @@ class PrisonConfigurationService(
       )
       log.info("Updated certification approval status [$tx]")
 
-      if (approvalActive) {
+      if (approvalActive && !cellCertificateService.hasCurrentCellCertificate(prisonId)) {
         approvalDecisionService.baselinePrisonCertificate(prisonId)
       }
       tx.txEndTime = LocalDateTime.now(clock)


### PR DESCRIPTION
## MAPA-112

Tidy-up follow-ups on the cell-certificate work.

### Changes

1. **Correct the linked `TransactionType` when *requesting* certification approval.**
   The request path was tagging transactions as `APPROVE_CERTIFICATION_REQUEST` (the type used when an approval is *granted*). It now correctly uses `REQUEST_CERTIFICATION_APPROVAL` across `ApprovalRequestService` (location approval, reactivation, signed-op-cap change, specialist cell type change, permanent deactivation) and the capacity-change path in `LocationService`.

2. **Avoid creating a duplicate baseline certificate.**
   The cell-certificate upload feature already creates a `CellCertificate` for a prison. Previously, turning on the certification approval process (`PUT /prison-configuration/{prisonId}/certification-approval-required/ACTIVE`) unconditionally called `baselinePrisonCertificate(...)`, creating a second certificate. `PrisonConfigurationService.updateCertificationApprovalProcess` now skips the baseline call when the prison already has a current cell certificate, via the new `CellCertificateService.hasCurrentCellCertificate(prisonId)` helper.
