### PR TITLE
MAPB-539 Add cross-cutting VIDEO_ENABLED service type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -254,6 +254,9 @@ class NonResidentialLocation(
       }
     }
 
+    // Preserve DPS-only cross-cutting services NOMIS does not manage (e.g. VIDEO_ENABLED)
+    serviceTypeForLocation.addAll(services.map { it.serviceType }.filter { it.crossCutting })
+
     updateServices(serviceTypeForLocation, upsert.lastUpdatedBy, clock, linkedTransaction)
 
     upsert.internalMovementAllowed?.let { internalMovementAllowedUpdate ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ServiceUsage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ServiceUsage.kt
@@ -102,4 +102,13 @@ enum class ServiceType(
   INTERNAL_MOVEMENTS(description = "Internal movements", NonResidentialUsageType.MOVEMENT, ServiceFamilyType.INTERNAL_MOVEMENTS, additionalInformation = "To record the location of unlocked prisoners within this establishment.", sequence = 6),
   OFFICIAL_VISITS(description = "Official visits", NonResidentialUsageType.VISIT, ServiceFamilyType.OFFICIAL_VISITS, additionalInformation = "For example, arranging a face to face visit with a solicitor.", sequence = 7),
   USE_OF_FORCE(description = "Use of force", NonResidentialUsageType.OCCURRENCE, ServiceFamilyType.USE_OF_FORCE, additionalInformation = "To report where a use of force incident took place.", sequence = 8),
+  VIDEO_ENABLED(description = "Video enabled", nonResidentialUsageType = null, ServiceFamilyType.VIDEO_LINK_APPOINTMENTS, additionalInformation = "For rooms that can host any type of video meeting.", sequence = 9),
+  ;
+
+  /**
+   * Cross-cutting services are DPS-only labels that are not derived from a NOMIS usage type or
+   * location type, so they must be preserved when a location is re-synced from NOMIS.
+   */
+  val crossCutting: Boolean
+    get() = nonResidentialUsageType == null && nonResidentialLocationType == null
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationConstantsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationConstantsIntTest.kt
@@ -1016,6 +1016,16 @@ class LocationConstantsIntTest : SqsIntegrationTestBase() {
                       "editableInParent": false
                     },
                     "additionalInformation": "To report where a use of force incident took place."
+                  },
+                  {
+                    "key": "VIDEO_ENABLED",
+                    "description": "Video enabled",
+                    "attributes": {
+                      "serviceFamilyType": "VIDEO_LINK_APPOINTMENTS",
+                      "serviceFamilyDescription": "Book a video link",
+                      "editableInParent": true
+                    },
+                    "additionalInformation": "For rooms that can host any type of video meeting."
                   }
                 ]
               }
@@ -1093,6 +1103,11 @@ class LocationConstantsIntTest : SqsIntegrationTestBase() {
                       "key": "VIDEO_LINK",
                       "description": "Book a video link",
                       "additionalInformation": "For example, managing a court hearing or probation meeting via video link."
+                    },
+                    {
+                      "key": "VIDEO_ENABLED",
+                      "description": "Video enabled",
+                      "additionalInformation": "For rooms that can host any type of video meeting."
                     }
                   ]
                 },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
@@ -2018,6 +2018,47 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
             JsonCompareMode.LENIENT,
           )
       }
+
+      @Test
+      fun `can retrieve locations by the cross-cutting VIDEO_ENABLED service type`() {
+        // tag the visit room as video enabled, in addition to its existing official visits service
+        webTestClient.patch().uri("/locations/non-residential/${visitRoom.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              PatchNonResidentialLocationRequest(
+                servicesUsingLocation = setOf(ServiceType.OFFICIAL_VISITS, ServiceType.VIDEO_ENABLED),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+
+        webTestClient.get().uri("/locations/non-residential/prison/${wingZ.prisonId}/service/VIDEO_ENABLED")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+                [{
+                  "prisonId": "MDI",
+                  "code": "VISIT",
+                  "pathHierarchy": "Z-VISIT",
+                  "servicesUsingLocation": [
+                    {
+                      "serviceType": "VIDEO_ENABLED",
+                      "serviceFamilyType": "VIDEO_LINK_APPOINTMENTS"
+                    }
+                  ],
+                  "key": "MDI-Z-VISIT"
+                }]
+                         """,
+            JsonCompareMode.LENIENT,
+          )
+      }
     }
 
     @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.NomisDeactivatedReason
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.NomisSyncLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.NonResidentialUsageDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PatchNonResidentialLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.EXPECTED_USERNAME
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.SqsIntegrationTestBase
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Capacity
@@ -1018,6 +1019,68 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
               "servicesUsingLocation": [
                 {
                   "serviceType": "VIDEO_LINK",
+                  "serviceFamilyType": "VIDEO_LINK_APPOINTMENTS"
+                }
+              ]
+             }
+          """,
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `sync preserves a cross-cutting VIDEO_ENABLED service that NOMIS does not manage`() {
+        // staff manually tag the video link room as video enabled (a DPS-only cross-cutting label)
+        webTestClient.patch().uri("/locations/non-residential/${videoLinkRoom.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              PatchNonResidentialLocationRequest(
+                servicesUsingLocation = setOf(ServiceType.VIDEO_LINK, ServiceType.VIDEO_ENABLED),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+
+        // a subsequent NOMIS sync (which knows nothing about VIDEO_ENABLED) must not strip it
+        webTestClient.post().uri("/sync/upsert")
+          .headers(setAuthorisation(roles = listOf("ROLE_SYNC_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              syncNonResRequest.copy(
+                id = videoLinkRoom.id,
+                code = "VIDEO",
+                locationType = LocationType.VIDEO_LINK,
+                localName = "Video Link Room",
+                usage = emptySet(),
+                internalMovementAllowed = false,
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+
+        webTestClient.get().uri("/locations/${videoLinkRoom.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+             {
+              "key": "ZZGHI-VIDEO",
+              "locationType": "VIDEO_LINK",
+              "servicesUsingLocation": [
+                {
+                  "serviceType": "VIDEO_LINK",
+                  "serviceFamilyType": "VIDEO_LINK_APPOINTMENTS"
+                },
+                {
+                  "serviceType": "VIDEO_ENABLED",
                   "serviceFamilyType": "VIDEO_LINK_APPOINTMENTS"
                 }
               ]


### PR DESCRIPTION
## Why

Prison staff need a "video room calendar" showing every video-capable room in a prison and its free capacity, regardless of which booking service owns the room. Today a room's service type (`VIDEO_LINK`, `OFFICIAL_VISITS`, `APPOINTMENT`, …) is specific to one service, so there is no single way to list "every room that can host a video meeting".

This adds a new **cross-cutting** service type, `VIDEO_ENABLED`, in the existing `VIDEO_LINK_APPOINTMENTS` family. It is a manual label staff add to video rooms (which usually already have another video-related service type). It is purely for visualising capacity — booking still happens in the individual services.

## What

- **`jpa/ServiceUsage.kt`** — added `VIDEO_ENABLED` to `ServiceType` (family `VIDEO_LINK_APPOINTMENTS`, sequence 9) with no NOMIS usage-type or location-type mapping, plus a `crossCutting` helper.
- **`jpa/NonResidentialLocation.kt`** — the NOMIS `sync` path rebuilds a location's service set from NOMIS usage + location-type mappings, which would strip a DPS-only label on the next sync. It now preserves cross-cutting services (mirroring the existing unmapped-usage handling).

Everything else is derived from the enums and needs no change:
- `GET /locations/non-residential/prison/{prisonId}/service/VIDEO_ENABLED` works automatically (`@PathVariable serviceType: ServiceType`).
- `/constants/service-types` and `/constants/service-family-types` expose the new value automatically (the UI's service checkboxes are driven from these).
- No DB migration needed (`service_usage.service_type` is `varchar(80)`, stored as string). No backfill — staff add the label manually.

## Tests

- Updated `LocationConstantsIntTest` expectations for both constants endpoints.
- Added an endpoint test for `/service/VIDEO_ENABLED`.
- Added a sync-preservation test confirming a NOMIS re-sync keeps `VIDEO_ENABLED`.
- `./gradlew build` passes (full suite + ktlint).

## Follow-up (UI)

No production code change in the non-residential UI — the service checkboxes render from the constants endpoint, so `VIDEO_ENABLED` appears under "Book a video link" once this is on dev. The UI's generated API types should be refreshed (`npm run generate-location-api-types`) after deployment.