### PR TITLE
MAPA-87 Block archive when a child location has a pending certificate change request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PendingApprovalsBelowDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PendingApprovalsBelowDto.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import java.util.UUID
+
+@Schema(description = "Pending certification approval requests on locations below a given location")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class PendingApprovalsBelowDto(
+  @param:Schema(description = "True if any location below the requested location has a pending certification approval request", example = "true", required = true)
+  val hasPendingBelow: Boolean,
+
+  @param:Schema(description = "The locations below the requested location that have a pending certification approval request", required = true)
+  val pendingLocations: List<PendingApprovalLocationDto>,
+)
+
+@Schema(description = "A location with a pending certification approval request, including its parent")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class PendingApprovalLocationDto(
+  @param:Schema(description = "The id of the location with the pending approval request", example = "2475f250-434a-4257-afe7-b911f1773a4d", required = true)
+  val id: UUID,
+  @param:Schema(description = "The business key of the location with the pending approval request", example = "LEI-B-1-001", required = true)
+  val key: String,
+  @param:Schema(description = "The local name of the location with the pending approval request, if any", example = "B-1-001", required = false)
+  val localName: String?,
+  @param:Schema(description = "The type of the location with the pending approval request", example = "CELL", required = true)
+  val locationType: LocationType,
+
+  @param:Schema(description = "The id of the parent of the location with the pending approval request", example = "0199e835-9eb8-7183-ab7e-f79149e5c1f8", required = false)
+  val parentId: UUID?,
+  @param:Schema(description = "The business key of the parent location", example = "LEI-B-1", required = false)
+  val parentKey: String?,
+  @param:Schema(description = "The local name of the parent location, if any", example = "Landing B-1", required = false)
+  val parentLocalName: String?,
+  @param:Schema(description = "The type of the parent location", example = "LANDING", required = false)
+  val parentLocationType: LocationType?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -145,6 +145,15 @@ open class ResidentialLocation(
 
   private fun hasPendingChangesBelowThisLevel() = childLocations.filterIsInstance<Cell>().any { it.hasPendingCertificationApproval() || it.isDraft() }
 
+  /**
+   * Returns every PENDING approval request attached to a location anywhere below this one (recursively).
+   * Each returned request exposes its own `location` (where the change is pending) and that location's parent.
+   * Intended to guard changes (e.g. archiving) made at a level above an in-flight pending approval.
+   */
+  fun findPendingApprovalRequestsBelowThisLevel(): List<LocationCertificationApprovalRequest> = findSubLocations()
+    .filterIsInstance<ResidentialLocation>()
+    .flatMap { location -> location.approvalRequests.filter { it.isPending() } }
+
   fun getPendingApprovalRequest(): LocationCertificationApprovalRequest? = findHighestLevelPending()?.approvalRequests?.firstOrNull { it.isPending() }
 
   fun getLatestApprovedDeactivationRequest(): LocationCertificationApprovalRequest? = findHighestLevelForStatus(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
@@ -310,6 +310,21 @@ class ApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(PendingApprovalBelowLocationException::class)
+  fun handlePendingApprovalBelowLocationException(e: PendingApprovalBelowLocationException): ResponseEntity<ErrorResponse> {
+    log.debug("Location has a pending approval below it: {}", e.message)
+    return ResponseEntity
+      .status(CONFLICT)
+      .body(
+        ErrorResponse(
+          status = CONFLICT,
+          errorCode = ErrorCode.PendingApprovalExistsBelowLocation,
+          userMessage = "Location cannot be archived as a location below it has a pending approval request: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
   @ExceptionHandler(TransactionNotFoundException::class)
   fun handleTransactionNotFound(e: TransactionNotFoundException): ResponseEntity<ErrorResponse> {
     log.debug("Transaction not found exception caught: {}", e.message)
@@ -755,6 +770,7 @@ class LocationIsNotACellException(key: String) : Exception("$key: Location must 
 class ApprovalRequestNotFoundException(approvalRequestId: UUID) : Exception("Approval request $approvalRequestId not found")
 class PendingApprovalOnLocationCannotBeUpdatedException(key: String) : Exception("Location $key cannot be updated as it has a pending approval request")
 class PendingApprovalAlreadyExistsException(key: String) : Exception("Location $key already has a pending approval request")
+class PendingApprovalBelowLocationException(key: String, pendingKey: String) : Exception("Location $key cannot be archived because $pendingKey below it has a pending approval request")
 class LocationCannotBeDeletedWhenNotDraftException(key: String) : Exception("Location $key cannot be deleted when not DRAFT")
 class ApprovalRequestNotInPendingStatusException(approvalRequestId: UUID) : Exception("Approval request $approvalRequestId is not in PENDING status")
 class LocationDoesNotRequireApprovalException(key: String) : Exception("Location $key does not need to be approved")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApprovalRequestResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApprovalRequestResource.kt
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ApproveCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PendingApprovalsBelowDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.RejectCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.WithdrawCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
@@ -459,4 +460,37 @@ class ApprovalRequestResource(
     @PathVariable
     id: UUID,
   ): CertificationApprovalRequestDto = approvalRequestService.getApprovalRequest(id)
+
+  @GetMapping("/location/{id}/pending-approvals-below")
+  @PreAuthorize("hasRole('ROLE_LOCATION_CERTIFICATION')")
+  @Operation(
+    summary = "Check whether any location below the given location has a pending certification approval request",
+    description = "Used to block archiving a location while a child location has an in-flight change request. Requires role LOCATION_CERTIFICATION",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns whether a pending approval exists below the location, with the pending location and its parent",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the LOCATION_CERTIFICATION role.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Location not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getPendingApprovalsBelow(
+    @Parameter(description = "Location ID being archived", example = "2475f250-434a-4257-afe7-b911f1773a4d", required = true)
+    @PathVariable
+    id: UUID,
+  ): PendingApprovalsBelowDto = approvalRequestService.getPendingApprovalsBelow(id)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
@@ -48,4 +48,5 @@ enum class ErrorCode(val errorCode: Int) {
   CellCertificateUploadAlreadyInProgress(139),
   CellCertificateUploadNotFound(140),
   WorkingCapacityCannotBeBelowOccupancyLevel(141),
+  PendingApprovalExistsBelowLocation(142),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalRequestService.kt
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.InactiveStatus
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PendingApprovalLocationDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PendingApprovalsBelowDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.SpecialistCellType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
@@ -27,6 +29,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationCanno
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationDoesNotRequireApprovalException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PendingApprovalAlreadyExistsException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PendingApprovalBelowLocationException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.SpecialistCellTypeChangesDoNotRequireApprovalException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.ApprovalDecisionService.Companion.log
 import java.time.Clock
@@ -58,6 +61,34 @@ class ApprovalRequestService(
     }
 
     return requests.map { it.toDto() }
+  }
+
+  @Transactional(readOnly = true)
+  fun getPendingApprovalsBelow(id: UUID): PendingApprovalsBelowDto {
+    val location = residentialLocationRepository.findById(id)
+      .orElseThrow { LocationNotFoundException(id.toString()) }
+
+    val pendingLocations = location.findPendingApprovalRequestsBelowThisLevel()
+      .map { it.location }
+      .distinctBy { it.id }
+      .map { pendingLocation ->
+        val parent = pendingLocation.getParent()
+        PendingApprovalLocationDto(
+          id = pendingLocation.id!!,
+          key = pendingLocation.getKey(),
+          localName = pendingLocation.localName,
+          locationType = pendingLocation.locationType,
+          parentId = parent?.id,
+          parentKey = parent?.getKey(),
+          parentLocalName = parent?.localName,
+          parentLocationType = parent?.locationType,
+        )
+      }
+
+    return PendingApprovalsBelowDto(
+      hasPendingBelow = pendingLocations.isNotEmpty(),
+      pendingLocations = pendingLocations,
+    )
   }
 
   @Transactional(readOnly = true)
@@ -323,6 +354,10 @@ class ApprovalRequestService(
 
     if (request.reason.isBlank()) {
       throw ApprovalRequestRequiresReasonForChangeException(location.getKey())
+    }
+
+    location.findPendingApprovalRequestsBelowThisLevel().firstOrNull()?.let { pending ->
+      throw PendingApprovalBelowLocationException(location.getKey(), pending.location.getKey())
     }
 
     val linkedTransaction = sharedLocationService.createLinkedTransaction(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationTest.kt
@@ -6,6 +6,8 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationGroupDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.EXPECTED_USERNAME
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.TestBase
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.DeactivationApprovalRequest
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
@@ -111,6 +113,47 @@ class LocationTest {
     assertThat(prisonHierarchyDto.subLocations.orEmpty().size).isEqualTo(2)
     assertThat(prisonHierarchyDto.subLocations?.get(0)?.subLocations.orEmpty().size).isEqualTo(2)
   }
+
+  @Test
+  fun `findPendingApprovalRequestsBelowThisLevel returns pending requests on descendants and ignores non-pending`() {
+    val wing = generateWingLocation("Wing A")
+    val landing = generateLandingLocation("Landing 1")
+    wing.addChildLocation(landing)
+    val pendingCell = generateCellLocation()
+    landing.addChildLocation(pendingCell)
+    val approvedCell = generateCellLocation()
+    landing.addChildLocation(approvedCell)
+
+    pendingCell.approvalRequests.add(deactivationApprovalRequest(pendingCell))
+    approvedCell.approvalRequests.add(
+      deactivationApprovalRequest(approvedCell).also { it.status = ApprovalRequestStatus.APPROVED },
+    )
+
+    val pending = wing.findPendingApprovalRequestsBelowThisLevel()
+    assertThat(pending).hasSize(1)
+    assertThat(pending.first().location).isEqualTo(pendingCell)
+  }
+
+  @Test
+  fun `findPendingApprovalRequestsBelowThisLevel only looks below the location, not at the location itself`() {
+    val wing = generateWingLocation("Wing A")
+    val cell = generateCellLocation()
+    wing.addChildLocation(cell)
+    cell.approvalRequests.add(deactivationApprovalRequest(cell))
+
+    // the cell has the pending request, so nothing is pending *below* it
+    assertThat(cell.findPendingApprovalRequestsBelowThisLevel()).isEmpty()
+    // but it is pending below the wing
+    assertThat(wing.findPendingApprovalRequestsBelowThisLevel()).hasSize(1)
+  }
+
+  private fun deactivationApprovalRequest(location: ResidentialLocation) = DeactivationApprovalRequest(
+    location = location,
+    requestedBy = "user",
+    requestedDate = LocalDateTime.now(clock),
+    workingCapacityChange = -1,
+    deactivatedReason = DeactivatedReason.DAMAGED,
+  )
 }
 
 fun generateWingLocation(localName: String?) = ResidentialLocation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CertificationApprovalResourceTest.kt
@@ -1377,6 +1377,96 @@ class CertificationApprovalResourceTest : CommonDataTestBase() {
       assertThat(cell.inactiveStatus).isEqualTo(InactiveStatus.INACTIVE_TEMP)
       assertThat(cell.pendingApprovalRequestId).isNull()
     }
+
+    @Test
+    fun `cannot request permanent deactivation when a location below has a pending approval`() {
+      val firstCell = leedsWing.findAllLeafLocations().first() as Cell
+      // The whole wing is temporarily inactive so it is eligible to archive
+      deactivateLocation(leedsWing, DeactivatedReason.DAMAGED)
+      // ...but a cell below it has an in-flight pending change request
+      deactivateLocation(
+        firstCell,
+        DeactivatedReason.MOTHBALLED,
+        requiresApproval = true,
+        reasonForChange = "Cell flooded",
+      )
+
+      webTestClient.put().uri("/certification/location/permanent-deactivation-request-approval")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(PermanentDeactivationApprovalRequestDto(locationId = leedsWing.id!!, reason = "Wing demolished")))
+        .exchange()
+        .expectStatus().isEqualTo(409)
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.PendingApprovalExistsBelowLocation.errorCode)
+
+      // no permanent deactivation approval request was created - only the child's pending deactivation remains
+      webTestClient.get().uri("/certification/request-approvals/prison/${leedsWing.prisonId}")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$[?(@.approvalType == 'PERMANENT_DEACTIVATION')]").doesNotExist()
+    }
+  }
+
+  @DisplayName("GET /certification/location/{id}/pending-approvals-below")
+  @Nested
+  inner class PendingApprovalsBelowTest {
+
+    @DisplayName("is secured")
+    @Nested
+    inner class Security {
+      @org.junit.jupiter.api.TestFactory
+      fun endpointRequiresAuthorisation() = endpointRequiresAuthorisation(
+        webTestClient.get().uri("/certification/location/${UUID.randomUUID()}/pending-approvals-below"),
+        "ROLE_LOCATION_CERTIFICATION",
+      )
+    }
+
+    @Test
+    fun `returns 404 when the location is not found`() {
+      webTestClient.get().uri("/certification/location/${UUID.randomUUID()}/pending-approvals-below")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isNotFound
+    }
+
+    @Test
+    fun `returns no pending approvals when nothing below is pending`() {
+      webTestClient.get().uri("/certification/location/${leedsWing.id}/pending-approvals-below")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.hasPendingBelow").isEqualTo(false)
+        .jsonPath("$.pendingLocations").isEmpty
+    }
+
+    @Test
+    fun `returns the pending location and its parent when a location below is pending`() {
+      val firstCell = leedsWing.findAllLeafLocations().first() as Cell
+      val parent = firstCell.getParent()!!
+      deactivateLocation(
+        firstCell,
+        DeactivatedReason.MOTHBALLED,
+        requiresApproval = true,
+        reasonForChange = "Cell flooded",
+      )
+
+      webTestClient.get().uri("/certification/location/${leedsWing.id}/pending-approvals-below")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.hasPendingBelow").isEqualTo(true)
+        .jsonPath("$.pendingLocations.length()").isEqualTo(1)
+        .jsonPath("$.pendingLocations[0].id").isEqualTo(firstCell.id.toString())
+        .jsonPath("$.pendingLocations[0].key").isEqualTo(firstCell.getKey())
+        .jsonPath("$.pendingLocations[0].locationType").isEqualTo("CELL")
+        .jsonPath("$.pendingLocations[0].parentId").isEqualTo(parent.id.toString())
+        .jsonPath("$.pendingLocations[0].parentKey").isEqualTo(parent.getKey())
+    }
   }
 
   @DisplayName("PUT /locations/{id}/reactivate")


### PR DESCRIPTION
## Summary

Stops a certificate administrator from archiving (permanently deactivating) a location while one of its descendants has an in-flight (PENDING) certificate change request, which would otherwise produce conflicting requests and data errors. Applies only to prisons where certification approval is enabled.

## Changes

- **Reusable descendant-pending check** — `ResidentialLocation.findPendingApprovalRequestsBelowThisLevel()` recursively returns every PENDING approval request attached to a descendant location. Each result exposes its own location and that location's parent. Intended to be reusable for other "change above the level where something is pending" flows.
- **Server-side block** — `requestPermanentDeactivationApproval` now throws `PendingApprovalBelowLocationException` when a descendant has a pending request, so no approval request is created.
- **Error plumbing** — new exception mapped to **409 CONFLICT** with new `ErrorCode.PendingApprovalExistsBelowLocation` (142).
- **Pre-check endpoint** — `GET /certification/location/{id}/pending-approvals-below` (role `ROLE_LOCATION_CERTIFICATION`) returns `hasPendingBelow` plus each pending location's id/key/localName/locationType and its parent's, so the front end can render the blocker page (e.g. cell `LEI-B-1-001` pending, reported on parent `Landing B-1`).

## Testing

- Unit tests for the helper (returns pending descendants, ignores APPROVED, only looks below the location).
- Integration tests: 409 block on archive (and assertion that no permanent-deactivation request is created), plus the GET endpoint (security, 404, empty, and the pending + parent happy path).
- `./gradlew ktlintCheck test` — all 883 tests pass.