### PR TITLE
MAPA-114 Capacity management prison dashboard endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/config/CacheConfiguration.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit
 class CacheConfiguration {
 
   @Bean
-  fun cacheManager(): CacheManager = ConcurrentMapCacheManager(ACTIVE_PRISONS_CACHE_NAME)
+  fun cacheManager(): CacheManager = ConcurrentMapCacheManager(ACTIVE_PRISONS_CACHE_NAME, PRISON_NAMES_CACHE_NAME)
 
   @CacheEvict(value = [ACTIVE_PRISONS_CACHE_NAME], allEntries = true)
   @Scheduled(fixedDelay = TTL_ACTIVE_PRISONS, timeUnit = TimeUnit.HOURS)
@@ -25,9 +25,17 @@ class CacheConfiguration {
     log.info("Evicting cache: $ACTIVE_PRISONS_CACHE_NAME after $TTL_ACTIVE_PRISONS hours")
   }
 
+  @CacheEvict(value = [PRISON_NAMES_CACHE_NAME], allEntries = true)
+  @Scheduled(fixedDelay = TTL_PRISON_NAMES, timeUnit = TimeUnit.HOURS)
+  fun cacheEvictPrisonNames() {
+    log.info("Evicting cache: $PRISON_NAMES_CACHE_NAME after $TTL_PRISON_NAMES hours")
+  }
+
   companion object {
     val log: org.slf4j.Logger = LoggerFactory.getLogger(this::class.java)
     const val ACTIVE_PRISONS_CACHE_NAME: String = "activePrisons"
     const val TTL_ACTIVE_PRISONS: Long = 1
+    const val PRISON_NAMES_CACHE_NAME: String = "prisonNames"
+    const val TTL_PRISON_NAMES: Long = 24
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDashboardDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDashboardDto.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "A summary row for a prison with a current cell certificate, used by the capacity management dashboard")
+data class CellCertificateDashboardDto(
+  @param:Schema(description = "Prison ID", example = "MDI", required = true)
+  val prisonId: String,
+
+  @param:Schema(description = "Prison name", example = "Moorland (HMP & YOI)", required = true)
+  val prisonName: String,
+
+  @param:Schema(description = "Certified working capacity for the prison", example = "1186", required = true)
+  val certifiedWorkingCapacity: Int,
+
+  @param:Schema(description = "Signed operational capacity for the prison", example = "1190", required = true)
+  val signedOperationCapacity: Int,
+
+  @param:Schema(description = "Number of pending certification change requests for the prison", example = "0", required = true)
+  val pendingChangeRequests: Int,
+
+  @param:Schema(description = "When the current certificate was last updated", example = "2025-02-02T12:00:00", required = true)
+  val certificateLastUpdated: LocalDateTime,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.CellCertificate
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.CellCertificateLocation
+import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
 
@@ -67,4 +68,23 @@ interface CellCertificateRepository : JpaRepository<CellCertificate, UUID> {
     nativeQuery = true,
   )
   fun findByPrisonIdAndPathHierarchies(prisonId: String, pathHierarchies: List<String>): List<CellCertificateLocation>
+
+  @Query(
+    """
+      select c.prisonId as prisonId,
+             c.totalWorkingCapacity as totalWorkingCapacity,
+             c.signedOperationCapacity as signedOperationCapacity,
+             c.approvedDate as approvedDate
+      from CellCertificate c
+      where c.current = true
+    """,
+  )
+  fun findCurrentCertificateSummaries(): List<CurrentCellCertificateSummary>
+}
+
+interface CurrentCellCertificateSummary {
+  val prisonId: String
+  val totalWorkingCapacity: Int
+  val signedOperationCapacity: Int
+  val approvedDate: LocalDateTime
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CertificationApprovalRequestRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CertificationApprovalRequestRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequest
@@ -10,4 +11,19 @@ import java.util.UUID
 interface CertificationApprovalRequestRepository : JpaRepository<CertificationApprovalRequest, UUID> {
   fun findByPrisonIdAndStatusOrderByRequestedDateDesc(prisonId: String, status: ApprovalRequestStatus): List<CertificationApprovalRequest>
   fun findByPrisonIdOrderByRequestedDateDesc(prisonId: String): List<CertificationApprovalRequest>
+
+  @Query(
+    """
+      select r.prisonId as prisonId, count(r) as count
+      from CertificationApprovalRequest r
+      where r.status = :status
+      group by r.prisonId
+    """,
+  )
+  fun countByStatusGroupedByPrison(status: ApprovalRequestStatus): List<PrisonApprovalCount>
+}
+
+interface PrisonApprovalCount {
+  val prisonId: String
+  val count: Long
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResource.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDashboardDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.ApprovalDecisionService
@@ -34,6 +36,31 @@ class CellCertificateResource(
   private val cellCertificateService: CellCertificateService,
   private val approvalDecisionService: ApprovalDecisionService,
 ) {
+
+  @GetMapping("/dashboard")
+  @Operation(
+    summary = "Get the capacity management dashboard",
+    description = "Returns one summary row per prison that has a current cell certificate, " +
+      "default-sorted by prison name. Used by the capacity management dashboard.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Dashboard rows returned",
+        content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = CellCertificateDashboardDto::class)))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json")],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden to access this endpoint",
+        content = [Content(mediaType = "application/json")],
+      ),
+    ],
+  )
+  fun getCellCertificateDashboard(): List<CellCertificateDashboardDto> = cellCertificateService.getCellCertificateDashboard()
 
   @GetMapping("/{id}")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -4,11 +4,14 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDashboardDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.CellCertificate
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CertificationApprovalRequestRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.ResidentialLocationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CellCertificateNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CurrentCellCertificateNotFoundException
@@ -20,6 +23,8 @@ import java.util.UUID
 class CellCertificateService(
   private val cellCertificateRepository: CellCertificateRepository,
   private val residentialLocationRepository: ResidentialLocationRepository,
+  private val certificationApprovalRequestRepository: CertificationApprovalRequestRepository,
+  private val prisonService: PrisonService,
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -74,6 +79,31 @@ class CellCertificateService(
   }
 
   fun hasCurrentCellCertificate(prisonId: String): Boolean = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(prisonId) != null
+
+  @Transactional(readOnly = true)
+  fun getCellCertificateDashboard(): List<CellCertificateDashboardDto> {
+    val summaries = cellCertificateRepository.findCurrentCertificateSummaries()
+    if (summaries.isEmpty()) return emptyList()
+
+    val pendingCounts = certificationApprovalRequestRepository
+      .countByStatusGroupedByPrison(ApprovalRequestStatus.PENDING)
+      .associate { it.prisonId to it.count.toInt() }
+
+    val prisonNames = prisonService.getPrisonNames()
+
+    return summaries
+      .map { summary ->
+        CellCertificateDashboardDto(
+          prisonId = summary.prisonId,
+          prisonName = prisonNames[summary.prisonId] ?: summary.prisonId,
+          certifiedWorkingCapacity = summary.totalWorkingCapacity,
+          signedOperationCapacity = summary.signedOperationCapacity,
+          pendingChangeRequests = pendingCounts[summary.prisonId] ?: 0,
+          certificateLastUpdated = summary.approvedDate,
+        )
+      }
+      .sortedBy { it.prisonName.lowercase() }
+  }
 
   fun updateSpecialistCellTypesInCurrentCertificate(cell: Cell) {
     val currentCert = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(cell.prisonId) ?: return

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonService.kt
@@ -2,11 +2,14 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.service
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
+import uk.gov.justice.digital.hmpps.locationsinsideprison.config.CacheConfiguration
 
 @Service
 class PrisonService(
@@ -37,6 +40,23 @@ class PrisonService(
       }
       throw ex
     }
+  }
+
+  /**
+   * Lookup all prisons and return a map of prison ID to prison name.
+   * Cached as this is a large, infrequently changing list.
+   */
+  @Cacheable(CacheConfiguration.PRISON_NAMES_CACHE_NAME)
+  fun getPrisonNames(): Map<String, String> {
+    log.debug("Looking up all prison names")
+    val prisons = prisonRegisterWebClient
+      .get()
+      .uri("/prisons")
+      .header("Content-Type", "application/json")
+      .retrieve()
+      .bodyToMono(object : ParameterizedTypeReference<List<PrisonDto>>() {})
+      .block() ?: emptyList()
+    return prisons.associate { it.prisonId to it.prisonName }
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/PrisonRegisterMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/PrisonRegisterMockServer.kt
@@ -27,6 +27,18 @@ class PrisonRegisterMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
+  fun stubGetAllPrisons(prisons: List<PrisonDto>) {
+    stubFor(
+      get("/prisons")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsBytes(prisons))
+            .withStatus(200),
+        ),
+    )
+  }
+
   fun stubLookupPrison(
     prisonId: String,
     female: Boolean = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
 import org.springframework.test.web.reactive.server.expectBody
+import uk.gov.justice.digital.hmpps.locationsinsideprison.config.CacheConfiguration
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ApproveCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellInformation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellInitialisationRequest
@@ -21,13 +23,17 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationService
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.PrisonDto
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
 import java.time.LocalDateTime
 import java.util.UUID
 
 @DisplayName("Cell Certificate Resource")
 @WithMockAuthUser(username = EXPECTED_USERNAME)
-class CellCertificateResourceTest(@param:Autowired private val locationService: LocationService) : CommonDataTestBase() {
+class CellCertificateResourceTest(
+  @param:Autowired private val locationService: LocationService,
+  @param:Autowired private val cacheManager: CacheManager,
+) : CommonDataTestBase() {
 
   private lateinit var wingApprovedRequestId: UUID
   private lateinit var cellPendingApprovalRequestId: UUID
@@ -352,6 +358,62 @@ class CellCertificateResourceTest(@param:Autowired private val locationService: 
         .jsonPath("$.locations[1].subLocations.length()").isEqualTo(2)
         .jsonPath("$.locations[1].subLocations[0].subLocations.length()").isEqualTo(4)
         .jsonPath("$.locations[1].subLocations[1].subLocations.length()").isEqualTo(3)
+    }
+  }
+
+  @DisplayName("GET /cell-certificates/dashboard")
+  @Nested
+  inner class GetCellCertificateDashboardTest {
+
+    @DisplayName("is secured")
+    @Nested
+    inner class Security {
+      @DisplayName("by role and scope")
+      @TestFactory
+      fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+        webTestClient.get().uri("/cell-certificates/dashboard"),
+        "ROLE_LOCATION_CERTIFICATION",
+      )
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `returns one row per prison with a current certificate, sorted by prison name`() {
+        cacheManager.getCache(CacheConfiguration.PRISON_NAMES_CACHE_NAME)?.clear()
+        prisonRegisterMockServer.stubGetAllPrisons(
+          listOf(
+            PrisonDto(prisonId = "LEI", prisonName = "Leeds (HMP)", active = true, male = true, female = false, contracted = false, lthse = false),
+          ),
+        )
+
+        webTestClient.get().uri("/cell-certificates/dashboard")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.length()").isEqualTo(1)
+          .jsonPath("$[0].prisonId").isEqualTo("LEI")
+          .jsonPath("$[0].prisonName").isEqualTo("Leeds (HMP)")
+          .jsonPath("$[0].certifiedWorkingCapacity").isEqualTo(12)
+          .jsonPath("$[0].signedOperationCapacity").exists()
+          .jsonPath("$[0].pendingChangeRequests").isEqualTo(1)
+          .jsonPath("$[0].certificateLastUpdated").exists()
+      }
+
+      @Test
+      fun `falls back to prison id when the prison name is not found`() {
+        cacheManager.getCache(CacheConfiguration.PRISON_NAMES_CACHE_NAME)?.clear()
+        prisonRegisterMockServer.stubGetAllPrisons(emptyList())
+
+        webTestClient.get().uri("/cell-certificates/dashboard")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$[0].prisonId").isEqualTo("LEI")
+          .jsonPath("$[0].prisonName").isEqualTo("LEI")
+      }
     }
   }
 }


### PR DESCRIPTION
## MAPA-114 — Capacity management prison dashboard

Adds the backend endpoint for the capacity management dashboard (epic MAPA-118), giving a "Certificate viewer" an overview of certificate information for every prison that holds a current cell certificate, with the data needed to navigate into a specific establishment.

### Endpoint
`GET /cell-certificates/dashboard` — returns one summary row per prison with a current cell certificate, default-sorted by prison name. Not paginated (frontend handles sorting). Secured by `ROLE_LOCATION_CERTIFICATION`.

Each row contains:
- Prison name (from Prison Register; falls back to prison id if not found)
- Certified working capacity (`totalWorkingCapacity`)
- Signed operational capacity
- Pending change requests (count of `PENDING` certification approval requests; `0` when none)
- Certificate last updated date (raw `LocalDateTime` — date formatting is a frontend concern)

### Implementation notes
- Lightweight JPQL projection for current certificates (avoids loading the full certificate location graph).
- Single grouped count query for pending approval requests instead of N queries.
- A single cached Prison Register `GET /prisons` lookup for names (24h cache), replacing ~120 individual calls.

### Tests
- New integration tests in `CellCertificateResourceTest`: security (401/403), happy path (row contents, pending count, sort), and prison-id fallback.
- New `stubGetAllPrisons` WireMock stub.

