### PR TITLE
MAPA-188 Add endpoint to un-archive (restore) a permanently deactivated location

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -808,6 +808,27 @@ data class PermanentDeactivationLocationRequest(
   val reason: String,
 )
 
+/**
+ * Request format for un-archiving (restoring) a permanently deactivated location. The location is restored to a
+ * temporarily inactive state; it is not made available for use.
+ */
+@Schema(description = "Request to un-archive (restore) a permanently deactivated location back to a temporarily inactive state")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class UnArchiveLocationRequest(
+  @param:Schema(description = "Reason the restored location will be temporarily inactive for", example = "MOTHBALLED", required = true)
+  val deactivationReason: DeactivatedReason,
+  @param:Schema(
+    description = "Additional information on the deactivation, for OTHER DeactivatedReason must be provided",
+    example = "Archived in error",
+    required = false,
+  )
+  @field:Size(max = 255, message = "Other deactivation reason cannot be more than 255 characters")
+  val deactivationReasonDescription: String? = null,
+  @param:Schema(description = "Explanation of why the location is being un-archived, recorded for audit", example = "Wing was archived in error", required = false)
+  @field:Size(max = 200, message = "Reason for un-archiving cannot be more than 200 characters")
+  val reason: String? = null,
+)
+
 fun String.capitalizeWords(delimiter: String = " ") = split(delimiter).joinToString(delimiter) { word ->
 
   val smallCaseWord = word.lowercase()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Cell.kt
@@ -405,6 +405,35 @@ class Cell(
     this.whenUpdated = LocalDateTime.now(clock)
   }
 
+  /**
+   * Reverses the effect of an archive on a single cell (see [Location.unarchive]): restores the pre-archive
+   * max / working / certified capacity - sourced from the cell's own [LocationHistory] (archive zeroed each, capturing
+   * the prior value as the history entry's old value) - and re-certifies the cell. No-ops the capacity restore if the
+   * cell has no usable capacity history.
+   */
+  fun restoreCapacityAndCertifyAfterUnarchive(userOrSystemInContext: String, amendedDate: LocalDateTime, linkedTransaction: LinkedTransaction) {
+    val preArchiveMaxCapacity = latestCapacityHistoryValue(LocationAttribute.MAX_CAPACITY)
+    if (preArchiveMaxCapacity != null && preArchiveMaxCapacity > 0) {
+      setCapacity(
+        maxCapacity = preArchiveMaxCapacity,
+        workingCapacity = latestCapacityHistoryValue(LocationAttribute.WORKING_CAPACITY) ?: 0,
+        certifiedNormalAccommodation = latestCapacityHistoryValue(LocationAttribute.CERTIFIED_CAPACITY) ?: 0,
+        userOrSystemInContext = userOrSystemInContext,
+        amendedDate = amendedDate,
+        linkedTransaction = linkedTransaction,
+      )
+    }
+    certifyCell(userOrSystemInContext, amendedDate, linkedTransaction)
+  }
+
+  // The most recent history entry's old value for a capacity attribute - i.e. the value it held immediately before the
+  // archive zeroed it. Nothing changes a cell's capacity after it is archived, so the latest entry is the archive.
+  private fun latestCapacityHistoryValue(attribute: LocationAttribute): Int? = getHistoryAsList()
+    .filter { it.attributeName == attribute }
+    .maxByOrNull { it.amendedDate }
+    ?.oldValue
+    ?.toIntOrNull()
+
   fun setCellDoorMark(newCellMark: String, amendedBy: String, amendedDate: LocalDateTime, linkedTransaction: LinkedTransaction) {
     addHistory(
       LocationAttribute.CELL_MARK,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/Location.kt
@@ -988,6 +988,70 @@ abstract class Location(
     }
   }
 
+  /**
+   * Reverses [permanentlyDeactivate] (an archive), restoring the location to a temporarily inactive
+   * ([LocationStatus.INACTIVE]) state - visible again but not available for use until separately reactivated.
+   * For residential locations the pre-archive capacity and certification of each cell (which archiving zeroed and
+   * de-certified) are restored from the cell's [LocationHistory]. Returns false if the location is not archived.
+   */
+  open fun unarchive(
+    deactivatedReason: DeactivatedReason,
+    deactivationReasonDescription: String? = null,
+    userOrSystemInContext: String,
+    clock: Clock,
+    linkedTransaction: LinkedTransaction,
+  ): Boolean {
+    if (!isArchived()) {
+      log.warn("Location [${getKey()}] is not archived")
+      return false
+    }
+    val amendedDate = LocalDateTime.now(clock)
+    addHistory(
+      LocationAttribute.STATUS,
+      LocationStatus.ARCHIVED.description,
+      LocationStatus.INACTIVE.description,
+      userOrSystemInContext,
+      amendedDate,
+      linkedTransaction,
+    )
+    addHistory(
+      LocationAttribute.PERMANENT_DEACTIVATION,
+      archivedReason,
+      null,
+      userOrSystemInContext,
+      amendedDate,
+      linkedTransaction,
+    )
+    addHistory(
+      LocationAttribute.DEACTIVATION_REASON,
+      null,
+      listOfNotBlank(deactivatedReason.description, deactivationReasonDescription).joinToString(" - "),
+      userOrSystemInContext,
+      amendedDate,
+      linkedTransaction,
+    )
+
+    this.status = LocationStatus.INACTIVE
+    this.archivedReason = null
+    this.deactivatedReason = deactivatedReason
+    this.deactivationReasonDescription = deactivationReasonDescription
+    this.deactivatedDate = amendedDate
+    this.deactivatedBy = userOrSystemInContext
+    this.updatedBy = userOrSystemInContext
+    this.whenUpdated = amendedDate
+
+    // Now that this location is no longer archived its descendant cells are temporarily deactivated again, so restore
+    // the capacity + certification that archiving stripped from them (converted cells were left untouched by archive).
+    if (this is ResidentialLocation) {
+      findAllLeafLocations().filterIsInstance<Cell>()
+        .filter { !it.isConvertedCell() }
+        .forEach { cell -> cell.restoreCapacityAndCertifyAfterUnarchive(userOrSystemInContext, amendedDate, linkedTransaction) }
+    }
+
+    log.info("Un-archived Location [${getKey()}]")
+    return true
+  }
+
   open fun reactivate(
     userOrSystemInContext: String,
     clock: Clock,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.De
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.DraftChangeApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.LocationCertificationApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.PermanentDeactivationApprovalRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.UnArchiveApprovalRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ApprovalRequiredAboveThisLevelException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CapacityException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ErrorCode
@@ -280,6 +281,25 @@ open class ResidentialLocation(
         workingCapacityChange = workingCapacityChange,
       ),
     ) as PermanentDeactivationApprovalRequest
+  }
+
+  fun requestApprovalForUnArchive(
+    requestedDate: LocalDateTime,
+    requestedBy: String,
+    reasonForChange: String? = null,
+  ): UnArchiveApprovalRequest {
+    if (hasPendingCertificationApproval()) {
+      throw PendingApprovalAlreadyExistsException(getKey())
+    }
+
+    return addApprovalToLocation(
+      UnArchiveApprovalRequest(
+        location = this,
+        requestedBy = requestedBy,
+        requestedDate = requestedDate,
+        reasonForChange = reasonForChange,
+      ),
+    ) as UnArchiveApprovalRequest
   }
 
   open fun processApproval(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/CertificationApprovalRequest.kt
@@ -175,6 +175,7 @@ enum class ApprovalType(
   DRAFT("Add new locations to certificate", true),
   DEACTIVATION("Deactivation"),
   PERMANENT_DEACTIVATION("Archive location"),
+  UN_ARCHIVE("Restore archived location"),
   CELL_MARK("Change cell door number", true),
   CELL_SANITATION("Change cell sanitation", true),
   REACTIVATION("Activation"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/UnArchiveApprovalRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/approvalrequest/UnArchiveApprovalRequest.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest
+
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Audit record of a location being un-archived (restored from an archive to temporarily inactive). The un-archive
+ * itself requires no human decision, but for prisons where certification approval is active the restore is recorded
+ * as an auto-approved request so the regenerated cell certificate has a corresponding approval trail
+ * (see ApprovalDecisionService.unarchiveWithApproval).
+ */
+@Entity
+@DiscriminatorValue("UN_ARCHIVE")
+open class UnArchiveApprovalRequest(
+  id: UUID? = null,
+  location: ResidentialLocation,
+  requestedBy: String,
+  requestedDate: LocalDateTime,
+  reasonForChange: String? = null,
+) : LocationCertificationApprovalRequest(
+  id = id,
+  location = location,
+  locationKey = location.getKey(),
+  requestedBy = requestedBy,
+  requestedDate = requestedDate,
+  reasonForChange = reasonForChange,
+) {
+  override fun getApprovalType() = ApprovalType.UN_ARCHIVE
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
@@ -415,6 +415,21 @@ class ApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(LocationCannotBeUnarchivedException::class)
+  fun handleLocationCannotBeUnarchived(e: LocationCannotBeUnarchivedException): ResponseEntity<ErrorResponse> {
+    log.debug("Location cannot be un-archived: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          errorCode = ErrorCode.LocationCannotBeUnarchived,
+          userMessage = "Location cannot be un-archived as it is not archived: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
   @ExceptionHandler(ReasonForDeactivationMustBeProvidedException::class)
   fun handleReasonForDeactivationMustBeProvided(e: ReasonForDeactivationMustBeProvidedException): ResponseEntity<ErrorResponse> {
     log.debug("De-activating location requires a reason when using OTHER reason type: {}", e.message)
@@ -757,6 +772,7 @@ class SignedOperationCapacityNotFoundException(prisonId: String) : Exception("Th
 class LocationAlreadyExistsException(key: String) : Exception("Location already exists = $key")
 class ReasonForDeactivationMustBeProvidedException(key: String) : Exception("De-activating location $key requires a reason when using OTHER reason type")
 class LocationCannotBeReactivatedException(key: String) : Exception("Location cannot be reactivated if parent is deactivated = $key")
+class LocationCannotBeUnarchivedException(key: String) : Exception("Location is not archived so cannot be un-archived = $key")
 class AlreadyDeactivatedLocationException(key: String) : ValidationException("$key: Cannot deactivate an already deactivated location")
 class CapacityException(val key: String, override val message: String, val errorCode: ErrorCode) : ValidationException("$key: [Error Code: $errorCode] - Capacity Exception: $message")
 class PermanentlyDeactivatedUpdateNotAllowedException(key: String) : ValidationException("Location $key cannot be updated as has been permanently deactivated")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
@@ -49,4 +49,5 @@ enum class ErrorCode(val errorCode: Int) {
   CellCertificateUploadNotFound(140),
   WorkingCapacityCannotBeBelowOccupancyLevel(141),
   PendingApprovalExistsBelowLocation(142),
+  LocationCannotBeUnarchived(143),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationResource.kt
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LegacyLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PermanentDeactivationLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.TemporaryDeactivationLocationRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.UnArchiveLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.UpdateLocationLocalNameRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.InternalLocationDomainEventType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationService
@@ -419,6 +420,53 @@ class LocationResource(
       id,
       reasonForPermanentDeactivation = permanentDeactivationLocationRequest.reason,
     )
+  }
+
+  @PutMapping("/{id}/unarchive")
+  @PreAuthorize("hasRole('ROLE_UNARCHIVE_LOCATIONS') and hasAuthority('SCOPE_write')")
+  @Operation(
+    summary = "Un-archive (restore) a permanently deactivated location",
+    description = "Restores an archived location back to a temporarily inactive state - visible again but not " +
+      "available for use. Where certification is active for the prison the cell certificate is regenerated via an " +
+      "auto-approved approval step. Requires role UNARCHIVE_LOCATIONS and write scope.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns the restored, temporarily inactive location",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid Request, e.g. the location is not archived",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the UNARCHIVE_LOCATIONS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Location not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun unarchiveLocation(
+    @Schema(description = "The location Id", example = "de91dfa7-821f-4552-a427-bf2f32eafeb0", required = true)
+    @PathVariable
+    id: UUID,
+    @RequestBody
+    @Validated
+    unArchiveLocationRequest: UnArchiveLocationRequest,
+  ): LocationDTO = eventPublishAndAudit(
+    InternalLocationDomainEventType.LOCATION_REACTIVATED,
+  ) {
+    locationService.unarchiveLocation(id, unArchiveLocationRequest)
   }
 
   @PutMapping("/{id}/reactivate")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalDecisionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/ApprovalDecisionService.kt
@@ -10,10 +10,12 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ApproveCertificati
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Capacity
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.RejectCertificationRequestDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.UnArchiveLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.WithdrawCertificationRequestDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CapacityChangeApprovalRequest
@@ -439,6 +441,42 @@ class ApprovalDecisionService(
       newLocation = newLocation,
       prisonId = approvalRequest.prisonId,
     ).also { linkedTransaction.txEndTime = LocalDateTime.now(clock) }
+  }
+
+  /**
+   * Un-archives (restores) a residential location in a prison where certification approval is active. The restore
+   * needs no human decision, but for audit it is recorded as an auto-approved [UnArchiveApprovalRequest] and the cell
+   * certificate is regenerated (via [approveCertificationRequest]) so it once again shows the now-inactive location.
+   * The location must already be moved out of ARCHIVED before the certificate is generated, since
+   * [CellCertificateService.createCellCertificate] excludes permanently deactivated locations.
+   */
+  @Transactional
+  fun unarchiveWithApproval(location: ResidentialLocation, request: UnArchiveLocationRequest) {
+    val username = sharedLocationService.getUsername()
+    val linkedTransaction = sharedLocationService.createLinkedTransaction(
+      type = TransactionType.REQUEST_CERTIFICATION_APPROVAL,
+      prisonId = location.prisonId,
+      detail = "Auto-approved un-archive of location ${location.getKey()}",
+    )
+
+    location.unarchive(
+      deactivatedReason = request.deactivationReason,
+      deactivationReasonDescription = request.deactivationReasonDescription,
+      userOrSystemInContext = username,
+      clock = clock,
+      linkedTransaction = linkedTransaction,
+    )
+
+    val approvalRequest = certificationApprovalRequestRepository.save(
+      location.requestApprovalForUnArchive(
+        requestedBy = username,
+        requestedDate = linkedTransaction.txStartTime,
+        reasonForChange = request.reason,
+      ),
+    )
+
+    approveCertificationRequest(ApproveCertificationRequestDto(approvalRequest.id!!))
+      .also { linkedTransaction.txEndTime = LocalDateTime.now(clock) }
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -1227,6 +1227,10 @@ class LocationService(
       throw LocationCannotBeUnarchivedException(location.getKey())
     }
 
+    if (request.deactivationReason == DeactivatedReason.OTHER && request.deactivationReasonDescription.isNullOrBlank()) {
+      throw ReasonForDeactivationMustBeProvidedException(location.getKey())
+    }
+
     if (location is ResidentialLocation && activePrisonService.isCertificationApprovalRequired(location.prisonId)) {
       approvalDecisionService.unarchiveWithApproval(location, request)
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PatchResidentialLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PrisonHierarchyDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ResidentialStructuralType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.UnArchiveLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.UpdateLocationLocalNameRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.addCellToParent
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.AccommodationType
@@ -71,6 +72,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationAlrea
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationCannotBeCreatedWithPendingApprovalException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationCannotBeDeletedWhenNotDraftException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationCannotBeReactivatedException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationCannotBeUnarchivedException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationContainsPrisonersException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationPrefixNotFoundException
@@ -110,6 +112,7 @@ class LocationService(
   private val locationGroupFromPropertiesService: LocationGroupFromPropertiesService,
   private val activePrisonService: ActivePrisonService,
   private val cellCertificateService: CellCertificateService,
+  private val approvalDecisionService: ApprovalDecisionService,
   @param:Qualifier("residentialGroups") private val groupsProperties: Properties,
 ) {
   companion object {
@@ -1206,6 +1209,44 @@ class LocationService(
     return locationToUpdate.toDto().also {
       linkedTransaction.txEndTime = now(clock)
     }
+  }
+
+  /**
+   * Un-archives (restores) a permanently deactivated location back to a temporarily inactive state - visible again but
+   * not available for use. Where certification approval is active for the prison the restore is routed through an
+   * auto-approved approval request that also regenerates the cell certificate (see
+   * [ApprovalDecisionService.unarchiveWithApproval]); otherwise the location is restored directly. The location itself
+   * must be archived (not merely a descendant of an archived location).
+   */
+  @Transactional
+  fun unarchiveLocation(id: UUID, request: UnArchiveLocationRequest): LocationDTO {
+    val location = locationRepository.findById(id)
+      .orElseThrow { LocationNotFoundException(id.toString()) }
+
+    if (!location.isArchived()) {
+      throw LocationCannotBeUnarchivedException(location.getKey())
+    }
+
+    if (location is ResidentialLocation && activePrisonService.isCertificationApprovalRequired(location.prisonId)) {
+      approvalDecisionService.unarchiveWithApproval(location, request)
+    } else {
+      val linkedTransaction = sharedLocationService.createLinkedTransaction(
+        prisonId = location.prisonId,
+        type = TransactionType.REACTIVATION,
+        detail = "Un-archiving location ${location.getKey()}",
+      )
+      location.unarchive(
+        deactivatedReason = request.deactivationReason,
+        deactivationReasonDescription = request.deactivationReasonDescription,
+        userOrSystemInContext = sharedLocationService.getUsername(),
+        clock = clock,
+        linkedTransaction = linkedTransaction,
+      )
+      sharedLocationService.trackLocationUpdate(location, "Un-archived location")
+      linkedTransaction.txEndTime = now(clock)
+    }
+
+    return location.toDto(includeChildren = true, includeParent = true)
   }
 
   @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationConstantsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationConstantsIntTest.kt
@@ -378,6 +378,10 @@ class LocationConstantsIntTest : SqsIntegrationTestBase() {
                     "description": "Archive location"
                   },
                   {
+                    "key": "UN_ARCHIVE",
+                    "description": "Restore archived location"
+                  },
+                  {
                     "key": "CELL_MARK",
                     "description": "Change cell door number"
                   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/UnarchiveLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/UnarchiveLocationResourceTest.kt
@@ -1,0 +1,220 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.json.JsonCompareMode
+import org.springframework.test.web.reactive.server.expectBody
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.ApproveCertificationRequestDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CertificationApprovalRequestDto
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PermanentDeactivationLocationRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.TemporaryDeactivationLocationRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.UnArchiveLocationRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
+import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.EXPECTED_USERNAME
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ResidentialLocation
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.PermanentDeactivationApprovalRequestDto
+import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
+
+@WithMockAuthUser(username = EXPECTED_USERNAME)
+@DisplayName("PUT /locations/{id}/unarchive")
+class UnarchiveLocationResourceTest : CommonDataTestBase() {
+
+  @Nested
+  inner class Security {
+    @Test
+    fun `access forbidden when no authority`() {
+      webTestClient.put().uri("/locations/${cell1.id}/unarchive")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `access forbidden when no role`() {
+      webTestClient.put().uri("/locations/${cell1.id}/unarchive")
+        .headers(setAuthorisation(roles = listOf()))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(UnArchiveLocationRequest(deactivationReason = DeactivatedReason.MOTHBALLED)))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `access forbidden with wrong role`() {
+      webTestClient.put().uri("/locations/${cell1.id}/unarchive")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(UnArchiveLocationRequest(deactivationReason = DeactivatedReason.MOTHBALLED)))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `access forbidden with right role, wrong scope`() {
+      webTestClient.put().uri("/locations/${cell1.id}/unarchive")
+        .headers(setAuthorisation(roles = listOf("ROLE_UNARCHIVE_LOCATIONS"), scopes = listOf("read")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(UnArchiveLocationRequest(deactivationReason = DeactivatedReason.MOTHBALLED)))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+  }
+
+  @Nested
+  inner class Validation {
+    @Test
+    fun `cannot un-archive a location that is not archived`() {
+      webTestClient.put().uri("/locations/${cell1.id}/unarchive")
+        .headers(setAuthorisation(roles = listOf("ROLE_UNARCHIVE_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(UnArchiveLocationRequest(deactivationReason = DeactivatedReason.MOTHBALLED)))
+        .exchange()
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(ErrorCode.LocationCannotBeUnarchived.errorCode)
+    }
+  }
+
+  @Nested
+  inner class HappyPath {
+    @Test
+    fun `un-archives a location in a prison without certification approval, restoring it to temporarily inactive`() {
+      prisonerSearchMockServer.stubSearchByLocations(wingZ.prisonId, listOf(cell1.getPathHierarchy()), false)
+
+      // archive cell1 - MDI does not require certification approval
+      webTestClient.put().uri("/locations/${cell1.id}/deactivate/permanent")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(PermanentDeactivationLocationRequest(reason = "Archived in error")))
+        .exchange()
+        .expectStatus().isOk
+
+      purgeDomainEvents()
+
+      webTestClient.put().uri("/locations/${cell1.id}/unarchive")
+        .headers(setAuthorisation(roles = listOf("ROLE_UNARCHIVE_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(UnArchiveLocationRequest(deactivationReason = DeactivatedReason.MOTHBALLED, reason = "Archived in error")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          // language=json
+          """
+          {
+            "key": "${cell1.getKey()}",
+            "active": false,
+            "permanentlyInactive": false,
+            "deactivatedReason": "MOTHBALLED",
+            "certifiedCell": true,
+            "capacity": {
+              "maxCapacity": 2,
+              "certifiedNormalAccommodation": 2
+            }
+          }
+          """,
+          JsonCompareMode.LENIENT,
+        )
+
+      getDomainEvents(3).let {
+        assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
+          "location.inside.prison.amended" to "MDI-Z-1",
+          "location.inside.prison.amended" to "MDI-Z",
+          "location.inside.prison.reactivated" to cell1.getKey(),
+        )
+      }
+    }
+
+    @Test
+    fun `un-archives a location in a prison with certification approval, regenerating the certificate via an auto-approved request`() {
+      val cell = leedsWing.findAllLeafLocations().first() as Cell
+
+      archiveViaApproval(cell)
+
+      // the archived cell has been removed from the current certificate
+      assertCurrentCertificateContainsCell(cell, expected = false)
+
+      purgeDomainEvents()
+
+      webTestClient.put().uri("/locations/${cell.id}/unarchive")
+        .headers(setAuthorisation(roles = listOf("ROLE_UNARCHIVE_LOCATIONS"), scopes = listOf("write")))
+        .header("Content-Type", "application/json")
+        .bodyValue(jsonString(UnArchiveLocationRequest(deactivationReason = DeactivatedReason.MOTHBALLED, reason = "Archived in error")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          // language=json
+          """
+          {
+            "key": "${cell.getKey()}",
+            "active": false,
+            "permanentlyInactive": false,
+            "deactivatedReason": "MOTHBALLED",
+            "certifiedCell": true,
+            "capacity": {
+              "maxCapacity": 2,
+              "certifiedNormalAccommodation": 1
+            }
+          }
+          """,
+          JsonCompareMode.LENIENT,
+        )
+
+      // the certificate was regenerated and now shows the restored (inactive) cell again
+      assertCurrentCertificateContainsCell(cell, expected = true)
+
+      // the restore was recorded as an auto-approved un-archive request for audit
+      val unArchiveRequests = certificationApprovalRequestRepository.findAll()
+        .filter { it.getApprovalType() == ApprovalType.UN_ARCHIVE }
+      assertThat(unArchiveRequests).hasSize(1)
+      assertThat(unArchiveRequests.first().status).isEqualTo(ApprovalRequestStatus.APPROVED)
+      assertThat(unArchiveRequests.first().prisonId).isEqualTo(leedsWing.prisonId)
+    }
+  }
+
+  private fun archiveViaApproval(cell: Cell) {
+    // the cell must be temporarily deactivated before permanent deactivation approval can be requested
+    prisonerSearchMockServer.stubSearchByLocations(cell.prisonId, listOf(cell.getPathHierarchy()), false)
+    webTestClient.put().uri("/locations/${cell.id}/deactivate/temporary")
+      .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+      .header("Content-Type", "application/json")
+      .bodyValue(jsonString(TemporaryDeactivationLocationRequest(deactivationReason = DeactivatedReason.DAMAGED)))
+      .exchange()
+      .expectStatus().isOk
+
+    val pendingApproval = webTestClient.put().uri("/certification/location/permanent-deactivation-request-approval")
+      .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+      .header("Content-Type", "application/json")
+      .bodyValue(jsonString(PermanentDeactivationApprovalRequestDto(locationId = cell.id!!, reason = "Cell demolished")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<CertificationApprovalRequestDto>()
+      .returnResult().responseBody!!
+
+    webTestClient.put().uri("/certification/location/approve")
+      .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+      .header("Content-Type", "application/json")
+      .bodyValue(jsonString(ApproveCertificationRequestDto(approvalRequestReference = pendingApproval.id)))
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  private fun assertCurrentCertificateContainsCell(cell: ResidentialLocation, expected: Boolean) {
+    webTestClient.get().uri("/cell-certificates/prison/${cell.prisonId}/current")
+      .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$..pathHierarchy").value<List<String>> { paths ->
+        if (expected) {
+          assertThat(paths).contains(cell.getPathHierarchy())
+        } else {
+          assertThat(paths).doesNotContain(cell.getPathHierarchy())
+        }
+      }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/UnarchiveLocationResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/UnarchiveLocationResourceTest.kt
@@ -28,7 +28,7 @@ class UnarchiveLocationResourceTest : CommonDataTestBase() {
   @Nested
   inner class Security {
     @Test
-    fun `access forbidden when no authority`() {
+    fun `access unauthorized when no authority`() {
       webTestClient.put().uri("/locations/${cell1.id}/unarchive")
         .exchange()
         .expectStatus().isUnauthorized

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationServiceTest.kt
@@ -59,6 +59,7 @@ class LocationServiceTest {
   private val locationGroupFromPropertiesService: LocationGroupFromPropertiesService = mock()
   private val activePrisonService: ActivePrisonService = mock()
   private val cellCertificateService: CellCertificateService = mock()
+  private val approvalDecisionService: ApprovalDecisionService = mock()
   private val prisonConfigurationRepository: PrisonConfigurationRepository = mock()
   private val groupsProperties: Properties = mock()
 
@@ -78,6 +79,7 @@ class LocationServiceTest {
     locationGroupFromPropertiesService,
     activePrisonService,
     cellCertificateService,
+    approvalDecisionService,
     groupsProperties,
   )
 


### PR DESCRIPTION
## MAPA-188

Some prisons have mistakenly archived (permanently deactivated) locations and there was previously no way to reverse it — `reactivate` only acts on temporarily deactivated locations. This adds a backend API to **un-archive** a location, restoring it to a **temporarily inactive** state (visible again but not available for use until separately reactivated).

### Endpoint
`PUT /locations/{id}/unarchive` — guarded by the **new role `ROLE_UNARCHIVE_LOCATIONS`** (+ `SCOPE_write`). Body carries the `deactivationReason` the restored location will hold, an optional description, and an optional free-text reason for audit.

### Behaviour
- **Entity restore** (`Location.unarchive`): `ARCHIVED → INACTIVE`, clears the archive reason, sets the deactivation reason/date, and for residential cells restores each cell's pre-archive max/working/CNA capacity and re-certifies it. Pre-archive capacity is read from each cell's **`LocationHistory`** (the archive transaction captured the prior values), so it works uniformly whether or not the prison uses certificates.
- **No human approval needed.** For prisons where **certification is active**, the restore is recorded as an **auto-approved `UN_ARCHIVE` approval request** and the cell certificate is regenerated so it shows the restored location again (mirrors the existing `baselinePrisonCertificate` auto-approve pattern). For prisons **without** certification the location is restored directly with a `location.inside.prison.reactivated` audit event.
- A location that is not archived is rejected with `400 LocationCannotBeUnarchived`.

### Scope
Single location only (the archived location itself; a descendant of an archived location is rejected). Bulk un-archive is out of scope for now.

### Tests
Full suite green (890 tests), ktlint clean. New `UnarchiveLocationResourceTest` covers security (401/403 incl. wrong scope), the not-archived validation error, and both happy paths:
- cert-off prison — restored state, capacity restored, `reactivated` event;
- cert-on prison — restored state, a new current cell certificate containing the cell, and an auto-`APPROVED` `UN_ARCHIVE` request.

> Note: `ROLE_UNARCHIVE_LOCATIONS` must be provisioned in HMPPS Auth.