### PR TITLE
MAPB-490 Add batch non-residential location lookup by ids

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
@@ -90,6 +90,41 @@ class LocationNonResidentialResource(
   ) = nonResidentialService.getById(id = id)
     ?: throw LocationNotFoundException(id.toString())
 
+  @PostMapping("/non-residential/batch", produces = [MediaType.APPLICATION_JSON_VALUE])
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")
+  @Operation(
+    summary = "Returns non-residential location information for the supplied ids in one call",
+    description = "Resolves several locations at once. Only ids that are non-residential locations are " +
+      "returned; residential or unknown ids are silently omitted. Requires role VIEW_LOCATIONS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns the matching non-residential locations",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid Request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the VIEW_LOCATIONS role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getNonResidentialLocationsByIds(
+    @RequestBody
+    @Validated
+    ids: List<UUID>,
+  ): List<NonResidentialLocationDTO> = nonResidentialService.getByIds(ids)
+
   @PostMapping("/non-residential", produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasRole('ROLE_MAINTAIN_LOCATIONS') and hasAuthority('SCOPE_write')")
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -60,6 +60,14 @@ class NonResidentialService(
 
   fun getById(id: UUID): NonResidentialLocationDTO? = nonResidentialLocationRepository.findById(id).getOrNull()?.toNonResidentialDto()
 
+  /**
+   * Resolve several non-residential locations by id in one call. The repository only returns
+   * non-residential entities, so ids that are residential or unknown are simply absent from the result.
+   */
+  fun getByIds(ids: List<UUID>): List<NonResidentialLocationDTO> = nonResidentialLocationRepository.findAllById(ids)
+    .map { it.toNonResidentialDto() }
+    .sortedBy { it.pathHierarchy }
+
   fun getByPrisonAndServiceType(
     prisonId: String,
     serviceType: ServiceType? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ServiceType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.buildNonResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.generateNonResidentialCode
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
+import java.util.UUID
 
 @WithMockAuthUser(username = EXPECTED_USERNAME)
 class LocationNonResidentialResourceTest : CommonDataTestBase() {
@@ -2070,6 +2071,105 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
           .header("Content-Type", "application/json")
           .exchange()
           .expectStatus().is4xxClientError
+      }
+    }
+  }
+
+  @DisplayName("POST /locations/non-residential/batch")
+  @Nested
+  inner class GetNonResidentialLocationsByIdsTest {
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no authority`() {
+        webTestClient.post().uri("/locations/non-residential/batch")
+          .header("Content-Type", "application/json")
+          .bodyValue(listOf(visitRoom.id))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.post().uri("/locations/non-residential/batch")
+          .headers(setAuthorisation(roles = listOf()))
+          .header("Content-Type", "application/json")
+          .bodyValue(listOf(visitRoom.id))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.post().uri("/locations/non-residential/batch")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .header("Content-Type", "application/json")
+          .bodyValue(listOf(visitRoom.id))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `returns the requested non-residential locations`() {
+        webTestClient.post().uri("/locations/non-residential/batch")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .bodyValue(listOf(visitRoom.id, adjRoom.id))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+              [
+                {
+                  "id": "${adjRoom.id}",
+                  "prisonId": "MDI",
+                  "code": "ADJUDICATION",
+                  "pathHierarchy": "Z-ADJUDICATION",
+                  "locationType": "ADJUDICATION_ROOM",
+                  "status": "ACTIVE"
+                },
+                {
+                  "id": "${visitRoom.id}",
+                  "prisonId": "MDI",
+                  "code": "VISIT",
+                  "pathHierarchy": "Z-VISIT",
+                  "locationType": "VISITS",
+                  "status": "ACTIVE"
+                }
+              ]
+            """,
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `only returns ids that are non-residential locations, ignoring residential and unknown ids`() {
+        webTestClient.post().uri("/locations/non-residential/batch")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .bodyValue(listOf(visitRoom.id, cell1.id, UUID.randomUUID()))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.length()").isEqualTo(1)
+          .jsonPath("$[0].id").isEqualTo(visitRoom.id.toString())
+      }
+
+      @Test
+      fun `returns an empty list when no ids match a non-residential location`() {
+        webTestClient.post().uri("/locations/non-residential/batch")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+          .header("Content-Type", "application/json")
+          .bodyValue(listOf(cell1.id, UUID.randomUUID()))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.length()").isEqualTo(0)
       }
     }
   }


### PR DESCRIPTION
## What
New `POST /locations/non-residential/batch` — takes a JSON array of location ids and returns the matching non-residential locations (`NonResidentialLocationDTO`) in one call.

## Why
The prisoner-property-api needs to resolve many property-storage location names when listing a prisoner's property. Today that's one `GET /locations/{id}` per id; this batch endpoint makes it a single round-trip.

## How
- `NonResidentialService.getByIds(ids)` uses the non-residential repository's inherited `findAllById`, so only non-residential ids resolve — residential or unknown ids are silently omitted (no 404).
- Reuses the existing `NonResidentialLocationDTO` / `toNonResidentialDto()` mapper, consistent with the other non-resi endpoints.
- `@PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")`, full springdoc annotations, modelled on the existing `POST /locations/keys` batch.
- Tests in `LocationNonResidentialResourceTest`: security (401/403), happy path, and filtering (residential + unknown ids excluded).

## Notes
- Consumers calling this (e.g. the property-api client credentials) need the `ROLE_VIEW_LOCATIONS` role granted — a config concern, not code here.
- Repointing the property-api's `LocationsClient.getLocations` at this endpoint is a follow-up in that repo.
