### PR TITLE
MAPA-114 Return empty array for location specialistCellTypes in approval requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequestLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequestLocation.kt
@@ -205,12 +205,11 @@ open class CertificationApprovalRequestLocation(
 
   fun certifiedNormalAccommodationChange(): Int = approvedCertifiedNormalAccommodation() - calcCurrentCertifiedNormalAccommodation()
 
-  fun getSpecialistCellTypesFromList(specialCellTypes: String?): List<SpecialistCellType>? = specialCellTypes?.let { types ->
-    types.takeIf { it.isNotEmpty() }
-      ?.split(",")
-      ?.map { SpecialistCellType.valueOf(it.trim()) }
-      ?: emptyList()
-  }
+  fun getSpecialistCellTypesFromList(specialCellTypes: String?): List<SpecialistCellType> = specialCellTypes
+    ?.takeIf { it.isNotEmpty() }
+    ?.split(",")
+    ?.map { SpecialistCellType.valueOf(it.trim()) }
+    ?: emptyList()
 
   fun refreshCapacities() {
     workingCapacity = approvedWorkingCapacity()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -1613,7 +1613,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.locations[0].workingCapacity).isEqualTo(1)
       assertThat(pendingApproval.locations[0].maxCapacity).isEqualTo(2)
       assertThat(pendingApproval.locations[0].certifiedNormalAccommodation).isEqualTo(1)
-      assertThat(pendingApproval.locations[0].currentSpecialistCellTypes).isNull()
+      assertThat(pendingApproval.locations[0].currentSpecialistCellTypes).isEmpty()
       assertThat(pendingApproval.locations[0].specialistCellTypes).containsExactlyInAnyOrder(
         SpecialistCellType.SAFE_CELL,
         SpecialistCellType.CONSTANT_SUPERVISION,
@@ -1892,7 +1892,7 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.locations[0].certifiedNormalAccommodation).isEqualTo(6)
       assertThat(pendingApproval.locations[0].subLocations).hasSize(2)
       assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations).hasSize(3)
-      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).isNull()
+      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).isEmpty()
       val approvedRequest = webTestClient.put().uri("/certification/location/approve")
         .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
         .header("Content-Type", "application/json")
@@ -2022,10 +2022,10 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(pendingApproval.locations[0].workingCapacity).isEqualTo(12)
       assertThat(pendingApproval.locations[0].maxCapacity).isEqualTo(12)
       assertThat(pendingApproval.locations[0].certifiedNormalAccommodation).isEqualTo(12)
-      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).isNull()
+      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.currentSpecialistCellTypes).isEmpty()
       assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(0)?.specialistCellTypes).isEmpty()
-      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(1)?.currentSpecialistCellTypes).isNull()
-      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(1)?.specialistCellTypes).isNull()
+      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(1)?.currentSpecialistCellTypes).isEmpty()
+      assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(1)?.specialistCellTypes).isEmpty()
       assertThat(pendingApproval.locations[0].subLocations?.get(0)?.subLocations?.get(2)?.specialistCellTypes).containsExactlyInAnyOrder(
         SpecialistCellType.SAFE_CELL,
         SpecialistCellType.CONSTANT_SUPERVISION,
@@ -3106,6 +3106,50 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
         SpecialistCellType.ACCESSIBLE_CELL,
         SpecialistCellType.BIOHAZARD_DIRTY_PROTEST,
       )
+    }
+
+    @Test
+    fun `request approval to remove all specialist cell types surfaces an empty array on the location`() {
+      val cell = firstLeedsCell()
+
+      // Give the cell an existing capacity-affecting specialist cell type via the approval flow.
+      val addApproval = requestSpecialistCellTypeApproval(cell, setOf(SpecialistCellType.BIOHAZARD_DIRTY_PROTEST))
+
+      prisonerSearchMockServer.stubSearchByLocations(
+        leedsWing.prisonId,
+        listOf(cell.getPathHierarchy()),
+        false,
+      )
+      approveRequest(addApproval.id)
+      getDomainEvents(3)
+
+      // Now request approval to remove all specialist cell types (restoring the original capacities).
+      val pendingApproval = requestSpecialistCellTypeApproval(
+        cell = cell,
+        specialistCellTypes = emptySet(),
+        workingCapacity = 1,
+        maxCapacity = 2,
+        certifiedNormalAccommodation = 1,
+      )
+
+      // Top-level and location both expose the proposed empty set rather than dropping the field.
+      assertThat(pendingApproval.specialistCellTypes).isEmpty()
+      assertThat(pendingApproval.locations).hasSize(1)
+      val locationInRequest = pendingApproval.locations!![0]
+      assertThat(locationInRequest.specialistCellTypes).isEmpty()
+      assertThat(locationInRequest.currentSpecialistCellTypes).containsExactlyInAnyOrder(
+        SpecialistCellType.BIOHAZARD_DIRTY_PROTEST,
+      )
+
+      // Confirm at the JSON level that the location-level specialistCellTypes is an empty array, not absent.
+      webTestClient.get().uri("/certification/request-approvals/${pendingApproval.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.specialistCellTypes").isEqualTo(emptyList<String>())
+        .jsonPath("$.locations[0].specialistCellTypes").isEqualTo(emptyList<String>())
+        .jsonPath("$.locations[0].currentSpecialistCellTypes").isEqualTo(listOf("BIOHAZARD_DIRTY_PROTEST"))
     }
 
     @Test


### PR DESCRIPTION
## What
When a `SPECIALIST_CELL_TYPE` approval request is created that removes **all** specialist cell types, reading it back returned `specialistCellTypes: []` correctly at the top level, but the field was **missing entirely** on each entry in the `locations[]` array.

## Why
The two values come from different code paths:
- **Top level (correct):** `SpecialistCellTypeChangeApprovalRequest.toDto()` always builds a (possibly empty) `Set`, so it serialises as `[]`.
- **Location level (buggy):** the snapshot stores specialist types as a CSV `String?` which is `null` when empty. The conversion helper `getSpecialistCellTypesFromList(String?)` returned `null` for a `null` input, and `@JsonInclude(NON_NULL)` on the location DTO then dropped the field.

This made it impossible for consumers to distinguish "all specialist cell types removed" from "field not provided".

## Change
`CertificationApprovalRequestLocation.getSpecialistCellTypesFromList(String?)` now returns `emptyList()` instead of `null` for a null/empty input. This helper feeds both `specialistCellTypes` and `currentSpecialistCellTypes` on the location DTO, so both are now consistently serialised as arrays for every approval type.

- Read-time fix, so existing PENDING requests are corrected with no DB migration.
- Top-level behaviour is unchanged.
- The separate cell-certificate path is untouched.

## Tests
- Updated existing location-level assertions that expected `null` to expect empty arrays.
- Added a regression test that removes all specialist cell types and asserts (on the DTO and at the JSON level) that `locations[0].specialistCellTypes` is `[]` while `currentSpecialistCellTypes` still reflects the prior type.
