### PR TITLE
MAPA-146 Fix stale bulk cell certificate and enforce working capacity occupancy rule

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ResidentialStructu
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.capitalizeWords
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CellCertificateUploadApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequestLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.DeactivationApprovalRequest
@@ -608,7 +609,9 @@ open class ResidentialLocation(
       .map { it.toCellCertificateLocation(approvalRequest, currentCellCertificate) }
 
     val locationInExistingCertificate = currentCellCertificate?.findLocationInCertificate(getPathHierarchy())
-    if (approvalLocationIsPartOfHierarchy(approvalRequest) || locationInExistingCertificate == null) {
+    // A cell certificate upload re-certifies every location directly from current state, so always build
+    // fresh rows rather than cloning the previous certificate (which would keep stale capacities).
+    if (approvalRequest is CellCertificateUploadApprovalRequest || approvalLocationIsPartOfHierarchy(approvalRequest) || locationInExistingCertificate == null) {
       return CellCertificateLocation(
         locationType = getDerivedLocationType(),
         locationCode = getLocationCode(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
@@ -47,4 +47,5 @@ enum class ErrorCode(val errorCode: Int) {
   UsedForTypesOnlyForNormalAccommodation(138),
   CellCertificateUploadAlreadyInProgress(139),
   CellCertificateUploadNotFound(140),
+  WorkingCapacityCannotBeBelowOccupancyLevel(141),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalDecisionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalDecisionService.kt
@@ -31,8 +31,6 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.Residen
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.SignedOperationCapacityRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ApprovalRequestNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ApprovalRequestNotInPendingStatusException
-import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CapacityException
-import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ErrorCode
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationDoesNotRequireApprovalException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ReactivationDetail
@@ -231,16 +229,13 @@ class ApprovalDecisionService(
     approvalRequest: CapacityChangeApprovalRequest,
     linkedTransaction: LinkedTransaction,
   ): Map<InternalLocationDomainEventType, List<LocationDTO>> {
-    // need to check that the new max cap value is not exceeding the number of prisoners in the cell at this time.
-    val prisoners = prisonerLocationService.prisonersInLocations(approvalRequest.location)
-    val newMaxCap = approvalRequest.maxCapacity
-    if (newMaxCap < prisoners.size) {
-      throw CapacityException(
-        approvalRequest.location.getKey(),
-        "Max capacity ($newMaxCap) cannot be decreased below current cell occupancy (${prisoners.size})",
-        ErrorCode.MaxCapacityCannotBeBelowOccupancyLevel,
-      )
-    }
+    // need to check that the new capacity values are not below the number of prisoners in the cell at this time.
+    validateCapacityNotBelowOccupancy(
+      approvalRequest.location,
+      prisonerLocationService.prisonersInLocations(approvalRequest.location).size,
+      approvalRequest.maxCapacity,
+      approvalRequest.workingCapacity,
+    )
 
     approvalRequest.location.setCapacity(
       maxCapacity = approvalRequest.maxCapacity,
@@ -261,15 +256,12 @@ class ApprovalDecisionService(
     linkedTransaction: LinkedTransaction,
   ): Map<InternalLocationDomainEventType, List<LocationDTO>> {
     val cell = approvalRequest.location as Cell
-    val prisoners = prisonerLocationService.prisonersInLocations(cell)
-    val newMaxCap = approvalRequest.maxCapacity
-    if (newMaxCap < prisoners.size) {
-      throw CapacityException(
-        cell.getKey(),
-        "Max capacity ($newMaxCap) cannot be decreased below current cell occupancy (${prisoners.size})",
-        ErrorCode.MaxCapacityCannotBeBelowOccupancyLevel,
-      )
-    }
+    validateCapacityNotBelowOccupancy(
+      cell,
+      prisonerLocationService.prisonersInLocations(cell).size,
+      approvalRequest.maxCapacity,
+      approvalRequest.workingCapacity,
+    )
 
     cell.updateSpecialistCellTypes(
       approvalRequest.getSpecialistCellTypesFromPendingList().toSet(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
@@ -40,6 +40,7 @@ class CellCertificateUploadProcessingService(
   private val signedOperationCapacityRepository: SignedOperationCapacityRepository,
   private val sharedLocationService: SharedLocationService,
   private val cellCertificateService: CellCertificateService,
+  private val prisonerSearchService: PrisonerSearchService,
   private val snsService: SnsService,
   private val clock: Clock,
   transactionManager: PlatformTransactionManager,
@@ -216,6 +217,10 @@ class CellCertificateUploadProcessingService(
     var capacityChanged = false
 
     if (oldMaxCapacity != row.maxCapacity || oldWorkingCapacity != row.workingCapacity || oldCertifiedNormalAccommodation != cna) {
+      // Look up occupancy via the non-transactional search service directly: a failure here must mark just this
+      // row FAILED (caught below), not roll back the per-row transaction the way a throwing @Transactional bean would.
+      val occupancy = prisonerSearchService.findPrisonersInLocations(cell.prisonId, listOf(cell.getPathHierarchy())).size
+      validateCapacityNotBelowOccupancy(cell, occupancy, row.maxCapacity, row.workingCapacity)
       cell.setCapacity(
         maxCapacity = row.maxCapacity,
         workingCapacity = row.workingCapacity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -804,15 +804,13 @@ class LocationService(
         prisonRequiresApprovalForChanges && temporaryWorkingCapacityChange && workingCapacityChange != 0 && maxCapacityChange == 0 && cnaChange == 0
       val changeMustBeApproved = prisonRequiresApprovalForChanges && !wcTempChangeAllowed && !locCapChange.isDraft()
 
-      if (!locCapChange.isDraft() && maxCapacityChange != 0) {
-        val prisoners = prisonerLocationService.prisonersInLocations(locCapChange)
-        if (maxCapacity < prisoners.size) {
-          throw CapacityException(
-            locCapChange.getKey(),
-            "Max capacity ($maxCapacity) cannot be decreased below current cell occupancy (${prisoners.size})",
-            ErrorCode.MaxCapacityCannotBeBelowOccupancyLevel,
-          )
-        }
+      if (!locCapChange.isDraft()) {
+        validateCapacityNotBelowOccupancy(
+          locCapChange,
+          prisonerLocationService.prisonersInLocations(locCapChange).size,
+          maxCapacity,
+          workingCapacity,
+        )
       }
 
       trackingTx = linkedTransaction ?: sharedLocationService.createLinkedTransaction(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonerLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonerLocationService.kt
@@ -7,10 +7,13 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.AccommodationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellLocationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LocationRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CapacityException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ErrorCode
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationNotFoundException
 import java.util.*
 import kotlin.jvm.optionals.getOrNull
@@ -66,6 +69,34 @@ class PrisonerLocationService(
         prisoners = it.value,
       )
     }.sortedBy { it.cellLocation }
+}
+
+/**
+ * Enforces that a capacity change does not drop a cell's certified capacity below the number of prisoners
+ * currently held there. Max capacity is always checked. Working capacity is additionally checked for NORMAL
+ * ACCOMMODATION cells only - segregation/healthcare/other cells may legitimately have a working capacity of 0
+ * even while occupied, so only their max capacity is constrained.
+ *
+ * Deliberately a plain function (not a method on the @Transactional [PrisonerLocationService]) so that throwing
+ * does not mark a participating transaction rollback-only: callers obtain [currentOccupancy] via the read-only
+ * service and then call this, which lets the cell certificate upload mark an individual row as failed without
+ * rolling back its per-row transaction, while the synchronous paths still roll back as intended.
+ */
+fun validateCapacityNotBelowOccupancy(location: Location, currentOccupancy: Int, newMaxCapacity: Int, newWorkingCapacity: Int) {
+  if (newMaxCapacity < currentOccupancy) {
+    throw CapacityException(
+      location.getKey(),
+      "Max capacity ($newMaxCapacity) cannot be decreased below current cell occupancy ($currentOccupancy)",
+      ErrorCode.MaxCapacityCannotBeBelowOccupancyLevel,
+    )
+  }
+  if (location is Cell && location.accommodationType == AccommodationType.NORMAL_ACCOMMODATION && newWorkingCapacity < currentOccupancy) {
+    throw CapacityException(
+      location.getKey(),
+      "Working capacity ($newWorkingCapacity) cannot be decreased below current cell occupancy ($currentOccupancy)",
+      ErrorCode.WorkingCapacityCannotBeBelowOccupancyLevel,
+    )
+  }
 }
 
 @Schema(description = "Prisoner Location Information")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
@@ -235,6 +235,78 @@ class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
   }
 
   @Test
+  fun `a second upload regenerates the certificate from the updated capacities`() {
+    prisonerSearchMockServer.stubSearchByLocations("MDI", listOf(cell1.getPathHierarchy()), false)
+
+    // first ingestion: reduce cell1 working capacity 2 -> 1, creating the current certificate
+    postCellCertificateUpdate(
+      mapOf(cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 1, certifiedNormalAccommodation = 2)),
+    )
+    await untilAsserted {
+      assertThat(cellCertificateUploadRepository.findAll().count { it.status == CellCertificateUploadStatus.FINISHED }).isEqualTo(1)
+    }
+    assertThat(
+      cellCertificateRepository.findByPrisonIdAndCurrentIsTrue("MDI")!!
+        .findLocationInCertificate(cell1.getPathHierarchy())?.workingCapacity,
+    ).isEqualTo(1)
+
+    // second ingestion: raise cell1 working capacity 1 -> 2. The regenerated certificate must reflect this,
+    // not clone the stale value from the previous certificate.
+    postCellCertificateUpdate(
+      mapOf(cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 2, certifiedNormalAccommodation = 2)),
+    )
+    await untilAsserted {
+      assertThat(cellCertificateUploadRepository.findAll().count { it.status == CellCertificateUploadStatus.FINISHED }).isEqualTo(2)
+    }
+
+    val certificate = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue("MDI")
+    assertThat(certificate).isNotNull
+    val cell1OnCert = certificate!!.findLocationInCertificate(cell1.getPathHierarchy())
+    assertThat(cell1OnCert?.workingCapacity).isEqualTo(2)
+    assertThat(cell1OnCert?.maxCapacity).isEqualTo(2)
+  }
+
+  @Test
+  fun `working capacity cannot be set below occupancy for a normal accommodation cell but is allowed for non-normal`() {
+    // cell1 (NORMAL_ACCOMMODATION) and cell2 (CARE_AND_SEPARATION) each hold 2 prisoners
+    prisonerSearchMockServer.stubSearchByLocations("MDI", listOf(cell1.getPathHierarchy()), true, numberOfPrisonersInCell = 2)
+    prisonerSearchMockServer.stubSearchByLocations("MDI", listOf(cell2.getPathHierarchy()), true, numberOfPrisonersInCell = 2)
+
+    postCellCertificateUpdate(
+      mapOf(
+        // normal cell: working capacity 1 < occupancy 2 -> must FAIL (max 2 is still >= occupancy)
+        cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 1, certifiedNormalAccommodation = 2),
+        // care & separation cell: working capacity 0 with occupancy 2 -> allowed (only max capacity is checked)
+        cell2.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 0, certifiedNormalAccommodation = 0),
+      ),
+    )
+
+    await untilAsserted {
+      assertThat(cellCertificateUploadRepository.findAll().firstOrNull()?.status).isEqualTo(CellCertificateUploadStatus.FINISHED)
+    }
+
+    TransactionTemplate(transactionManager).execute {
+      val rows = cellCertificateUploadRepository.findAll().first().locations.associateBy { it.locationKey }
+      with(rows.getValue(cell1.getKey())) {
+        assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.FAILED)
+        assertThat(message).contains("Working capacity (1) cannot be decreased below current cell occupancy (2)")
+      }
+      with(rows.getValue(cell2.getKey())) {
+        assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.PROCESSED)
+      }
+    }
+  }
+
+  private fun postCellCertificateUpdate(locations: Map<String, CellCapacityUpdateDetail>) {
+    webTestClient.post().uri("/locations/bulk/update-cell-certificate/MDI")
+      .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+      .header("Content-Type", "application/json")
+      .bodyValue(jsonString(UpdateCapacityRequest(locations = locations)))
+      .exchange()
+      .expectStatus().isAccepted
+  }
+
+  @Test
   fun `running counts are incremented atomically per row`() {
     val uploadId = TransactionTemplate(transactionManager).execute {
       cellCertificateUploadRepository.save(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadResourceIntTest.kt
@@ -93,6 +93,10 @@ class CellCertificateUploadResourceIntTest : CommonDataTestBase() {
   inner class HappyPath {
     @Test
     fun `stores the upload, returns 202 with PENDING status and queues processing`() {
+      // the bulk processing checks occupancy before changing capacities - both cells are empty
+      prisonerSearchMockServer.stubSearchByLocations("MDI", listOf("Z-1-001"), false)
+      prisonerSearchMockServer.stubSearchByLocations("MDI", listOf("Z-1-002"), false)
+
       val response = webTestClient.post().uri("/locations/bulk/update-cell-certificate/MDI")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
         .header("Content-Type", "application/json")


### PR DESCRIPTION
## Context

Two related defects in cell-certificate / capacity handling.

### 1. Stale certificate on bulk re-ingestion
`POST /locations/bulk/update-cell-certificate/{prisonId}` applies capacity changes directly to cells (e.g. a cell W/C 1 → 2) and then generates a new cell certificate. The first ingestion worked, but a **second** ingestion produced a certificate that still showed the old values — the location data was correct, only the certificate was wrong.

Root cause: `ResidentialLocation.toCellCertificateLocation()` only built a fresh certificate row when the approval was a `LocationCertificationApprovalRequest` or there was no prior certificate; otherwise it cloned the previous certificate row. Bulk uploads run under a `CellCertificateUploadApprovalRequest`, so on a second ingestion the clone branch was taken and the just-applied changes were ignored.

Fix: a cell certificate upload re-certifies every location from current state, so the clone optimisation is now skipped for `CellCertificateUploadApprovalRequest` and fresh rows are always built.

### 2. Working capacity must not drop below occupancy (NORMAL cells)
Previously only **max** capacity was blocked from dropping below current cell occupancy. For NORMAL ACCOMMODATION cells the certified **working** capacity must also not drop below occupancy. Non-normal cells (segregation / healthcare / other) may legitimately have a working capacity of 0, so they remain max-capacity-only.

Fix: the occupancy check is centralised into a single `validateCapacityNotBelowOccupancy(...)` helper and applied across the three existing paths (direct cell capacity update, capacity-change approval, specialist-cell-type-change approval) **and** the bulk cell-certificate upload (a violating row is marked FAILED). NOMIS sync is intentionally left untouched as the legacy source of truth. A new error code `WorkingCapacityCannotBeBelowOccupancyLevel` (141) is returned for working-capacity violations.

The helper is a plain function rather than a method on the `@Transactional` `PrisonerLocationService`, and the bulk path looks up occupancy via the non-transactional search service, so a failed/violating row can be marked FAILED without rolling back its per-row transaction; the synchronous paths still roll back as intended.

## Tests
- Regression test: a second bulk upload regenerates the certificate from the updated capacities.
- New test: working capacity below occupancy fails for a normal cell but is allowed (W/C 0) for a non-normal cell.
- Existing bulk happy-path test updated to stub occupancy (the bulk path now queries it).

Full `./gradlew build` (all tests + ktlint) passes.