### PR TITLE
MAPA-112 Prevent duplicate cell certificates from concurrent upload processing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateUploadRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateUploadRepository.kt
@@ -1,6 +1,10 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUpload
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUploadStatus
@@ -9,6 +13,15 @@ import java.util.UUID
 @Repository
 interface CellCertificateUploadRepository : JpaRepository<CellCertificateUpload, UUID> {
   fun findFirstByPrisonIdAndStatusIn(prisonId: String, statuses: Collection<CellCertificateUploadStatus>): CellCertificateUpload?
+
+  /**
+   * Fetches the upload while taking a pessimistic write lock (SELECT ... FOR UPDATE) so that concurrent
+   * consumers (the same SQS message redelivered to multiple pods) serialise on the row and only one can
+   * claim it for processing. Must be called within a transaction.
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select u from CellCertificateUpload u where u.id = :id")
+  fun findByIdForUpdate(@Param("id") id: UUID): CellCertificateUpload?
 
   fun findByPrisonIdOrderByRequestedDateDesc(prisonId: String): List<CellCertificateUpload>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CellCertificateUploadApprovalRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUpload
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUploadLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUploadLocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUploadStatus
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.Certifi
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LinkedTransactionRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.SignedOperationCapacityRepository
 import java.time.Clock
+import java.time.Duration
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -108,7 +110,11 @@ class CellCertificateUploadProcessingService(
   }
 
   private fun startProcessing(uploadId: UUID): ProcessingContext? = newTransaction.execute {
-    val upload = cellCertificateUploadRepository.findById(uploadId).orElse(null)
+    // Pessimistic lock so concurrent consumers (the same SQS message redelivered to multiple pods while a
+    // long upload is still in flight) serialise here: the first claims the upload (PENDING -> STARTED) and
+    // commits; the others then read STARTED and skip, guaranteeing a single run and a single certificate.
+    val upload = cellCertificateUploadRepository.findByIdForUpdate(uploadId)
+    val now = LocalDateTime.now(clock)
     when {
       upload == null -> {
         log.warn("Cell certificate upload $uploadId not found, ignoring")
@@ -118,11 +124,18 @@ class CellCertificateUploadProcessingService(
         log.info("Cell certificate upload $uploadId already FINISHED, ignoring duplicate message")
         null
       }
+      upload.status == CellCertificateUploadStatus.STARTED && !isStaleClaim(upload, now) -> {
+        log.info("Cell certificate upload $uploadId already being processed by another consumer, ignoring duplicate message")
+        null
+      }
       else -> {
-        if (upload.status == CellCertificateUploadStatus.PENDING) {
-          upload.status = CellCertificateUploadStatus.STARTED
-          upload.startTime = LocalDateTime.now(clock)
+        // PENDING, or a STARTED claim that has gone stale (the previous run crashed) - (re)claim it and
+        // process whatever rows are still PENDING.
+        if (upload.status == CellCertificateUploadStatus.STARTED) {
+          log.warn("Cell certificate upload $uploadId STARTED at ${upload.startTime} looks stale, re-claiming")
         }
+        upload.status = CellCertificateUploadStatus.STARTED
+        upload.startTime = now
 
         val linkedTransaction = sharedLocationService.createLinkedTransaction(
           prisonId = upload.prisonId,
@@ -238,7 +251,9 @@ class CellCertificateUploadProcessingService(
   }
 
   private fun finish(uploadId: UUID, linkedTransactionId: UUID) {
-    val upload = cellCertificateUploadRepository.findById(uploadId).orElse(null) ?: return
+    // Lock the row again so the FINISHED check-and-set is atomic - defence in depth against any concurrent
+    // path slipping past the claim guard and double-creating a certificate.
+    val upload = cellCertificateUploadRepository.findByIdForUpdate(uploadId) ?: return
     if (upload.status == CellCertificateUploadStatus.FINISHED) return
 
     upload.processedRecords = upload.locations.count { it.status == CellCertificateUploadLocationStatus.PROCESSED }
@@ -272,6 +287,15 @@ class CellCertificateUploadProcessingService(
     log.info("Finished cell certificate upload ${upload.id}: processed=${upload.processedRecords}, skipped=${upload.skippedRecords}, failed=${upload.failedRecords}, certificate=${cellCertificate.id}")
   }
 
+  /**
+   * A STARTED claim is considered stale (its consumer crashed) once its startTime is older than
+   * [STALE_CLAIM_THRESHOLD], allowing a redelivered message to re-claim and finish the upload.
+   */
+  private fun isStaleClaim(upload: CellCertificateUpload, now: LocalDateTime): Boolean {
+    val startTime = upload.startTime ?: return true
+    return startTime.isBefore(now.minus(STALE_CLAIM_THRESHOLD))
+  }
+
   data class ProcessingContext(
     val pendingLocationIds: List<UUID>,
     val linkedTransactionId: UUID,
@@ -280,5 +304,8 @@ class CellCertificateUploadProcessingService(
 
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
+
+    /** How long a STARTED upload can sit untouched before a redelivery is allowed to re-claim it. */
+    private val STALE_CLAIM_THRESHOLD: Duration = Duration.ofMinutes(30)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
@@ -10,6 +10,8 @@ import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUpload
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUploadLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUploadLocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUploadStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateUploadRepository
@@ -17,6 +19,10 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.service.CellCertificat
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.UPDATE_CELL_CERTIFICATE_QUEUE_CONFIG_KEY
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import java.time.LocalDateTime
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
 
@@ -140,5 +146,53 @@ class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
     processingService.process(uploadId)
 
     assertThat(cellCertificateRepository.findByPrisonIdOrderByApprovedDateDesc("MDI").filter { it.toDto().current }).hasSize(1)
+  }
+
+  @Test
+  fun `concurrent processing of the same upload creates only one certificate`() {
+    // Build a PENDING upload directly (a single no-change row) without sending an SQS message, so the test
+    // controls when processing is invoked. cell2 already has 2/2/2, so the row is a no-op (SKIPPED); this
+    // isolates the test to the claim/finish concurrency rather than capacity validation.
+    val uploadId = TransactionTemplate(transactionManager).execute {
+      val upload = CellCertificateUpload(
+        prisonId = "MDI",
+        requestedBy = "TEST_USER",
+        requestedDate = LocalDateTime.now(),
+        totalRecords = 1,
+      ).apply {
+        addLocation(
+          CellCertificateUploadLocation(
+            locationKey = cell2.getKey(),
+            maxCapacity = 2,
+            workingCapacity = 2,
+            certifiedNormalAccommodation = 2,
+          ),
+        )
+      }
+      cellCertificateUploadRepository.save(upload).id!!
+    }!!
+
+    // Simulate the same SQS message being redelivered to several pods at once. Without the pessimistic
+    // claim each run would create its own certificate (the bug); the lock must serialise them to one.
+    val threadCount = 3
+    val startLatch = CountDownLatch(1)
+    val executor = Executors.newFixedThreadPool(threadCount)
+    try {
+      val futures = (1..threadCount).map {
+        executor.submit {
+          startLatch.await()
+          processingService.process(uploadId)
+        }
+      }
+      startLatch.countDown()
+      futures.forEach { it.get(30, TimeUnit.SECONDS) }
+    } finally {
+      executor.shutdownNow()
+    }
+
+    TransactionTemplate(transactionManager).execute {
+      assertThat(cellCertificateUploadRepository.findById(uploadId).get().status).isEqualTo(CellCertificateUploadStatus.FINISHED)
+    }
+    assertThat(cellCertificateRepository.findByPrisonIdOrderByApprovedDateDesc("MDI")).hasSize(1)
   }
 }


### PR DESCRIPTION
## MAPA-112

### Problem

Uploading a large prison (e.g. MKI, 1421 rows, ~8 min to process) produced **3 cell certificates** instead of 1.

The async upload is processed by an `@SqsListener`, and the SQS message is only deleted when processing returns. The `update_cell_certificate_queue` has a **120s visibility timeout** and `maxReceiveCount = 3`, so a multi-minute job let the message become visible again and be **redelivered to other pods**, processing the same upload concurrently — one certificate per run (3 deliveries → 3 certificates).

The existing guards weren't enough: `startProcessing()` only skipped `FINISHED` uploads (an in-flight `STARTED` upload was processed again), and `finish()` used a non-atomic `if (status == FINISHED) return` across separate transactions.

### Change

- New `CellCertificateUploadRepository.findByIdForUpdate` with `@Lock(PESSIMISTIC_WRITE)` (`SELECT … FOR UPDATE`).
- `startProcessing()` claims the upload under the row lock: the first consumer moves `PENDING → STARTED` and commits; concurrent consumers then read `STARTED` and **skip**, so only one run proceeds and a single certificate is created. A 30-minute stale-claim threshold still lets a redelivery re-claim an upload whose consumer crashed mid-processing.
- `finish()` re-locks the row so the `FINISHED` check-and-set is atomic (defence in depth).

The lock is held only for the brief claim/finish transactions — the long per-row loop runs outside it.

### Testing

- New integration test processes the same upload from 3 threads simultaneously and asserts exactly one certificate is produced.
- Full suite: `./gradlew test` — 831 tests pass. `ktlintCheck` clean.

### Follow-ups (separate)

- Raise the queue `visibility_timeout_seconds` in cloud-platform-environments to reduce redelivery churn.
- Reconcile the duplicate MKI certificates already created.
