### PR TITLE
MAPA-131 Accept reason for change on cell to non-residential conversion

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResource.kt
@@ -464,7 +464,7 @@ class LocationResidentialResource(
     convertCellToNonResidentialLocationRequest: ConvertCellToNonResidentialLocationRequest,
   ): Location {
     val updatedLocation = with(convertCellToNonResidentialLocationRequest) {
-      locationService.convertToNonResidentialCell(id, convertedCellType, otherConvertedCellType)
+      locationService.convertToNonResidentialCell(id, convertedCellType, otherConvertedCellType, reasonForChange)
     }
     // On a prison that requires certification approval the cell is temporarily deactivated and an approval request
     // is raised (conversion happens later on approval), so a deactivation event is published. Otherwise the cell is
@@ -598,6 +598,12 @@ class LocationResidentialResource(
     @param:Schema(description = "Other type of converted cell", example = "Swimming pool", required = false, maxLength = 255)
     @field:Size(max = 255, message = "Description of other cell type must be no more than 255 characters")
     val otherConvertedCellType: String? = null,
+    @param:Schema(
+      description = "The reason why the approval was requested, mandatory if the conversion must be approved",
+      example = "Cell converted to an office",
+      required = false,
+    )
+    val reasonForChange: String? = null,
   )
 
   @Schema(description = "Request to update the type of a non-res cell location")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -1441,6 +1441,7 @@ class LocationService(
     id: UUID,
     convertedCellType: ConvertedCellType,
     otherConvertedCellType: String? = null,
+    reasonForChange: String? = null,
   ): LocationDTO {
     var locationToConvert = residentialLocationRepository.findById(id)
       .orElseThrow { LocationNotFoundException(id.toString()) }
@@ -1452,7 +1453,7 @@ class LocationService(
     val certificationApprovalRequired = activePrisonService.isCertificationApprovalRequired(locationToConvert.prisonId)
     if (certificationApprovalRequired) {
       val cell = locationToConvert as? Cell ?: throw LocationNotFoundException(id.toString())
-      return requestConversionApproval(cell, convertedCellType, otherConvertedCellType)
+      return requestConversionApproval(cell, convertedCellType, otherConvertedCellType, reasonForChange)
     }
 
     val linkedTransaction = sharedLocationService.createLinkedTransaction(
@@ -1504,7 +1505,12 @@ class LocationService(
     cell: Cell,
     convertedCellType: ConvertedCellType,
     otherConvertedCellType: String?,
+    reasonForChange: String?,
   ): LocationDTO {
+    if (reasonForChange.isNullOrBlank()) {
+      throw ApprovalRequestRequiresReasonForChangeException(cell.getKey())
+    }
+
     val linkedTransaction = sharedLocationService.createLinkedTransaction(
       prisonId = cell.prisonId,
       TransactionType.CELL_CONVERTION_TO_ROOM,
@@ -1521,7 +1527,7 @@ class LocationService(
       requestedBy = username,
       convertedCellType = convertedCellType,
       otherConvertedCellType = otherConvertedCellType,
-      reasonForChange = null,
+      reasonForChange = reasonForChange,
     )
 
     // Reflect the loss of working capacity on the snapshot (current values from the live certificate, new = 0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -4099,10 +4099,11 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
     private fun requestConversion(
       cell: Cell,
       convertedCellType: ConvertedCellType = ConvertedCellType.OFFICE,
+      reasonForChange: String = "Cell converted to an office",
     ): Location = webTestClient.put().uri("/locations/${cell.id}/convert-cell-to-non-res-cell")
       .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
       .header("Content-Type", "application/json")
-      .bodyValue(jsonString(LocationResidentialResource.ConvertCellToNonResidentialLocationRequest(convertedCellType = convertedCellType)))
+      .bodyValue(jsonString(LocationResidentialResource.ConvertCellToNonResidentialLocationRequest(convertedCellType = convertedCellType, reasonForChange = reasonForChange)))
       .exchange()
       .expectStatus().isOk
       .expectBody<Location>()
@@ -4167,6 +4168,9 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(approval.locationId).isEqualTo(cell.id)
       assertThat(approval.locationKey).isEqualTo(cell.getKey())
 
+      // The reason for change supplied on the request is captured on the approval request.
+      assertThat(approval.reasonForChange).isEqualTo("Cell converted to an office")
+
       // The new (proposed) value is the converted cell type...
       assertThat(approval.convertedCellType).isEqualTo(ConvertedCellType.OFFICE)
       assertThat(approval.otherConvertedCellType).isNull()
@@ -4184,6 +4188,26 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(approval.locations!![0].currentWorkingCapacity).isEqualTo(1)
       assertThat(approval.locations[0].currentMaxCapacity).isEqualTo(2)
       assertThat(approval.locations[0].currentCertifiedNormalAccommodation).isEqualTo(1)
+    }
+
+    @Test
+    fun `requesting a conversion without a reason for change is rejected`() {
+      val cell = firstLeedsCell()
+      stubNoPrisoners(cell)
+
+      webTestClient.put().uri("/locations/${cell.id}/convert-cell-to-non-res-cell")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(LocationResidentialResource.ConvertCellToNonResidentialLocationRequest(convertedCellType = ConvertedCellType.OFFICE)))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody<ErrorResponse>()
+        .returnResult().responseBody!!.also {
+        assertThat(it.errorCode).isEqualTo(ErrorCode.ApprovalRequestRequiresReasonForChange.errorCode)
+      }
+
+      // No deactivation or approval request should have been raised.
+      assertThat(getLocation(cell.id!!).pendingApprovalRequestId).isNull()
     }
 
     @Test
@@ -4221,7 +4245,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         webTestClient.put().uri("/locations/${cell.id}/convert-cell-to-non-res-cell")
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
           .header("Content-Type", "application/json")
-          .bodyValue(jsonString(LocationResidentialResource.ConvertCellToNonResidentialLocationRequest(convertedCellType = ConvertedCellType.OFFICE)))
+          .bodyValue(jsonString(LocationResidentialResource.ConvertCellToNonResidentialLocationRequest(convertedCellType = ConvertedCellType.OFFICE, reasonForChange = "Cell converted to an office")))
           .exchange()
           .expectStatus().isEqualTo(HttpStatus.CONFLICT)
           .expectBody<ErrorResponse>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResourceTest.kt
@@ -2564,6 +2564,7 @@ class LocationResidentialResourceTest(@param:Autowired private val locationServi
       LocationResidentialResource.ConvertCellToNonResidentialLocationRequest(
         convertedCellType = ConvertedCellType.OTHER,
         otherConvertedCellType = "Tanning room",
+        reasonForChange = "Converting cell to a tanning room",
       )
 
     var nonResStoreRoomRequest =


### PR DESCRIPTION
## What

The **Convert cell to non-residential room** page lets the user "Explain the reason for this change", but `PUT /locations/{id}/convert-cell-to-non-res-cell` did not accept a `reasonForChange`, so the text was silently dropped.

This adds an optional `reasonForChange` to the convert request contract and persists it on the certification-approval flow.

## Changes

- **Contract**: `ConvertCellToNonResidentialLocationRequest` gains an optional `reasonForChange`.
- **Service**: `convertToNonResidentialCell` forwards the reason to `requestConversionApproval`, which now:
  - requires a non-blank reason on prisons that require certification approval (400 `ApprovalRequestRequiresReasonForChange`, matching `cell-mark-change` / `cell-sanitation-change`), and
  - stores it on the `ConvertToNonResidentialCellApprovalRequest` (replacing the previously hardcoded `null`).
- No entity/DB migration needed — the approval request already has the `reasonForChange` column.
- Prisons that do not require approval accept the field but do not persist it.

## Tests

- Approval flow: asserts the supplied reason is stored on the approval request; new test that an approval-required prison rejects a conversion with no reason (and raises no pending request).
- Updated the prisoner-present test to supply a reason so it still exercises the 409 conflict.
- Non-approval happy path now sends a reason, confirming the field is accepted.

All 191 tests in the affected resource test classes pass.