### PR TITLE
MAPA-127 Record working capacity change in history on cell reactivation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -1077,16 +1077,18 @@ abstract class Location(
           this.residentialHousingType = this.accommodationType.mapToResidentialHousingType()
         }
 
-        if (!capacityAdjusted) {
-          addHistory(
-            LocationAttribute.WORKING_CAPACITY,
-            previousWorkingCapacity.toString(),
-            getWorkingCapacityIgnoreParent().toString(),
-            userOrSystemInContext,
-            LocalDateTime.now(clock),
-            linkedTransaction,
-          )
-        }
+        // Always record the working capacity returning to its active value. Temporary deactivation records the
+        // working capacity dropping to 0 without changing the stored Capacity, so when a cell is reactivated to the
+        // same stored value (e.g. via an approval that supplies the unchanged capacity) setCapacity is a no-op and
+        // would otherwise leave no history of the working capacity coming back.
+        addHistory(
+          LocationAttribute.WORKING_CAPACITY,
+          previousWorkingCapacity.toString(),
+          getWorkingCapacityIgnoreParent().toString(),
+          userOrSystemInContext,
+          linkedTransaction.txStartTime,
+          linkedTransaction,
+        )
       }
       reactivatedLocations?.add(this)
       amendedLocations?.addAll(this.getParentLocations())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ConvertedCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationAttribute
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
@@ -1676,6 +1677,87 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(reactivatedLocation.status).isEqualTo(DerivedLocationStatus.ACTIVE)
       assertThat(reactivatedLocation.pendingChanges).isNull()
       assertThat(reactivatedLocation.pendingApprovalRequestId).isNull()
+    }
+
+    @Test
+    fun `reactivating a cell via approval records the working capacity returning to its previous value in history`() {
+      val firstCell = leedsWing.findAllLeafLocations().first() as Cell
+      // Cell starts with a stored working capacity of 1 (the leeds wing default).
+      deactivateLocation(
+        firstCell,
+        deactivatedReason = DeactivatedReason.MOTHBALLED,
+        planetFmReference = "11111",
+        reasonForChange = "The wing has been flooded",
+        requiresApproval = true,
+        approveDeactivation = true,
+      )
+
+      // Request reactivation back to the SAME stored capacity (working capacity 1). This reproduces the scenario
+      // where the stored capacity does not technically change, only the active/displayed working capacity does
+      // (0 while inactive -> 1 once active again).
+      webTestClient.put().uri("/certification/location/reactivation-request-approval")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            ReactivationLocationsApprovalRequest(
+              topLevelLocationId = firstCell.id!!,
+              cellReactivationChanges = mapOf(
+                firstCell.id!! to CellReactivationDetail(
+                  capacity = Capacity(
+                    workingCapacity = 1,
+                    maxCapacity = 2,
+                    certifiedNormalAccommodation = 1,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+
+      val pendingApprovalRequestId = webTestClient.get().uri("/locations/${firstCell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!.pendingApprovalRequestId!!
+
+      webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingApprovalRequestId)))
+        .exchange()
+        .expectStatus().isOk
+
+      val reactivatedCell = webTestClient.get().uri("/locations/${firstCell.id}?includeHistory=true")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      assertThat(reactivatedCell.status).isEqualTo(DerivedLocationStatus.ACTIVE)
+
+      val workingCapacityHistory = reactivatedCell.changeHistory.orEmpty()
+        .filter { it.attribute == LocationAttribute.WORKING_CAPACITY.description }
+
+      // Deactivation should have recorded working capacity dropping to 0...
+      assertThat(workingCapacityHistory)
+        .anySatisfy {
+          assertThat(it.oldValues).isEqualTo(listOf("1"))
+          assertThat(it.newValues).isEqualTo(listOf("0"))
+        }
+      // ...and reactivation should record it returning to 1, even though the stored capacity value did not change.
+      assertThat(workingCapacityHistory)
+        .anySatisfy {
+          assertThat(it.transactionType).isEqualTo(TransactionType.APPROVE_CERTIFICATION_REQUEST)
+          assertThat(it.oldValues).isEqualTo(listOf("0"))
+          assertThat(it.newValues).isEqualTo(listOf("1"))
+        }
     }
 
     @Test


### PR DESCRIPTION
# MAPA-127 Record working capacity change in history on cell reactivation

## Problem

When a cell is temporarily deactivated, the service writes a `LocationHistory`
entry recording the working capacity dropping to `0`, but it does **not** change
the cell's stored `Capacity.workingCapacity`.

On approval-driven reactivation (`ApprovalDecisionService.handleReactivation` →
`buildReactivationDetail`) a `Capacity` is always supplied, so in
`Location.reactivate()`:

- `capacityAdjusted` is `true`, which skipped the working-capacity history
  fallback (`if (!capacityAdjusted)`), and
- it relied on `setCapacity()` to log the change — but `setCapacity()` compares
  the new value against the **stored** working capacity. Because deactivation
  never altered the stored value, reactivating to the same value (the normal
  case) made `setCapacity()` a no-op.

The result was an asymmetric audit trail: history showed working capacity
`X → 0` on deactivation but nothing showing it returning to `X` on
reactivation.

## Change

In `Location.reactivate()`, the working-capacity history entry is now recorded
on every cell reactivation (the `!capacityAdjusted` guard has been removed),
using the deactivated value (`previousWorkingCapacity`, `0` while inactive) as
the old value and the now-active working capacity as the new value. The amended
date is aligned with `linkedTransaction.txStartTime` to match the sibling
reactivation history entries.

`addHistory()` already de-duplicates identical entries and is a no-op when the
old and new values match, so genuine capacity changes continue to record
correctly without producing duplicate entries.

## Testing

- Added integration test
  `reactivating a cell via approval records the working capacity returning to its previous value in history`
  to `CertificationApprovalResourceTest`. It deactivates a cell, reactivates it
  via the approval flow back to the same stored capacity, and asserts the
  `changeHistory` contains both the deactivation `1 → 0` entry and the
  reactivation `0 → 1` entry. This test fails before the fix and passes after.
- Regression suites pass: `CertificationApprovalResourceTest`,
  `LocationResourceIntTest`, `LocationCapacityResourceIntTest`,
  `CellCertificateResourceTest`, `LocationNonResidentialResourceTest`, and all
  `jpa.*` tests.
- `./gradlew ktlintCheck` passes.
