### PR TITLE
MAPA-130 Fix slow cell certificate history by avoiding location over-fetch

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -41,6 +41,15 @@ import java.util.UUID
         ),
       ],
     ),
+    // Lightweight graph for the certificate history list: fetch the one-to-one approval
+    // request (to avoid an N+1 across the list) but NOT the location tree, which the list
+    // does not render (showLocations = false).
+    NamedEntityGraph(
+      name = "cell.certificate.summary.graph",
+      attributeNodes = [
+        NamedAttributeNode("certificationApprovalRequest"),
+      ],
+    ),
   ],
 )
 @Entity
@@ -79,7 +88,7 @@ open class CellCertificate(
   private var current: Boolean = true,
 
   @SortNatural
-  @OneToMany(fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinColumn(name = "cell_certificate_id", nullable = false)
   open var locations: SortedSet<CellCertificateLocation> = sortedSetOf(),
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateRepository.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 
 @Repository
 interface CellCertificateRepository : JpaRepository<CellCertificate, UUID> {
-  @EntityGraph(value = "cell.certificate.graph", type = EntityGraph.EntityGraphType.LOAD)
+  @EntityGraph(value = "cell.certificate.summary.graph", type = EntityGraph.EntityGraphType.LOAD)
   fun findByPrisonIdOrderByApprovedDateDesc(prisonId: String): List<CellCertificate>
 
   @EntityGraph(value = "cell.certificate.graph", type = EntityGraph.EntityGraphType.LOAD)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
@@ -222,6 +222,42 @@ class CellCertificateResourceTest(
       }
 
       @Test
+      fun `history list returns summary rows for every certificate without loading the location tree`() {
+        // Approve the pending cell change to produce a second (now current) certificate, so the
+        // history list contains more than one certificate.
+        webTestClient.put().uri("/certification/location/approve")
+          .headers(setAuthorisation(user = EXPECTED_USERNAME, roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              ApproveCertificationRequestDto(
+                approvalRequestReference = cellPendingApprovalRequestId,
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+
+        webTestClient.get().uri("/cell-certificates/prison/LEI")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          // Ordered by approved date desc: newest certificate is current, the previous one is not.
+          // The presence of $[1] confirms the history list holds more than one certificate.
+          .jsonPath("$[0].current").isEqualTo(true)
+          .jsonPath("$[1].current").isEqualTo(false)
+          // Every row exposes summary fields but never the (discarded) location tree.
+          .jsonPath("$[0].id").exists()
+          .jsonPath("$[0].approvedBy").exists()
+          .jsonPath("$[0].totalWorkingCapacity").exists()
+          .jsonPath("$[0].approvedRequest.id").exists()
+          .jsonPath("$[0].locations").doesNotExist()
+          .jsonPath("$[1].approvedRequest.id").exists()
+          .jsonPath("$[1].locations").doesNotExist()
+      }
+
+      @Test
       fun `returns empty list when no cell certificates found for prison`() {
         webTestClient.get().uri("/cell-certificates/prison/MDI")
           .headers(setAuthorisation(user = EXPECTED_USERNAME, roles = listOf("ROLE_LOCATION_CERTIFICATION")))


### PR DESCRIPTION
## Problem

The cell-certificate history page (`…/{prisonId}/cell-certificate/history`) hangs and eventually errors out. It is backed by `GET /cell-certificates/prison/{prisonId}` (the certificate history list).

The list endpoint suffered a JPA over-fetch with a recursive N+1:

- `CellCertificate.locations` was `@OneToMany(fetch = EAGER)` and `CellCertificateLocation.subLocations` is also eager and self-recursive.
- The history query applied the full `cell.certificate.graph` LOAD graph, so for **every historic certificate** Hibernate materialised the **entire prison location tree**, issuing a separate `SELECT` per node down every level.
- `getCellCertificatesForPrison` then maps with `showLocations = false`, so all of that loaded data was **discarded**.

For a large prison (e.g. MDI) with many historic certificates this loaded millions of rows just to render a summary list → the page hung.

## Fix

- Make `CellCertificate.locations` `FetchType.LAZY`.
- Add a lightweight `cell.certificate.summary.graph` that fetches only the one-to-one approval request (avoiding an N+1 across the list) but not the location tree.
- Point `findByPrisonIdOrderByApprovedDateDesc` at the new graph. The by-id and current-certificate endpoints keep the full `cell.certificate.graph` because they genuinely render the tree.

The JSON contract is unchanged — the history list already returned `locations: null`.

## Scope

Certificate history list only. The approval-requests list has a milder version of the same pattern but `Location.childLocations` is already lazy, so it is out of scope here.

## Testing

- Added a regression test asserting the history list returns multiple certificates with summary fields populated and no location tree.
- `./gradlew ktlintCheck build` — green (847 tests).