### PR TITLE
MAPA-132 Add overcrowding to establishment roll count

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -843,6 +843,7 @@ open class ResidentialLocation(
     capacity = CapacityDto(
       maxCapacity = calcMaxCapacity(),
       workingCapacity = calcWorkingCapacity(),
+      certifiedNormalAccommodation = calcCertifiedNormalAccommodation(),
     ),
     certified = hasCertifiedCells(),
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonRollCountService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonRollCountService.kt
@@ -135,6 +135,8 @@ class PrisonRollCountService(
       )
     },
     outOfOrder = locations.sumOf { it.getOutOfOrder() },
+    cellsOvercrowded = locations.sumOf { it.getOvercrowdedCellCount() },
+    totalOvercrowded = locations.sumOf { it.getTotalOvercrowding() },
   )
 
   fun getConsecutiveOutMoveCount(offenderMovements: List<OffenderMovement>): Int {
@@ -184,6 +186,8 @@ data class ResidentialPrisonerLocation(
     localName = localName,
     certified = certified,
     deactivatedReason = deactivatedReason,
+    overcrowded = getTotalOvercrowding() > 0,
+    overcrowdedBy = getTotalOvercrowding(),
     rollCount = getRollCount(filterSeg),
     subLocations = removeLocations(subLocations, includeCells = includeCells, filterSeg = filterSeg),
   )
@@ -195,6 +199,8 @@ data class ResidentialPrisonerLocation(
     workingCapacity = getWorkingCapacity(),
     netVacancies = getNetVacancies(filterSeg),
     outOfOrder = getOutOfOrder(),
+    cellsOvercrowded = getOvercrowdedCellCount(),
+    totalOvercrowded = getTotalOvercrowding(),
   )
 
   fun getWorkingCapacity() = capacity?.workingCapacity ?: 0
@@ -207,6 +213,13 @@ data class ResidentialPrisonerLocation(
   fun getCurrentlyOut(filterSeg: Boolean = false): Int = getCells(filterSeg).sumOf { it.prisoners?.filter { p -> p.inOutStatus == "OUT" }?.size ?: 0 }
 
   fun getOutOfOrder(): Int = getCells().filter { it.status == DerivedLocationStatus.INACTIVE }.size
+
+  // occupants beyond CNA for THIS leaf cell (0 if not a leaf cell or not overcrowded). Null CNA treated as 0.
+  private fun cellOvercrowding(): Int = if (isLeafLevel) ((prisoners?.size ?: 0) - (capacity?.certifiedNormalAccommodation ?: 0)).coerceAtLeast(0) else 0
+
+  fun getOvercrowdedCellCount(): Int = getCells().count { it.cellOvercrowding() > 0 }
+
+  fun getTotalOvercrowding(): Int = getCells().sumOf { it.cellOvercrowding() }
 
   private fun getNetVacancies(filterSeg: Boolean) = getWorkingCapacity() - getNumOfOccupants(filterSeg)
 
@@ -291,6 +304,10 @@ data class LocationRollCount(
   val netVacancies: Int = 0,
   @param:Schema(description = "Out of order", required = true)
   val outOfOrder: Int = 0,
+  @param:Schema(description = "Number of overcrowded cells (cells holding more prisoners than their CNA)", required = true)
+  val cellsOvercrowded: Int = 0,
+  @param:Schema(description = "Total amount of overcrowding (sum of prisoners over CNA across all cells)", required = true)
+  val totalOvercrowded: Int = 0,
 )
 
 @Schema(description = "Residential Prisoner Location Information")
@@ -319,6 +336,12 @@ data class ResidentialLocationRollCount(
 
   @param:Schema(description = "Reason for deactivation", example = "DAMAGED", required = false)
   val deactivatedReason: DeactivatedReason? = null,
+
+  @param:Schema(description = "Indicates this location is overcrowded (for a cell, holds more prisoners than its CNA)", required = false)
+  val overcrowded: Boolean = false,
+
+  @param:Schema(description = "Amount of overcrowding (for a cell, prisoners over CNA; for a parent, the total across its cells)", example = "1", required = false)
+  val overcrowdedBy: Int = 0,
 
   @param:Schema(description = "Roll count details", required = true)
   val rollCount: LocationRollCount,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonRollResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonRollResourceIntTest.kt
@@ -186,7 +186,9 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
                   "currentlyOut": 0,
                   "workingCapacity": 4,
                   "netVacancies": 3,
-                  "outOfOrder": 0
+                  "outOfOrder": 0,
+                  "cellsOvercrowded": 0,
+                  "totalOvercrowded": 0
                 },
                 "locations": [
                   {
@@ -196,13 +198,17 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
                     "fullLocationPath": "Z-1",
                     "localName": "Landing 1",
                     "certified": true,
+                    "overcrowded": false,
+                    "overcrowdedBy": 0,
                     "rollCount": {
                       "bedsInUse": 2,
                       "currentlyInCell": 2,
                       "currentlyOut": 0,
                       "workingCapacity": 4,
                       "netVacancies": 3,
-                      "outOfOrder": 0
+                      "outOfOrder": 0,
+                      "cellsOvercrowded": 0,
+                      "totalOvercrowded": 0
                     },
                     "subLocations": [
                       {
@@ -212,13 +218,17 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
                         "fullLocationPath": "Z-1-001",
                         "localName": "001",
                         "certified": true,
+                        "overcrowded": false,
+                        "overcrowdedBy": 0,
                         "rollCount": {
                           "bedsInUse": 1,
                           "currentlyInCell": 1,
                           "currentlyOut": 0,
                           "workingCapacity": 2,
                           "netVacancies": 1,
-                          "outOfOrder": 0
+                          "outOfOrder": 0,
+                          "cellsOvercrowded": 0,
+                          "totalOvercrowded": 0
                         }
                       },
                       {
@@ -228,13 +238,17 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
                         "fullLocationPath": "Z-1-002",
                         "localName": "002",
                         "certified": true,
+                        "overcrowded": false,
+                        "overcrowdedBy": 0,
                         "rollCount": {
                           "bedsInUse": 1,
                           "currentlyInCell": 1,
                           "currentlyOut": 0,
                           "workingCapacity": 2,
                           "netVacancies": 2,
-                          "outOfOrder": 0
+                          "outOfOrder": 0,
+                          "cellsOvercrowded": 0,
+                          "totalOvercrowded": 0
                         }
                       },
                       {
@@ -251,6 +265,82 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
                           "workingCapacity": 0,
                           "netVacancies": 0,
                           "outOfOrder": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            """.trimIndent(),
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `reports overcrowding when cells hold more prisoners than their CNA`() {
+        // Both active cells on Z-1 have a CNA of 2; stub 3 prisoners in each so each is overcrowded by 1
+        prisonerSearchMockServer.stubSearchByLocations(
+          landingZ1.prisonId,
+          landingZ1.cellLocations().map { it.getPathHierarchy() },
+          returnResult = true,
+          numberOfPrisonersInCell = 3,
+        )
+        prisonApiMockServer.stubMovementsToday(landingZ1.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(1, 2), enRouteToday = 2))
+
+        webTestClient.get().uri("/prison/roll-count/${landingZ1.prisonId}/cells-only/${landingZ1.id!!}")
+          .headers(setAuthorisation(roles = listOf("ESTABLISHMENT_ROLL")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            """
+              {
+                "totals": {
+                  "cellsOvercrowded": 2,
+                  "totalOvercrowded": 2
+                },
+                "locations": [
+                  {
+                    "key": "MDI-Z-1",
+                    "locationType": "LANDING",
+                    "overcrowded": true,
+                    "overcrowdedBy": 2,
+                    "rollCount": {
+                      "cellsOvercrowded": 2,
+                      "totalOvercrowded": 2
+                    },
+                    "subLocations": [
+                      {
+                        "key": "MDI-Z-1-001",
+                        "locationType": "CELL",
+                        "overcrowded": true,
+                        "overcrowdedBy": 1,
+                        "rollCount": {
+                          "bedsInUse": 3,
+                          "workingCapacity": 2,
+                          "cellsOvercrowded": 1,
+                          "totalOvercrowded": 1
+                        }
+                      },
+                      {
+                        "key": "MDI-Z-1-002",
+                        "locationType": "CELL",
+                        "overcrowded": true,
+                        "overcrowdedBy": 1,
+                        "rollCount": {
+                          "bedsInUse": 3,
+                          "workingCapacity": 2,
+                          "cellsOvercrowded": 1,
+                          "totalOvercrowded": 1
+                        }
+                      },
+                      {
+                        "key": "MDI-Z-1-01S",
+                        "locationType": "STORE",
+                        "overcrowded": false,
+                        "overcrowdedBy": 0,
+                        "rollCount": {
+                          "cellsOvercrowded": 0,
+                          "totalOvercrowded": 0
                         }
                       }
                     ]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonRollCountServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonRollCountServiceTest.kt
@@ -3,11 +3,113 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.service
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Capacity
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.DerivedLocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.TestBase.Companion.clock
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import java.util.UUID
 
 class PrisonRollCountServiceTest {
 
   private val service = PrisonRollCountService(mock(), mock(), mock(), mock(), clock)
+
+  private fun prisoner(cell: String) = Prisoner(
+    prisonerNumber = "A0000AA",
+    prisonId = "LEI",
+    prisonName = "HMP Leeds",
+    cellLocation = cell,
+    firstName = "Dave",
+    lastName = "Jones",
+    gender = "Male",
+    status = "ACTIVE IN",
+    inOutStatus = "IN",
+  )
+
+  private fun cell(
+    code: String,
+    cna: Int?,
+    occupants: Int,
+  ) = ResidentialPrisonerLocation(
+    locationId = UUID.randomUUID(),
+    key = "LEI-A-1-$code",
+    locationType = LocationType.CELL,
+    locationCode = code,
+    fullLocationPath = "A-1-$code",
+    certified = true,
+    status = DerivedLocationStatus.ACTIVE,
+    subLocations = emptyList(),
+    capacity = Capacity(maxCapacity = 3, workingCapacity = cna ?: 0, certifiedNormalAccommodation = cna),
+    prisoners = (1..occupants).map { prisoner("A-1-$code") },
+    isLeafLevel = true,
+  )
+
+  private fun wing(cells: List<ResidentialPrisonerLocation>) = ResidentialPrisonerLocation(
+    locationId = UUID.randomUUID(),
+    key = "LEI-A",
+    locationType = LocationType.WING,
+    locationCode = "A",
+    fullLocationPath = "A",
+    status = DerivedLocationStatus.ACTIVE,
+    subLocations = cells,
+    isLeafLevel = false,
+  )
+
+  @Test
+  fun `overcrowding totals for the worked example`() {
+    // 5 cells each CNA 1: two hold 2, one holds 3, two hold 1 -> 3 overcrowded cells, total overcrowding 4
+    val wing = wing(
+      listOf(
+        cell("001", cna = 1, occupants = 2),
+        cell("002", cna = 1, occupants = 2),
+        cell("003", cna = 1, occupants = 3),
+        cell("004", cna = 1, occupants = 1),
+        cell("005", cna = 1, occupants = 1),
+      ),
+    )
+
+    assertThat(wing.getOvercrowdedCellCount()).isEqualTo(3)
+    assertThat(wing.getTotalOvercrowding()).isEqualTo(4)
+
+    val dto = wing.toDto(includeCells = true, filterSeg = false)
+    assertThat(dto.overcrowded).isTrue()
+    assertThat(dto.overcrowdedBy).isEqualTo(4)
+    assertThat(dto.rollCount.cellsOvercrowded).isEqualTo(3)
+    assertThat(dto.rollCount.totalOvercrowded).isEqualTo(4)
+  }
+
+  @Test
+  fun `a single overcrowded cell reports its own flag and amount`() {
+    val overcrowded = cell("001", cna = 1, occupants = 2)
+    assertThat(overcrowded.getOvercrowdedCellCount()).isEqualTo(1)
+    assertThat(overcrowded.getTotalOvercrowding()).isEqualTo(1)
+
+    val dto = overcrowded.toDto(includeCells = true, filterSeg = false)
+    assertThat(dto.overcrowded).isTrue()
+    assertThat(dto.overcrowdedBy).isEqualTo(1)
+    assertThat(dto.rollCount.cellsOvercrowded).isEqualTo(1)
+    assertThat(dto.rollCount.totalOvercrowded).isEqualTo(1)
+  }
+
+  @Test
+  fun `a cell at or below its CNA is not overcrowded`() {
+    val atCapacity = cell("001", cna = 2, occupants = 2)
+    val underCapacity = cell("002", cna = 2, occupants = 1)
+
+    assertThat(atCapacity.getOvercrowdedCellCount()).isEqualTo(0)
+    assertThat(atCapacity.getTotalOvercrowding()).isEqualTo(0)
+    assertThat(underCapacity.getTotalOvercrowding()).isEqualTo(0)
+
+    val dto = atCapacity.toDto(includeCells = true, filterSeg = false)
+    assertThat(dto.overcrowded).isFalse()
+    assertThat(dto.overcrowdedBy).isEqualTo(0)
+  }
+
+  @Test
+  fun `a null CNA is treated as zero so any occupant is overcrowding`() {
+    val noCna = cell("001", cna = null, occupants = 2)
+    assertThat(noCna.getOvercrowdedCellCount()).isEqualTo(1)
+    assertThat(noCna.getTotalOvercrowding()).isEqualTo(2)
+  }
 
   @Test
   fun `Get duplicate count`() {


### PR DESCRIPTION
## What

Adds overcrowding information to the establishment roll count (`GET /prison/roll-count/{prisonId}` and `.../cells-only/{locationId}`).

A cell is **overcrowded** when it holds more prisoners than its **CNA** (certified normal accommodation). The overcrowding amount is the number of prisoners over the CNA (floored at 0; a null CNA is treated as 0).

## Changes

`ResidentialLocationRollCount` now exposes per-location fields:
- `overcrowded` — boolean; for a cell, whether it is overcrowded; for a parent, whether it contains any overcrowding
- `overcrowdedBy` — for a cell, prisoners over CNA; for a parent, the total across its cells

`LocationRollCount` now exposes rolled-up totals at every level (including the establishment `totals`):
- `cellsOvercrowded` — count of overcrowded cells
- `totalOvercrowded` — total amount of overcrowding

Example: 5 cells each CNA 1, with two cells holding 2 prisoners and one holding 3 → 3 overcrowded cells, total overcrowding 4.

Also populates CNA on the capacity used when building the roll-count tree, so the per-cell calculation has the certified normal accommodation available (this capacity object is internal to the roll-count computation and is not serialized, so no existing output changes).

## Testing

- Unit tests (`PrisonRollCountServiceTest`): worked example, single-cell, at/under-capacity, and null-CNA cases
- Integration tests (`PrisonRollResourceIntTest`): not-overcrowded path asserts the new fields are zero; new test stages 3 prisoners in CNA-2 cells and asserts per-cell and rolled-up overcrowding
- Full suite green (839 tests), ktlint clean