### PR TITLE
MAPA-90: Change 'Archived' to 'Archive location' for PERMANENT_DEACTIVATION cert request type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequest.kt
@@ -174,7 +174,7 @@ enum class ApprovalType(
   SIGNED_OP_CAP("Change signed operational capacity"),
   DRAFT("Add new locations to certificate", true),
   DEACTIVATION("Deactivation"),
-  PERMANENT_DEACTIVATION("Archived"),
+  PERMANENT_DEACTIVATION("Archive location"),
   CELL_MARK("Change cell door number", true),
   CELL_SANITATION("Change cell sanitation", true),
   REACTIVATION("Activation"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationConstantsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationConstantsIntTest.kt
@@ -375,7 +375,7 @@ class LocationConstantsIntTest : SqsIntegrationTestBase() {
                   },
                   {
                     "key": "PERMANENT_DEACTIVATION",
-                    "description": "Archived"
+                    "description": "Archive location"
                   },
                   {
                     "key": "CELL_MARK",


### PR DESCRIPTION
Change 'Archived' to 'Archive location' for PERMANENT_DEACTIVATION cert request type.

[MAPA-90](https://dsdmoj.atlassian.net/browse/MAPA-90)

[MAPA-90]: https://dsdmoj.atlassian.net/browse/MAPA-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ