### PR TITLE
MAPA-187 Capacity management dashboard displays only active cert enabled prisons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateRepository.kt
@@ -76,7 +76,9 @@ interface CellCertificateRepository : JpaRepository<CellCertificate, UUID> {
              c.signedOperationCapacity as signedOperationCapacity,
              c.approvedDate as approvedDate
       from CellCertificate c
+      join PrisonConfiguration pc on pc.id = c.prisonId
       where c.current = true
+        and pc.certificationApprovalRequired = true
     """,
   )
   fun findCurrentCertificateSummaries(): List<CurrentCellCertificateSummary>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateResourceTest.kt
@@ -438,6 +438,28 @@ class CellCertificateResourceTest(
       }
 
       @Test
+      fun `excludes prisons that have a current certificate but certification disabled`() {
+        cacheManager.getCache(CacheConfiguration.PRISON_NAMES_CACHE_NAME)?.clear()
+        prisonRegisterMockServer.stubGetAllPrisons(
+          listOf(
+            PrisonDto(prisonId = "LEI", prisonName = "Leeds (HMP)", active = true, male = true, female = false, contracted = false, lthse = false),
+          ),
+        )
+
+        // Switch certification off for LEI even though it still has a current certificate
+        val config = configurationRepository.findById("LEI").get()
+        config.certificationApprovalRequired = false
+        configurationRepository.saveAndFlush(config)
+
+        webTestClient.get().uri("/cell-certificates/dashboard")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.length()").isEqualTo(0)
+      }
+
+      @Test
       fun `falls back to prison id when the prison name is not found`() {
         cacheManager.getCache(CacheConfiguration.PRISON_NAMES_CACHE_NAME)?.clear()
         prisonRegisterMockServer.stubGetAllPrisons(emptyList())


### PR DESCRIPTION
## Description

Updates the capacity management dashboard (`GET /cell-certificates/dashboard`) so it only lists prisons where certification is **currently enabled**.

Previously the dashboard listed every prison that had a "current" cell certificate. Because enabling certification auto-baselines a certificate, a prison that was once enabled kept its `current = true` certificate even after certification was switched off — so it lingered on the dashboard (e.g. Lewes).

## Change

- `CellCertificateRepository.findCurrentCertificateSummaries()` now joins `PrisonConfiguration` and requires `certificationApprovalRequired = true`, so only prisons with a current certificate **and** certification actively enabled are returned.

An inner join is correct: a prison can only have certification enabled if it has a `PrisonConfiguration` row, so no enabled prison is lost.

## Acceptance criteria

- [x] The dashboard displays only prisons with certification actively enabled.
- [x] Prisons where certification has been switched off are excluded.
- [x] Previously active but now disabled prisons are not shown.
- [x] Existing functionality for actively enabled prisons is unchanged.

## Testing

- Added `CellCertificateResourceTest` case asserting a prison with a current certificate but certification disabled is excluded from the dashboard.
- Existing dashboard tests still pass (enabled prisons unchanged).
- `./gradlew ktlintCheck` clean.