### PR TITLE
MAPA-133 Don't show stale explanation on temp-inactive banner

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -793,8 +793,13 @@ open class ResidentialLocation(
     val pendingApprovalRequest = getPendingApprovalRequest()
     return if (ApprovalType.DEACTIVATION == pendingApprovalRequest?.getApprovalType()) {
       pendingApprovalRequest.reasonForChange
-    } else {
+    } else if (getInactiveStatus() == InactiveStatus.INACTIVE_MATCHING_CELL_CERT) {
+      // Only surface the explanation when the current deactivation is aligned to the cell certificate.
+      // A short-term temporary deactivation requires no explanation, so any previously approved
+      // deactivation reason must not be resurfaced on the temp-inactive banner (MAPA-133).
       getLatestApprovedDeactivationRequest()?.reasonForChange
+    } else {
+      null
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -1680,6 +1680,77 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
     }
 
     @Test
+    fun `temporarily deactivating a cell that was previously off-cert deactivated does not show the old explanation (MAPA-133)`() {
+      val firstCell = leedsWing.findAllLeafLocations().first() as Cell
+      val previousExplanation = "As discussed, taking P wing offline due to FSI work"
+
+      // Deactivate with a certified working capacity reduction (off-cert), supplying an explanation, then approve it.
+      val offCertDeactivated = deactivateLocation(
+        firstCell,
+        deactivatedReason = DeactivatedReason.MOTHBALLED,
+        planetFmReference = "11111",
+        reasonForChange = previousExplanation,
+        requiresApproval = true,
+        approveDeactivation = true,
+      )
+      assertThat(offCertDeactivated.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_MATCHING_CELL_CERT)
+      assertThat(offCertDeactivated.lastDeactivationReasonForChange).isEqualTo(previousExplanation)
+
+      // Reactivate the cell (requires approval as it returns capacity to the certificate).
+      webTestClient.put().uri("/certification/location/reactivation-request-approval")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            ReactivationLocationsApprovalRequest(
+              topLevelLocationId = firstCell.id!!,
+              cellReactivationChanges = mapOf(
+                firstCell.id!! to CellReactivationDetail(
+                  capacity = Capacity(workingCapacity = 1, maxCapacity = 2, certifiedNormalAccommodation = 1),
+                ),
+              ),
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+
+      val pendingReactivation = webTestClient.get().uri("/locations/${firstCell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      webTestClient.put().uri("/certification/location/approve")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingReactivation.pendingApprovalRequestId!!)))
+        .exchange()
+        .expectStatus().isOk
+
+      val reactivatedCell = webTestClient.get().uri("/locations/${firstCell.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+      assertThat(reactivatedCell.status).isEqualTo(DerivedLocationStatus.ACTIVE)
+
+      // Clear the deactivation/reactivation domain events so the helper below asserts only on the new deactivation.
+      purgeDomainEvents()
+
+      // Now temporarily deactivate again without reducing certified capacity (no approval, no explanation required).
+      val tempDeactivated = deactivateLocation(firstCell, deactivatedReason = DeactivatedReason.DAMAGED)
+
+      assertThat(tempDeactivated.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_TEMP)
+      // The previously approved off-cert explanation must not be resurfaced on the temp-inactive banner.
+      assertThat(tempDeactivated.lastDeactivationReasonForChange).isNull()
+    }
+
+    @Test
     fun `reactivating a cell via approval records the working capacity returning to its previous value in history`() {
       val firstCell = leedsWing.findAllLeafLocations().first() as Cell
       // Cell starts with a stored working capacity of 1 (the leeds wing default).


### PR DESCRIPTION
## Summary

Fixes [MAPA-133](https://dsdmoj.atlassian.net/browse/MAPA-133).

When a cell that was previously deactivated with a certified working-capacity reduction (an approved off-cert deactivation carrying an explanation) is reactivated and then **temporarily** deactivated again, the temp-inactive banner displayed the **old, unrelated explanation**.

A plain temporary deactivation requires no explanation, so the Explanation field should never display.

## Root cause

`lastDeactivationReasonForChange` is computed by `getLastReasonForDeactivation()` in `ResidentialLocation.kt`. When no deactivation approval was pending, it fell back to `getLatestApprovedDeactivationRequest()`, which returns *any* historically approved deactivation request walking up the hierarchy. Approval requests are not cleared on reactivation, so a later short-term temporary deactivation (`INACTIVE_TEMP`) resurfaced the stale `reasonForChange`.

## Fix

Only surface the approved deactivation's explanation when the current inactive state is aligned to the cell certificate (`INACTIVE_MATCHING_CELL_CERT`); otherwise return `null`. Behaviour for pending approvals and approved/aligned deactivations is unchanged.

## Testing

- Added a regression test reproducing the exact sequence: off-cert deactivate-with-approval (with explanation) → reactivate-with-approval → temporarily deactivate again. It asserts the new deactivation is `INACTIVE_TEMP` with `lastDeactivationReasonForChange == null`.
- Confirmed the test **fails without the fix** (`expected: null but was: "As discussed, taking P wing offline due to FSI work"`) and passes with it.
- All 88 tests in `CertificationApprovalResourceTest` pass; `ktlintCheck` is clean.

[MAPA-133]: https://dsdmoj.atlassian.net/browse/MAPA-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ