### PR TITLE
MAPA-147 Allow editing draft cells under a non-draft landing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResidentialResource.kt
@@ -197,7 +197,7 @@ class LocationResidentialResource(
   @PreAuthorize("hasRole('ROLE_MAINTAIN_LOCATIONS') and hasAuthority('SCOPE_write')")
   @ResponseStatus(HttpStatus.OK)
   @Operation(
-    summary = "Updates a list of DRAFT cells below a parent DRAFT location",
+    summary = "Updates a list of DRAFT cells below a parent location",
     description = "Requires role MAINTAIN_LOCATIONS and write scope",
     responses = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -486,10 +486,6 @@ class LocationService(
       residentialLocationRepository.findById(it).getOrNull() ?: throw LocationNotFoundException(it.toString())
     }
 
-    if (!parentLocation.isDraft()) {
-      throw ValidationException("Cannot update cells for a non-draft location")
-    }
-
     if (parentLocation.hasPendingCertificationApproval()) {
       throw LocationCannotBeCreatedWithPendingApprovalException(parentLocation.getKey())
     }
@@ -501,9 +497,13 @@ class LocationService(
     )
     val userOrSystemInContext = sharedLocationService.getUsername()
 
-    // find cells missing from `cellDraftUpdateRequest.cells` that are currently under this parentLocation
+    // find editable-draft cells missing from `cellDraftUpdateRequest.cells` that are currently under this parentLocation.
+    // Live cells and locked-draft cells (draft with a pending certification approval) are never sent in the request
+    // and must not be deleted.
     val listOfIds = cellDraftUpdateRequest.cells.mapNotNull { it.id }
-    val cellsToRemove = parentLocation.cellLocations().filter { cell -> cell.id !in listOfIds }
+    val cellsToRemove = parentLocation.cellLocations().filter { cell ->
+      cell.id !in listOfIds && cell.isDraft() && !cell.hasPendingCertificationApproval()
+    }
     val deletedCells = cellsToRemove.size
     cellsToRemove.forEach { cell ->
       parentLocation.removeCell(cell)
@@ -539,6 +539,11 @@ class LocationService(
     cellDraftUpdateRequest.cells.filter { it.id != null }.forEach { cell ->
       val cellToUpdate = cellLocationRepository.findById(cell.id!!)
         .orElseThrow { LocationNotFoundException(cell.id.toString()) }
+
+      // only editable draft cells can be updated via this endpoint - never live or locked-draft cells
+      if (!cellToUpdate.isDraft() || cellToUpdate.hasPendingCertificationApproval()) {
+        throw ValidationException("Cannot update cell ${cellToUpdate.getKey()} - it is not an editable draft")
+      }
 
       // update the cell
       cellToUpdate.update(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocatio
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.UsedForType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.ResidentialSummary
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
 import java.time.LocalDateTime
@@ -652,6 +653,25 @@ class DraftLocationResourceTest : CommonDataTestBase() {
             .returnResult().responseBody!!.errorCode,
         ).isEqualTo(ErrorCode.WorkingCapacityExceedsMaxCapacity.errorCode)
       }
+
+      @Test
+      fun `cannot update a cell that is not an editable draft`() {
+        // cell1 is a live (ACTIVE) cell under landingZ1 - it must not be editable via this endpoint
+        val request = createCellDraftUpdateRequest(
+          prisonId = landingZ1.prisonId,
+          parentLocation = landingZ1.id!!,
+          cells = listOf(cell1.toCellInformation(specialistCellTypes = null)),
+        )
+
+        webTestClient.put().uri(url)
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(request)
+          .exchange()
+          .expectStatus().isBadRequest
+          .expectBody()
+          .jsonPath("$.userMessage").value<String> { assertThat(it).contains("not an editable draft") }
+      }
     }
 
     @Nested
@@ -885,6 +905,90 @@ class DraftLocationResourceTest : CommonDataTestBase() {
           )
 
         assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero()
+      }
+
+      @Test
+      fun `can edit draft cells under an existing non-draft landing without deleting the live cells`() {
+        // landingZ1 is an existing ACTIVE landing already containing live cells (cell1, cell2).
+        // Add a DRAFT cell to it - the real "create locations in DRAFT from an existing landing" flow.
+        webTestClient.post().uri("/locations/create-cells")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(createCellInitialisationRequest(startingCellNumber = 10, parentLocation = landingZ1.id).copy(newLevelAboveCells = null))
+          .exchange()
+          .expectStatus().isCreated
+
+        val draftCell = repository.findOneByKey("${landingZ1.getKey()}-010") as Cell
+
+        // The request only carries the draft cell - the live cells are not editable here.
+        val request = createCellDraftUpdateRequest(
+          prisonId = landingZ1.prisonId,
+          parentLocation = landingZ1.id!!,
+          cells = listOf(
+            draftCell.toCellInformation(specialistCellTypes = setOf(SpecialistCellType.ACCESSIBLE_CELL))
+              .copy(maxCapacity = 2, workingCapacity = 2),
+          ),
+        )
+
+        webTestClient.put().uri(url)
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(request)
+          .exchange()
+          .expectStatus().isOk
+
+        // the live cells must NOT have been deleted
+        assertThat(cellRepository.findById(cell1.id!!)).isPresent
+        assertThat(cellRepository.findById(cell2.id!!)).isPresent
+        // the draft cell was updated
+        webTestClient.get().uri("/locations/${draftCell.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.pendingChanges.workingCapacity").isEqualTo(2)
+          .jsonPath("$.pendingChanges.maxCapacity").isEqualTo(2)
+
+        assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero()
+      }
+
+      @Test
+      fun `does not delete locked-draft sibling cells that are omitted from the request`() {
+        // Add two DRAFT cells (010, 011) to the existing live landingZ1
+        webTestClient.post().uri("/locations/create-cells")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(createCellInitialisationRequest(startingCellNumber = 10, numberOfCells = 2, parentLocation = landingZ1.id).copy(newLevelAboveCells = null))
+          .exchange()
+          .expectStatus().isCreated
+
+        val lockedDraftCell = repository.findOneByKey("${landingZ1.getKey()}-010") as Cell
+        val editableDraftCell = repository.findOneByKey("${landingZ1.getKey()}-011") as Cell
+
+        // Lock one of the draft cells by requesting certification approval for it
+        webTestClient.put().uri("/certification/location/request-approval")
+          .headers(setAuthorisation(user = EXPECTED_USERNAME, roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(LocationApprovalRequest(locationId = lockedDraftCell.id!!)))
+          .exchange()
+          .expectStatus().isOk
+
+        // The request only carries the still-editable draft cell - the locked draft is omitted
+        val request = createCellDraftUpdateRequest(
+          prisonId = landingZ1.prisonId,
+          parentLocation = landingZ1.id!!,
+          cells = listOf(editableDraftCell.toCellInformation(specialistCellTypes = null)),
+        )
+
+        webTestClient.put().uri(url)
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(request)
+          .exchange()
+          .expectStatus().isOk
+
+        // the locked-draft cell must NOT have been deleted
+        assertThat(cellRepository.findById(lockedDraftCell.id!!)).isPresent
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/DraftLocationResourceTest.kt
@@ -908,6 +908,50 @@ class DraftLocationResourceTest : CommonDataTestBase() {
       }
 
       @Test
+      fun `can add a new draft cell to an existing non-draft landing via edit-cells`() {
+        // landingZ1 is an existing ACTIVE landing already containing live cells (cell1, cell2).
+        // Send a brand-new cell (no id) directly to the edit-cells endpoint - it should be created as DRAFT.
+        val request = createCellDraftUpdateRequest(
+          prisonId = landingZ1.prisonId,
+          parentLocation = landingZ1.id!!,
+          cells = listOf(
+            CellInformation(
+              code = "010",
+              cellMark = "Z1-010",
+              maxCapacity = 2,
+              workingCapacity = 1,
+              certifiedNormalAccommodation = 1,
+              specialistCellTypes = setOf(SpecialistCellType.ACCESSIBLE_CELL),
+              inCellSanitation = true,
+            ),
+          ),
+        )
+
+        webTestClient.put().uri(url)
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(request)
+          .exchange()
+          .expectStatus().isOk
+
+        // the new cell was created as a DRAFT under the live landing
+        webTestClient.get().uri("/locations/key/${landingZ1.getKey()}-010")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.status").isEqualTo("DRAFT")
+          .jsonPath("$.pendingChanges.maxCapacity").isEqualTo(2)
+          .jsonPath("$.pendingChanges.workingCapacity").isEqualTo(1)
+
+        // the live cells must NOT have been deleted
+        assertThat(cellRepository.findById(cell1.id!!)).isPresent
+        assertThat(cellRepository.findById(cell2.id!!)).isPresent
+
+        assertThat(getNumberOfMessagesCurrentlyOnQueue()).isZero()
+      }
+
+      @Test
       fun `can edit draft cells under an existing non-draft landing without deleting the live cells`() {
         // landingZ1 is an existing ACTIVE landing already containing live cells (cell1, cell2).
         // Add a DRAFT cell to it - the real "create locations in DRAFT from an existing landing" flow.


### PR DESCRIPTION
## Context

Supports creating new locations in DRAFT from an existing (live) landing. The `PUT /locations/edit-cells` endpoint previously rejected any parent that was not itself a draft with `Cannot update cells for a non-draft location`, so draft cells added beneath an existing ACTIVE landing could not be edited.

The edit-cells request only carries the draft cells, so the "remove cells not in the request" logic also needed to be narrowed to avoid deleting the parent's live or locked-draft cells.

Note: there is no separate "locked draft" status — a locked draft is `isDraft()` **and** `hasPendingCertificationApproval()`, so the filter checks both rather than status alone.

## Changes

- `service/LocationService.kt` (`updateCells`):
  - Remove the non-draft parent restriction (the parent pending-approval check is kept).
  - Only remove editable-draft cells absent from the request (`isDraft() && !hasPendingCertificationApproval()`), protecting live and locked-draft cells. This also fixes a latent bug where `deleteById` ran even when `removeCell()` (drafts-only) returned false.
  - Add a defensive guard rejecting updates targeting live or locked-draft cells.
- `resource/LocationResidentialResource.kt`: drop "parent DRAFT" from the OpenAPI summary.
- `resource/DraftLocationResourceTest.kt`: add tests for editing draft cells under a live landing without deleting live cells, preserving omitted locked-draft cells, and the new guard.

## Verification

- `./gradlew test --tests "...DraftLocationResourceTest"` — all pass
- `./gradlew ktlintCheck` — passes