### PR TITLE
MAPA-112 Cell certificate upload: live progress counts and treat location-not-found as a failure

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateUploadRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateUploadRepository.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository
 import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -22,6 +23,20 @@ interface CellCertificateUploadRepository : JpaRepository<CellCertificateUpload,
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select u from CellCertificateUpload u where u.id = :id")
   fun findByIdForUpdate(@Param("id") id: UUID): CellCertificateUpload?
+
+  // Atomic per-row increments so the "so far" counts climb during processing and are visible to a GET
+  // refresh, rather than only being written at the end in finish().
+  @Modifying
+  @Query("update CellCertificateUpload u set u.processedRecords = u.processedRecords + 1 where u.id = :id")
+  fun incrementProcessedRecords(@Param("id") id: UUID)
+
+  @Modifying
+  @Query("update CellCertificateUpload u set u.skippedRecords = u.skippedRecords + 1 where u.id = :id")
+  fun incrementSkippedRecords(@Param("id") id: UUID)
+
+  @Modifying
+  @Query("update CellCertificateUpload u set u.failedRecords = u.failedRecords + 1 where u.id = :id")
+  fun incrementFailedRecords(@Param("id") id: UUID)
 
   fun findByPrisonIdOrderByRequestedDateDesc(prisonId: String): List<CellCertificateUpload>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
@@ -59,7 +59,7 @@ class CellCertificateUploadProcessingService(
     context.pendingLocationIds.forEach { locationId ->
       try {
         val changedId = requiresNewTransaction.execute {
-          processRow(locationId, context.linkedTransactionId, context.requestedBy)
+          processRow(locationId, uploadId, context.linkedTransactionId, context.requestedBy)
         }
         if (changedId != null) capacityChangedLocationIds.add(changedId)
       } catch (e: Exception) {
@@ -156,7 +156,7 @@ class CellCertificateUploadProcessingService(
   }
 
   /** @return the cell's location id when its capacity (max/working/CNA) changed, otherwise null. */
-  private fun processRow(locationId: UUID, linkedTransactionId: UUID, requestedBy: String): UUID? {
+  private fun processRow(locationId: UUID, uploadId: UUID, linkedTransactionId: UUID, requestedBy: String): UUID? {
     val row = cellCertificateUploadLocationRepository.findById(locationId).orElse(null) ?: return null
     val now = LocalDateTime.now(clock)
     var capacityChangedLocationId: UUID? = null
@@ -164,7 +164,7 @@ class CellCertificateUploadProcessingService(
     try {
       val cell = cellLocationRepository.findOneByKey(row.locationKey)
       if (cell == null) {
-        row.markSkipped("Location not found", now)
+        row.markFailed("Location not found", now)
       } else if (cell.isPermanentlyDeactivated()) {
         row.markSkipped("Archived location", now)
       } else {
@@ -178,7 +178,22 @@ class CellCertificateUploadProcessingService(
       row.markFailed("Update failed: ${e.message}", now)
     }
     cellCertificateUploadLocationRepository.save(row)
+    incrementRunningCount(uploadId, row.status)
     return capacityChangedLocationId
+  }
+
+  /**
+   * Bumps the matching running count on the upload master record so the "so far" processed/skipped/failed
+   * totals are visible to a GET refresh while the upload is still being processed. Committed with the row's
+   * own transaction; finish() later recomputes the authoritative totals from the location rows.
+   */
+  private fun incrementRunningCount(uploadId: UUID, status: CellCertificateUploadLocationStatus) {
+    when (status) {
+      CellCertificateUploadLocationStatus.PROCESSED -> cellCertificateUploadRepository.incrementProcessedRecords(uploadId)
+      CellCertificateUploadLocationStatus.SKIPPED -> cellCertificateUploadRepository.incrementSkippedRecords(uploadId)
+      CellCertificateUploadLocationStatus.FAILED -> cellCertificateUploadRepository.incrementFailedRecords(uploadId)
+      CellCertificateUploadLocationStatus.PENDING -> {}
+    }
   }
 
   /** @return true when the cell's capacity (max/working/CNA) values were changed. */

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
@@ -195,4 +195,71 @@ class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
     }
     assertThat(cellCertificateRepository.findByPrisonIdOrderByApprovedDateDesc("MDI")).hasSize(1)
   }
+
+  @Test
+  fun `a location that cannot be found is recorded as a failure`() {
+    prisonerSearchMockServer.stubSearchByLocations("MDI", listOf(cell1.getPathHierarchy()), false)
+
+    val body = jsonString(
+      UpdateCapacityRequest(
+        locations = mapOf(
+          // existing cell, working capacity reduced 2 -> 1
+          cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 1, certifiedNormalAccommodation = 2),
+          // non-existent location -> must be recorded as FAILED, not skipped
+          "MDI-Z-9-999" to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 1, certifiedNormalAccommodation = 1),
+        ),
+      ),
+    )
+
+    webTestClient.post().uri("/locations/bulk/update-cell-certificate/MDI")
+      .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+      .header("Content-Type", "application/json")
+      .bodyValue(body)
+      .exchange()
+      .expectStatus().isAccepted
+
+    await untilAsserted {
+      assertThat(cellCertificateUploadRepository.findAll().firstOrNull()?.status).isEqualTo(CellCertificateUploadStatus.FINISHED)
+    }
+
+    TransactionTemplate(transactionManager).execute {
+      val upload = cellCertificateUploadRepository.findAll().first()
+      assertThat(upload.processedRecords).isEqualTo(1) // cell1 changed
+      assertThat(upload.skippedRecords).isEqualTo(0)
+      assertThat(upload.failedRecords).isEqualTo(1) // the missing location
+      with(upload.locations.associateBy { it.locationKey }.getValue("MDI-Z-9-999")) {
+        assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.FAILED)
+        assertThat(message).isEqualTo("Location not found")
+      }
+    }
+  }
+
+  @Test
+  fun `running counts are incremented atomically per row`() {
+    val uploadId = TransactionTemplate(transactionManager).execute {
+      cellCertificateUploadRepository.save(
+        CellCertificateUpload(
+          prisonId = "MDI",
+          requestedBy = "TEST_USER",
+          requestedDate = LocalDateTime.now(),
+          totalRecords = 4,
+        ),
+      ).id!!
+    }!!
+
+    // each increment mirrors what processRow commits as a row completes - visible to a GET refresh mid-upload
+    TransactionTemplate(transactionManager).execute {
+      cellCertificateUploadRepository.incrementProcessedRecords(uploadId)
+      cellCertificateUploadRepository.incrementProcessedRecords(uploadId)
+      cellCertificateUploadRepository.incrementSkippedRecords(uploadId)
+      cellCertificateUploadRepository.incrementFailedRecords(uploadId)
+    }
+
+    TransactionTemplate(transactionManager).execute {
+      val upload = cellCertificateUploadRepository.findById(uploadId).get()
+      assertThat(upload.processedRecords).isEqualTo(2)
+      assertThat(upload.skippedRecords).isEqualTo(1)
+      assertThat(upload.failedRecords).isEqualTo(1)
+    }
+  }
 }


### PR DESCRIPTION
## MAPA-112

Two refinements to asynchronous cell certificate upload processing, prompted by the large-prison (MKI) upload.

### 1. Live progress counts

The `processed / skipped / failed` counts on the upload were only written in `finish()`, so a UI refresh showed `0 / 0 / 0` until the whole (multi-minute) job completed.

Each row is already processed in its own `REQUIRES_NEW` transaction, so the counts are now incremented atomically per row (`@Modifying` update committed with the row outcome) and become visible to the read-only GET endpoint immediately — the "so far" totals climb as the upload runs. `finish()` still recomputes the authoritative totals from the location rows (self-heals any drift and the stale-reclaim path).

No API/DTO change: `CellCertificateUploadDto` already exposes these counts.

### 2. "Location not found" is now a failure

A row whose location can't be found during processing was previously `markSkipped("Location not found")`; it is now `markFailed`, so it surfaces in the **Failed** total rather than being quietly skipped. Archived locations and no-change rows remain skips.

### Testing

- New tests: a not-found row ends `FAILED` (`failedRecords` counted), and the atomic increment methods bump the right columns.
- Full suite: `./gradlew test` — 833 tests pass. `ktlintCheck` clean.
