### PR TITLE
MAPB-573 Use lastMovementDate from prisoner search for overnight roll count

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonApiService.kt
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import java.time.LocalDate
-import java.time.LocalTime
 
 inline fun <reified T : Any> typeReference() = object : ParameterizedTypeReference<T>() {}
 
@@ -35,19 +34,6 @@ class PrisonApiService(
     .retrieve()
     .bodyToMono(typeReference<List<OffenderMovement>>())
     .block() ?: emptyList()
-
-  fun getLatestMovementsForOffenders(offenderNumbers: List<String>): List<LatestOffenderMovement> {
-    if (offenderNumbers.isEmpty()) return emptyList()
-
-    return prisonApiWebClient
-      .post()
-      .uri("/api/movements/offenders?latestOnly=true")
-      .header("Content-Type", "application/json")
-      .bodyValue(offenderNumbers)
-      .retrieve()
-      .bodyToMono(typeReference<List<LatestOffenderMovement>>())
-      .block() ?: emptyList()
-  }
 }
 
 data class MovementCount(
@@ -64,11 +50,4 @@ data class OffenderMovement(
   val offenderNo: String,
   val movementSequence: String?,
   val movementType: String,
-)
-
-data class LatestOffenderMovement(
-  val offenderNo: String,
-  val directionCode: String,
-  val movementDate: LocalDate? = null,
-  val movementTime: LocalTime? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonRollCountService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonRollCountService.kt
@@ -21,7 +21,6 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.Residen
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationNotFoundException
 import java.time.Clock
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.*
 import kotlin.collections.count
 import kotlin.jvm.optionals.getOrNull
@@ -131,21 +130,14 @@ class PrisonRollCountService(
 
   internal fun getNumOvernights(prisoners: List<Prisoner>): Int {
     val overnightMovementTypes = setOf("CRT", "TAP")
-    val prisonerNumbers = prisoners
-      .filter { it.lastMovementTypeCode in overnightMovementTypes && it.status == "ACTIVE OUT" }
-      .map { it.prisonerNumber }
+    val today = LocalDate.now(clock)
 
-    if (prisonerNumbers.isEmpty()) return 0
-
-    val currentDayStart = LocalDate.now(clock).atStartOfDay()
-
-    return prisonApiService.getLatestMovementsForOffenders(prisonerNumbers)
-      .count { movement ->
-        movement.directionCode == "OUT" &&
-          movement.movementDate != null &&
-          movement.movementTime != null &&
-          LocalDateTime.of(movement.movementDate, movement.movementTime) < currentDayStart
-      }
+    return prisoners.count { prisoner ->
+      prisoner.lastMovementTypeCode in overnightMovementTypes &&
+        prisoner.status == "ACTIVE OUT" &&
+        prisoner.lastMovementDate != null &&
+        prisoner.lastMovementDate < today
+    }
   }
 
   private fun locationRollCount(locations: List<ResidentialPrisonerLocation>, filterSeg: Boolean) = LocationRollCount(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonerSearchService.kt
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
+import java.time.LocalDate
 
 @Service
 class PrisonerSearchService(
@@ -114,6 +115,8 @@ data class Prisoner(
   val alerts: List<Alert>? = null,
   @param:Schema(description = "Last Movement Type Code of prisoner", example = "CRT", required = false)
   val lastMovementTypeCode: String? = null,
+  @param:Schema(description = "Date of the last movement of the prisoner", example = "2023-05-01", required = false)
+  val lastMovementDate: LocalDate? = null,
 )
 
 data class Alert(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/PrisonApiMockServer.kt
@@ -3,14 +3,9 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.integration.wiremock
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
-import com.github.tomakehurst.wiremock.client.WireMock.equalTo
-import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import com.github.tomakehurst.wiremock.client.WireMock.post
-import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.http.HttpHeader
 import com.github.tomakehurst.wiremock.http.HttpHeaders
-import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LatestOffenderMovement
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.MovementCount
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.OffenderMovement
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.PrisonRollMovementInfo
@@ -64,27 +59,6 @@ class PrisonApiMockServer : WireMockServer(WIREMOCK_PORT) {
             .withBody(mapper.writeValueAsBytes(offenderMovements))
             .withStatus(200),
         ),
-    )
-  }
-
-  fun stubLatestOffenderMovements(
-    latestMovements: List<LatestOffenderMovement> = emptyList(),
-    expectedOffenderNumbers: List<String>? = null,
-  ) {
-    var mappingBuilder = post(urlPathEqualTo("/api/movements/offenders"))
-      .withQueryParam("latestOnly", equalTo("true"))
-
-    if (expectedOffenderNumbers != null) {
-      mappingBuilder = mappingBuilder.withRequestBody(equalToJson(mapper.writeValueAsString(expectedOffenderNumbers), true, true))
-    }
-
-    stubFor(
-      mappingBuilder.willReturn(
-        aResponse()
-          .withHeader("Content-Type", "application/json")
-          .withBody(mapper.writeValueAsBytes(latestMovements))
-          .withStatus(200),
-      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/integration/wiremock/PrisonerSearchMockServer.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.service.AttributeSearc
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.Matcher
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.Prisoner
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.SearchResult
+import java.time.LocalDate
 
 class PrisonerSearchMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
@@ -100,7 +101,7 @@ class PrisonerSearchMockServer : WireMockServer(WIREMOCK_PORT) {
         createPrisoner(prisonId = prisonId, cellLocation = "RECP", prisonerCount = 1003, inOutStatus = "IN", status = "ACTIVE IN"),
         createPrisoner(prisonId = prisonId, cellLocation = "TAP", prisonerCount = 1004, inOutStatus = "IN", status = "ACTIVE IN"),
         createPrisoner(prisonId = prisonId, cellLocation = "COURT", prisonerCount = 1005, inOutStatus = "IN", status = "ACTIVE IN"),
-        createPrisoner(prisonId = prisonId, cellLocation = "COURT", prisonerCount = 1006, inOutStatus = "OUT", status = "ACTIVE OUT", lastMovementTypeCode = "CRT"),
+        createPrisoner(prisonId = prisonId, cellLocation = "COURT", prisonerCount = 1006, inOutStatus = "OUT", status = "ACTIVE OUT", lastMovementTypeCode = "CRT", lastMovementDate = LocalDate.of(2023, 12, 4)),
         createPrisoner(prisonId = prisonId, cellLocation = "RECP", prisonerCount = 1007, inOutStatus = "IN", status = "ACTIVE IN"),
         createPrisoner(prisonId = prisonId, cellLocation = "RECP", prisonerCount = 1008, inOutStatus = "OUT", status = "ACTIVE OUT"),
         createPrisoner(prisonId = prisonId, cellLocation = "CSWAP", prisonerCount = 1009, inOutStatus = "IN", status = "ACTIVE IN"),
@@ -121,7 +122,7 @@ class PrisonerSearchMockServer : WireMockServer(WIREMOCK_PORT) {
   }
 }
 
-fun createPrisoner(prisonId: String, cellLocation: String, prisonerCount: Int, status: String = "ACTIVE IN", inOutStatus: String = "IN", lastMovementTypeCode: String = "ADM") = Prisoner(
+fun createPrisoner(prisonId: String, cellLocation: String, prisonerCount: Int, status: String = "ACTIVE IN", inOutStatus: String = "IN", lastMovementTypeCode: String = "ADM", lastMovementDate: LocalDate? = null) = Prisoner(
   prisonerNumber = "A${prisonerCount.toString().padStart(4, '0')}AA",
   firstName = "Firstname-$prisonerCount",
   lastName = "Surname-$prisonerCount",
@@ -131,6 +132,7 @@ fun createPrisoner(prisonId: String, cellLocation: String, prisonerCount: Int, s
   gender = "MALE",
   status = status,
   lastMovementTypeCode = lastMovementTypeCode,
+  lastMovementDate = lastMovementDate,
   inOutStatus = inOutStatus,
   csra = "High",
   category = "C",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonRollResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonRollResourceIntTest.kt
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.json.JsonCompareMode
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.PrisonConfigurationRepository
-import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LatestOffenderMovement
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.MovementCount
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.OffenderMovement
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.PrisonRollMovementInfo
@@ -76,7 +75,6 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
       fun `can obtain a role count for NMI`() {
         prisonerSearchMockServer.stubAllPrisonersInPrison(cell1N.prisonId)
         prisonApiMockServer.stubMovementsToday(cell1N.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(2, 1), enRouteToday = 1))
-        prisonApiMockServer.stubLatestOffenderMovements()
         prisonApiMockServer.stubOffenderMovementsToday(
           prisonId = cell1N.prisonId,
           date = LocalDate.now(clock),
@@ -155,7 +153,6 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
       fun `can obtain a role count for MDI sub-level`() {
         prisonerSearchMockServer.stubSearchByLocations(landingZ1.prisonId, landingZ1.cellLocations().map { it.getPathHierarchy() }, true)
         prisonApiMockServer.stubMovementsToday(landingZ1.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(1, 2), enRouteToday = 2))
-        prisonApiMockServer.stubLatestOffenderMovements()
 
         webTestClient.get().uri("/prison/roll-count/${landingZ1.prisonId}/cells-only/${landingZ1.id!!}")
           .headers(setAuthorisation(roles = listOf("ESTABLISHMENT_ROLL")))
@@ -358,7 +355,6 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
       fun `can obtain a role count for MDI`() {
         prisonerSearchMockServer.stubAllPrisonersInPrison(cell1.prisonId)
         prisonApiMockServer.stubMovementsToday(cell1.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(1, 2), enRouteToday = 2))
-        prisonApiMockServer.stubLatestOffenderMovements()
         prisonApiMockServer.stubOffenderMovementsToday(prisonId = cell1.prisonId, date = LocalDate.now(clock), offenderMovements = emptyList())
         prisonApiMockServer.stubOffenderMovementsToday(
           prisonId = cell1.prisonId,
@@ -489,12 +485,6 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
         prisonerSearchMockServer.stubAllPrisonersInPrison(prisonId = cell1.prisonId)
 
         prisonApiMockServer.stubMovementsToday(cell1.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(1, 2), enRouteToday = 2))
-        prisonApiMockServer.stubLatestOffenderMovements(
-          latestMovements = listOf(
-            LatestOffenderMovement(offenderNo = "A1006AA", directionCode = "OUT", movementDate = LocalDate.of(2023, 12, 4), movementTime = java.time.LocalTime.of(11, 59)),
-          ),
-          expectedOffenderNumbers = listOf("A1006AA", "A1011AA"),
-        )
         prisonApiMockServer.stubOffenderMovementsToday(
           prisonId = cell1.prisonId,
           date = LocalDate.now(clock),
@@ -519,7 +509,6 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
 
         prisonerSearchMockServer.stubAllPrisonersInPrison(cell1.prisonId)
         prisonApiMockServer.stubMovementsToday(cell1.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(1, 2), enRouteToday = 2))
-        prisonApiMockServer.stubLatestOffenderMovements()
         prisonApiMockServer.stubOffenderMovementsToday(prisonId = cell1.prisonId, date = LocalDate.now(clock), offenderMovements = emptyList())
         prisonApiMockServer.stubOffenderMovementsToday(
           prisonId = cell1.prisonId,
@@ -649,7 +638,6 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
       fun `can obtain a role count for MDI with cells`() {
         prisonerSearchMockServer.stubAllPrisonersInPrison(cell1.prisonId)
         prisonApiMockServer.stubMovementsToday(cell1.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(1, 2), enRouteToday = 2))
-        prisonApiMockServer.stubLatestOffenderMovements()
         prisonApiMockServer.stubOffenderMovementsToday(
           prisonId = cell1.prisonId,
           date = LocalDate.now(clock),
@@ -828,7 +816,6 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
       fun `can obtain a role count for MDI with an offender moving to court and then released`() {
         prisonerSearchMockServer.stubAllPrisonersInPrison(cell1.prisonId)
         prisonApiMockServer.stubMovementsToday(cell1.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(1, 3), enRouteToday = 2))
-        prisonApiMockServer.stubLatestOffenderMovements()
         prisonApiMockServer.stubOffenderMovementsToday(
           prisonId = cell1.prisonId,
           date = LocalDate.now(clock),
@@ -872,7 +859,6 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
       fun `can obtain a role count for MDI with two offenders moving to court and then released`() {
         prisonerSearchMockServer.stubAllPrisonersInPrison(cell1.prisonId)
         prisonApiMockServer.stubMovementsToday(cell1.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(1, 4), enRouteToday = 2))
-        prisonApiMockServer.stubLatestOffenderMovements()
         prisonApiMockServer.stubOffenderMovementsToday(
           prisonId = cell1.prisonId,
           date = LocalDate.now(clock),
@@ -917,7 +903,6 @@ class PrisonRollResourceIntTest : CommonDataTestBase() {
       fun `can obtain a role count for MDI with an offender moving to court and then back and then released`() {
         prisonerSearchMockServer.stubAllPrisonersInPrison(cell1.prisonId)
         prisonApiMockServer.stubMovementsToday(cell1.prisonId, PrisonRollMovementInfo(inOutMovementsToday = MovementCount(1, 2), enRouteToday = 2))
-        prisonApiMockServer.stubLatestOffenderMovements()
         prisonApiMockServer.stubOffenderMovementsToday(
           prisonId = cell1.prisonId,
           date = LocalDate.now(clock),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonRollCountServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonRollCountServiceTest.kt
@@ -3,9 +3,7 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.service
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.verifyNoInteractions
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Capacity
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.DerivedLocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.TestBase.Companion.clock
@@ -13,7 +11,6 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.PrisonConfigurationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.ResidentialLocationRepository
 import java.time.LocalDate
-import java.time.LocalTime
 import java.util.UUID
 
 class PrisonRollCountServiceTest {
@@ -193,7 +190,7 @@ class PrisonRollCountServiceTest {
     assertThat(doubleMoveCount).isEqualTo(0)
   }
 
-  private fun overnightPrisoner(number: String, lastMovementType: String) = Prisoner(
+  private fun overnightPrisoner(number: String, lastMovementType: String, lastMovementDate: LocalDate?) = Prisoner(
     prisonerNumber = number,
     prisonId = "MDI",
     prisonName = "HMP Moorland",
@@ -203,21 +200,16 @@ class PrisonRollCountServiceTest {
     status = "ACTIVE OUT",
     inOutStatus = "OUT",
     lastMovementTypeCode = lastMovementType,
+    lastMovementDate = lastMovementDate,
   )
 
   @Test
-  fun `get overnight count returns number of offender movements with OUT direction`() {
-    // Test clock is fixed at 2023-12-05, so overnight cutoff is strictly before 2023-12-05 00:00:00.
+  fun `get overnight count returns number of CRT and TAP prisoners last moved before today`() {
+    // Test clock is fixed at 2023-12-05, so overnight cutoff is any movement date before 2023-12-05.
     val prisoners = listOf(
-      overnightPrisoner("A1000AA", "CRT"),
-      overnightPrisoner("A1001AA", "ADM"), // ADM — not an overnight candidate
-      overnightPrisoner("A1002AA", "TAP"),
-    )
-    whenever(prisonApiService.getLatestMovementsForOffenders(listOf("A1000AA", "A1002AA"))).thenReturn(
-      listOf(
-        LatestOffenderMovement(offenderNo = "A1000AA", directionCode = "OUT", movementDate = LocalDate.of(2023, 12, 4), movementTime = LocalTime.of(11, 59)),
-        LatestOffenderMovement(offenderNo = "A1002AA", directionCode = "OUT", movementDate = LocalDate.of(2023, 12, 3), movementTime = LocalTime.of(23, 30)),
-      ),
+      overnightPrisoner("A1000AA", "CRT", LocalDate.of(2023, 12, 4)),
+      overnightPrisoner("A1001AA", "ADM", LocalDate.of(2023, 12, 4)), // ADM — not an overnight candidate
+      overnightPrisoner("A1002AA", "TAP", LocalDate.of(2023, 12, 3)),
     )
 
     val overnightCount = service.getNumOvernights(prisoners)
@@ -226,19 +218,15 @@ class PrisonRollCountServiceTest {
   }
 
   @Test
-  fun `get overnight count only includes out movements from the previous day or earlier`() {
-    // Test clock is fixed at 2023-12-05, so overnight cutoff is strictly before 2023-12-05 00:00:00.
-    // 2023-12-04 23:59:59 → counts; 2023-12-05 00:00:00 or later → does not count.
-    val prisoners = (0..5).map { overnightPrisoner("A100${it}AA", "CRT") }
-    whenever(prisonApiService.getLatestMovementsForOffenders(prisoners.map { it.prisonerNumber })).thenReturn(
-      listOf(
-        LatestOffenderMovement(offenderNo = "A1000AA", directionCode = "OUT", movementDate = LocalDate.of(2023, 12, 4), movementTime = LocalTime.of(23, 59, 59)),
-        LatestOffenderMovement(offenderNo = "A1001AA", directionCode = "OUT", movementDate = LocalDate.of(2023, 12, 5), movementTime = LocalTime.MIDNIGHT),
-        LatestOffenderMovement(offenderNo = "A1002AA", directionCode = "OUT", movementDate = LocalDate.of(2023, 12, 5), movementTime = LocalTime.of(9, 0)),
-        LatestOffenderMovement(offenderNo = "A1003AA", directionCode = "OUT", movementDate = null, movementTime = LocalTime.of(8, 0)),
-        LatestOffenderMovement(offenderNo = "A1004AA", directionCode = "IN", movementDate = LocalDate.of(2023, 12, 4), movementTime = LocalTime.of(10, 0)),
-        LatestOffenderMovement(offenderNo = "A1005AA", directionCode = "OUT", movementDate = LocalDate.of(2023, 12, 3), movementTime = LocalTime.of(12, 0)),
-      ),
+  fun `get overnight count only includes movements from the previous day or earlier`() {
+    // Test clock is fixed at 2023-12-05, so a movement date before 2023-12-05 counts; 2023-12-05 or a
+    // missing date does not.
+    val prisoners = listOf(
+      overnightPrisoner("A1000AA", "CRT", LocalDate.of(2023, 12, 4)), // yesterday — counts
+      overnightPrisoner("A1001AA", "CRT", LocalDate.of(2023, 12, 5)), // today — does not count
+      overnightPrisoner("A1002AA", "TAP", LocalDate.of(2023, 12, 5)), // today — does not count
+      overnightPrisoner("A1003AA", "CRT", null), // no movement date — does not count
+      overnightPrisoner("A1004AA", "TAP", LocalDate.of(2023, 12, 3)), // earlier — counts
     )
 
     val overnightCount = service.getNumOvernights(prisoners)
@@ -247,10 +235,12 @@ class PrisonRollCountServiceTest {
   }
 
   @Test
-  fun `get overnight count does not call prison api when no eligible CRT or TAP ACTIVE OUT prisoners`() {
-    val overnightCount = service.getNumOvernights(emptyList())
+  fun `get overnight count does not call prison api`() {
+    val prisoners = listOf(overnightPrisoner("A1000AA", "CRT", LocalDate.of(2023, 12, 4)))
 
-    assertThat(overnightCount).isEqualTo(0)
-    verify(prisonApiService, never()).getLatestMovementsForOffenders(org.mockito.kotlin.any())
+    val overnightCount = service.getNumOvernights(prisoners)
+
+    assertThat(overnightCount).isEqualTo(1)
+    verifyNoInteractions(prisonApiService)
   }
 }


### PR DESCRIPTION
## ⚠️ Blocked — do not merge until prisoner-search is reindexed - NOW UNBLOCKED
Depends on ministryofjustice/hmpps-prisoner-search#798. The new `lastMovementDate` field must be deployed **and a full reindex completed in dev, preprod and prod** before this is merged. Until then `lastMovementDate` is null everywhere and `numOvernights` would always be 0.

## What
`getNumOvernights` now reads `lastMovementDate` directly from the prisoner search results instead of making a separate prison-api call.

## Changes
- `PrisonerSearchService`: added `lastMovementDate` to the `Prisoner` DTO (automatically requested via `responseFields`)
- `PrisonRollCountService.getNumOvernights`: counts CRT/TAP `ACTIVE OUT` prisoners whose `lastMovementDate` is before today
- `PrisonApiService`: removed `getLatestMovementsForOffenders` and `LatestOffenderMovement` (no longer used)
- Tests updated (unit + integration), dead WireMock stubs removed

## Behaviour
The old code filtered to `ACTIVE OUT` + CRT/TAP then checked the latest OUT movement was before today. For those prisoners prison-api's `lastMovementTime` is the matching OUT movement, so the new date-based check is equivalent.