### PR TITLE
MAPA-138 Reflect local name changes on the current cell certificate

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -140,7 +140,7 @@ open class CellCertificateLocation(
   private val cellMark: String? = null,
 
   @Column(nullable = true)
-  private val localName: String? = null,
+  open var localName: String? = null,
 
   @Column(nullable = false)
   val pathHierarchy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDashboardDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.capitalizeWords
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.CellCertificate
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateRepository
@@ -116,6 +118,13 @@ class CellCertificateService(
     val currentCert = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(cell.prisonId) ?: return
     currentCert.findLocationInCertificate(cell.getPathHierarchy())?.let { certLocation ->
       certLocation.usedForTypes = cell.getUsedForValuesAsCSV()
+    }
+  }
+
+  fun updateLocalNameInCurrentCertificate(location: Location) {
+    val currentCert = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(location.prisonId) ?: return
+    currentCert.findLocationInCertificate(location.getPathHierarchy())?.let { certLocation ->
+      certLocation.localName = location.localName?.capitalizeWords()
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -993,6 +993,10 @@ class LocationService(
       )
     }
 
+    if (activePrisonService.isCertificationApprovalRequired(location.prisonId)) {
+      cellCertificateService.updateLocalNameInCurrentCertificate(location)
+    }
+
     log.info("Location local name updated [${location.getKey()}")
     sharedLocationService.trackLocationUpdate(location, "Location local name updated")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationTransformResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationTransformResourceTest.kt
@@ -1121,4 +1121,38 @@ class LocationTransformResourceTest : CommonDataTestBase() {
       }
     }
   }
+
+  @DisplayName("PUT /locations/{id}/change-local-name")
+  @Nested
+  inner class ChangeLocalNameTest {
+
+    @Nested
+    inner class CurrentCertificateReflection {
+
+      @Test
+      fun `updating local name updates the current cell certificate for the affected location`() {
+        baselinePrison(leedsWing.prisonId)
+
+        val leedsWingPath = leedsWing.getPathHierarchy()
+
+        webTestClient.put().uri("/locations/${leedsWing.id}/change-local-name")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue("""{ "localName": "New Wing Name" }""")
+          .exchange()
+          .expectStatus().isOk
+
+        val currentCert = webTestClient.get().uri("/cell-certificates/prison/${leedsWing.prisonId}/current")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody<CellCertificateDto>()
+          .returnResult().responseBody!!
+
+        val locationInCert = currentCert.findLocationInCertificate(leedsWingPath)
+        assertThat(locationInCert).isNotNull
+        assertThat(locationInCert?.localName).isEqualTo("New Wing Name")
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What

For prisons where certification approval is required, changing a location's **local name** does **not** require a fresh certificate approval — but the new name should be reflected on the **current** cell certificate for accuracy. This mirrors the existing behaviour already in place for "used for" types and specialist cell types.

Previously the `PUT /locations/{id}/change-local-name` endpoint updated the location but left the current certificate stale.

## Changes

- **`CellCertificate.kt`** — `localName` on `CellCertificateLocation` is now an `open var` so it can be mutated in place (matching `usedForTypes` / `specialistCellTypes`).
- **`CellCertificateService.kt`** — added `updateLocalNameInCurrentCertificate(location)`, which finds the current certificate for the prison, locates the matching entry by path hierarchy and writes the capitalised local name. Safe no-op when there is no current certificate or the location isn't on it.
- **`LocationService.kt`** — `updateLocalName()` now calls the new method when `activePrisonService.isCertificationApprovalRequired(prisonId)` is true. No approval request is created.
- **`LocationTransformResourceTest.kt`** — new integration test asserting the current certificate reflects the updated local name for an approval-required prison.

## Scope

Hooks the dedicated `change-local-name` endpoint, consistent with how the used-for reflection only hooks its dedicated endpoint. The generic `PATCH /locations/residential/{id}` localName path is out of scope.

## Verification

- `./gradlew build` — passes (tests, ktlint, kover).
- New test `updating local name updates the current cell certificate for the affected location` passes.