### PR TITLE
MAPA-137 Fix converted cell data in cell certificate locations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateDto.kt
@@ -115,6 +115,9 @@ data class CellCertificateLocationDto(
   @param:Schema(description = "If converted, the type of cell this location has been converted to")
   val convertedCellType: ConvertedCellType? = null,
 
+  @param:Schema(description = "Free-text description when the converted cell type is OTHER", example = "Yoga room")
+  val otherConvertedCellType: String? = null,
+
   @param:Schema(description = "Sub locations within this cell certificate location")
   val subLocations: List<CellCertificateLocationDto>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -186,6 +186,8 @@ class Cell(
 
   override fun isConvertedCell() = convertedCellType != null
 
+  fun getOtherConvertedCellType(): String? = otherConvertedCellType
+
   private fun getConvertedCellTypeSummary() = listOfNotBlank(convertedCellType?.description, otherConvertedCellType).joinToString(" - ")
 
   fun convertToNonResidentialCell(convertedCellType: ConvertedCellType, otherConvertedCellType: String? = null, userOrSystemInContext: String, clock: Clock, linkedTransaction: LinkedTransaction) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -174,6 +174,9 @@ open class CellCertificateLocation(
   @Enumerated(EnumType.STRING)
   private val convertedCellType: ConvertedCellType? = null,
 
+  @Column(nullable = true)
+  private val otherConvertedCellType: String? = null,
+
   @OneToMany(fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinColumn(name = "parent_location_id")
   @SortNatural
@@ -214,6 +217,7 @@ open class CellCertificateLocation(
     cellMark = cellMark,
     level = level,
     convertedCellType = convertedCellType,
+    otherConvertedCellType = otherConvertedCellType,
     subLocations = if (traverseDown)subLocations.map { it.toDto() } else null,
   )
 
@@ -237,6 +241,8 @@ open class CellCertificateLocation(
     specialistCellTypes = specialistCellTypes,
     accommodationTypes = accommodationTypes,
     usedForTypes = usedForTypes,
+    convertedCellType = convertedCellType,
+    otherConvertedCellType = otherConvertedCellType,
     subLocations = subLocations,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -610,7 +610,7 @@ open class ResidentialLocation(
     val locationInExistingCertificate = currentCellCertificate?.findLocationInCertificate(getPathHierarchy())
     if (approvalLocationIsPartOfHierarchy(approvalRequest) || locationInExistingCertificate == null) {
       return CellCertificateLocation(
-        locationType = locationType,
+        locationType = getDerivedLocationType(),
         locationCode = getLocationCode(),
         pathHierarchy = getPathHierarchy(),
         localName = localName?.capitalizeWords(),
@@ -637,6 +637,11 @@ open class ResidentialLocation(
         specialistCellTypes = getSpecialistCellTypesAsCSV(),
         convertedCellType = if (this is Cell && isConvertedCell()) {
           convertedCellType
+        } else {
+          null
+        },
+        otherConvertedCellType = if (this is Cell && isConvertedCell()) {
+          getOtherConvertedCellType()
         } else {
           null
         },

--- a/src/main/resources/db/migration/V1_96__cell_cert_other_converted_cell_type.sql
+++ b/src/main/resources/db/migration/V1_96__cell_cert_other_converted_cell_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cell_certificate_location add column if not exists other_converted_cell_type varchar(255);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ConvertedCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationAttribute
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
@@ -4379,6 +4380,64 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
           *cell1.getParentLocations().map { parent -> "location.inside.prison.amended" to parent.getKey() }.toTypedArray(),
         )
       }
+    }
+
+    @Test
+    fun `approving a conversion records the location as a ROOM with its converted cell type and free text in the certificate`() {
+      val cell = firstLeedsCell()
+      stubNoPrisoners(cell)
+
+      val updatedLocation = webTestClient.put().uri("/locations/${cell.id}/convert-cell-to-non-res-cell")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(
+          jsonString(
+            LocationResidentialResource.ConvertCellToNonResidentialLocationRequest(
+              convertedCellType = ConvertedCellType.OTHER,
+              otherConvertedCellType = "Swimming pool",
+              reasonForChange = "Cell converted to a swimming pool",
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody<Location>()
+        .returnResult().responseBody!!
+
+      approveRequest(updatedLocation.pendingApprovalRequestId!!)
+
+      // The certificate exposes the converted location as a ROOM (derived) and carries both the converted
+      // cell type and its free-text description for display on the cell schedule.
+      val roomInCert = currentCertificate(cell.prisonId).findLocationInCertificate(cell.getPathHierarchy())!!
+      assertThat(roomInCert.locationType).isEqualTo(LocationType.ROOM)
+      assertThat(roomInCert.convertedCellType).isEqualTo(ConvertedCellType.OTHER)
+      assertThat(roomInCert.otherConvertedCellType).isEqualTo("Swimming pool")
+    }
+
+    @Test
+    fun `a previously converted cell keeps its room type and converted cell type when a later certificate is generated`() {
+      val cells = leedsWing.findAllLeafLocations().filterIsInstance<Cell>()
+      val cellA = cells[0]
+      val cellB = cells[1]
+      stubNoPrisoners(cellA)
+      stubNoPrisoners(cellB)
+
+      // Convert and approve cell A -> generates the first certificate with cell A as a converted room.
+      approveRequest(requestConversion(cellA).pendingApprovalRequestId!!)
+
+      // Convert and approve cell B -> generates a second certificate. Cell A is not part of cell B's
+      // approval hierarchy, so it is cloned from the first certificate. It must retain its converted type.
+      approveRequest(requestConversion(cellB).pendingApprovalRequestId!!)
+
+      val cert = currentCertificate(cellA.prisonId)
+
+      val cellAInCert = cert.findLocationInCertificate(cellA.getPathHierarchy())!!
+      assertThat(cellAInCert.locationType).isEqualTo(LocationType.ROOM)
+      assertThat(cellAInCert.convertedCellType).isEqualTo(ConvertedCellType.OFFICE)
+
+      val cellBInCert = cert.findLocationInCertificate(cellB.getPathHierarchy())!!
+      assertThat(cellBInCert.locationType).isEqualTo(LocationType.ROOM)
+      assertThat(cellBInCert.convertedCellType).isEqualTo(ConvertedCellType.OFFICE)
     }
   }
 }


### PR DESCRIPTION
## Context
Cells converted to non-residential rooms were returned incorrectly from `GET /cell-certificates/*`, which the cell schedule table on the cell certificate page relies on to display the room type.

## Bugs fixed
1. **`otherConvertedCellType` was missing** — certificate locations returned `convertedCellType` but never the free-text "other" description, so cells converted with type `OTHER` had no displayable room type.
2. **Converted cells reported `locationType: CELL`** instead of the derived `ROOM`. The derived type already existed (`Cell.getDerivedLocationType()`) but wasn't used when building the certificate.
3. **Previously-converted cells lost their `convertedCellType`** whenever a new certificate was generated. Cells not part of the in-flight approval are cloned from the existing certificate, and `CellCertificateLocation.clone()` did not copy `convertedCellType` — so only the most-recently-converted cell kept its value.

## Changes
- `ResidentialLocation.toCellCertificateLocation()` now stores `getDerivedLocationType()` and populates `otherConvertedCellType`.
- Added `otherConvertedCellType` to the `CellCertificateLocation` entity (+ migration `V1_96`) and `CellCertificateLocationDto`.
- `CellCertificateLocation.clone()` now carries `convertedCellType` and `otherConvertedCellType`.
- Added `Cell.getOtherConvertedCellType()` accessor.

## Tests
Added two integration tests in `CertificationApprovalResourceTest`:
- Converting a cell records it as `ROOM` with its `convertedCellType` and `otherConvertedCellType` in the certificate.
- A previously-converted cell retains its room type and converted cell type after a later cell is converted (regression for the clone bug).

Existing cell certificate / certification approval suites pass; ktlint clean.

## Notes
No data backfill — certificates already stored with the bad data self-heal when each prison's certificate is next regenerated.