### PR TITLE
MAPB-643 Add property storage locations endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PropertyLocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/PropertyLocationDto.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import java.util.UUID
+
+@Schema(description = "A leaf location that can hold prisoner property, with the capacity of its PROPERTY usage")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class PropertyLocationDto(
+  @param:Schema(description = "Location Id", example = "2475f250-434a-4257-afe7-b911f1773a4d", required = true)
+  val id: UUID,
+
+  @param:Schema(description = "Prison ID", example = "MDI", required = true)
+  val prisonId: String,
+
+  @param:Schema(description = "Location Code", example = "PROP1", required = true)
+  val code: String,
+
+  @param:Schema(description = "Full path of the location within the prison", example = "PROP-1-001", required = true)
+  val pathHierarchy: String,
+
+  @param:Schema(description = "Description to display for the location", example = "Property store 1", required = false)
+  val localName: String? = null,
+
+  @param:Schema(description = "Location Type", example = "BOX", required = true)
+  val locationType: LocationType,
+
+  @param:Schema(
+    description = "Capacity of this location's PROPERTY usage - how many property containers it can hold. May be null if not configured.",
+    example = "10",
+    required = false,
+  )
+  val capacity: Int? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.NomisSyncLocationR
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.NonResidentialUsageDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PatchLocationRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PatchNonResidentialLocationRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PropertyLocationDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.formatLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.NonResidentialLocationDTO
 import java.time.Clock
@@ -70,6 +71,19 @@ class NonResidentialLocation(
 ) {
 
   fun toUsageTypes() = nonResidentialUsages.map { it.usageType }
+
+  /** Capacity of this location's PROPERTY usage (how many property containers it can hold), or null if it has no PROPERTY usage. */
+  fun getPropertyCapacity(): Int? = nonResidentialUsages.find { it.usageType == NonResidentialUsageType.PROPERTY }?.capacity
+
+  fun toPropertyLocationDto() = PropertyLocationDto(
+    id = id!!,
+    prisonId = prisonId,
+    code = getLocationCode(),
+    pathHierarchy = getPathHierarchy(),
+    localName = localName?.let { formatLocation(it) },
+    locationType = locationType,
+    capacity = getPropertyCapacity(),
+  )
 
   override fun isNonResidential() = true
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateOrUpdateNonR
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PatchNonResidentialLocationRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PropertyLocationDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ServiceFamilyType
@@ -509,6 +510,45 @@ class LocationNonResidentialResource(
     formatLocalName = formatLocalName,
     filterParents = filterParents,
   )
+
+  @GetMapping("/prison/{prisonId}/property")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")
+  @Operation(
+    summary = "Return the leaf property storage locations, with capacity, for this prison",
+    description = "Returns every location that has a PROPERTY non-residential usage (any location type), leaf-only " +
+      "so aggregate parents are not double-counted, each carrying the capacity of its PROPERTY usage. Requires role VIEW_LOCATIONS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns property locations",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid Request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the VIEW_LOCATIONS role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getPropertyLocations(
+    @Schema(description = "Prison Id", example = "MDI", required = true, minLength = 3, maxLength = 5, pattern = "^[A-Z]{2}I|ZZGHI$")
+    @Size(min = 3, message = "Prison ID must be a minimum of 3 characters")
+    @NotBlank(message = "Prison ID cannot be blank")
+    @Size(max = 5, message = "Prison ID cannot be more than 5 characters")
+    @Pattern(regexp = "^[A-Z]{2}I|ZZGHI$", message = "Prison ID must be 3 characters ending in an I or ZZGHI")
+    @PathVariable
+    prisonId: String,
+  ): List<PropertyLocationDto> = nonResidentialService.getPropertyLocations(prisonId)
 
   @GetMapping("/prison/{prisonId}/non-residential-usage-type")
   @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CreateOrUpdateNonR
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.DerivedLocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PatchNonResidentialLocationRequest
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PropertyLocationDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
@@ -142,6 +143,22 @@ class NonResidentialService(
     } else {
       filteredResults
     }
+  }
+
+  /**
+   * The leaf locations in a prison that can hold property, each with its PROPERTY-usage capacity.
+   * A location can hold property iff it has a non-residential usage of type PROPERTY (any location type).
+   * Parents are dropped when a sub-location is also a property location (leaf-only), so capacity is not
+   * double-counted; inactive locations and the RTU code are excluded.
+   */
+  fun getPropertyLocations(prisonId: String): List<PropertyLocationDto> {
+    val propertyLocations = nonResidentialLocationRepository.findAllByPrisonIdAndNonResidentialUsages(prisonId, NonResidentialUsageType.PROPERTY)
+    return propertyLocations
+      .filter { it.getLocationCode() != "RTU" }
+      .filter { it.isActiveAndAllParentsActive() }
+      .filter { it.findSubLocations().intersect(propertyLocations.toSet()).isEmpty() }
+      .map { it.toPropertyLocationDto() }
+      .sortedBy { it.localName ?: it.pathHierarchy }
   }
 
   @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PropertyLocationsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PropertyLocationsIntTest.kt
@@ -1,0 +1,97 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ServiceType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.buildNonResidentialLocation
+
+class PropertyLocationsIntTest : CommonDataTestBase() {
+
+  @Test
+  fun `requires the VIEW_LOCATIONS role`() {
+    webTestClient.get().uri("/locations/prison/MDI/property")
+      .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  fun `returns property-usage locations of any location type, with their capacity`() {
+    // A non-BOX property location, and a BOX property location with an explicit capacity.
+    val store = buildNonResidentialLocation(
+      prisonId = "MDI",
+      pathHierarchy = "PSTORE",
+      localName = "Property Store",
+      locationType = LocationType.STORE,
+      usageTypes = setOf(NonResidentialUsageType.PROPERTY),
+    )
+    store.addUsage(NonResidentialUsageType.PROPERTY, 700)
+    repository.save(store)
+
+    val box = buildNonResidentialLocation(
+      prisonId = "MDI",
+      pathHierarchy = "PBOX",
+      localName = "Property Box",
+      locationType = LocationType.BOX,
+      usageTypes = setOf(NonResidentialUsageType.PROPERTY),
+    )
+    box.addUsage(NonResidentialUsageType.PROPERTY, 1)
+    repository.save(box)
+
+    // A non-residential location WITHOUT a property usage - must be excluded.
+    repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "APPT",
+        localName = "Appointment Room",
+        locationType = LocationType.ROOM,
+        serviceTypes = setOf(ServiceType.APPOINTMENT),
+      ),
+    )
+
+    webTestClient.get().uri("/locations/prison/MDI/property")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$[?(@.localName == 'Property Store')].locationType").isEqualTo("STORE")
+      .jsonPath("$[?(@.localName == 'Property Store')].capacity").isEqualTo(700)
+      .jsonPath("$[?(@.localName == 'Property Box')].locationType").isEqualTo("BOX")
+      .jsonPath("$[?(@.localName == 'Property Box')].capacity").isEqualTo(1)
+      .jsonPath("$[?(@.localName == 'Appointment Room')]").doesNotExist()
+  }
+
+  @Test
+  fun `returns leaf property locations only - a property parent whose child is also property is dropped`() {
+    val parent = repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "PARENT",
+        localName = "Parent Property",
+        locationType = LocationType.AREA,
+        usageTypes = setOf(NonResidentialUsageType.PROPERTY),
+      ),
+    )
+    val child = repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "PARENT-CHILD",
+        localName = "Child Property",
+        locationType = LocationType.BOX,
+        usageTypes = setOf(NonResidentialUsageType.PROPERTY),
+      ),
+    )
+    parent.addChildLocation(child)
+    repository.save(parent)
+
+    webTestClient.get().uri("/locations/prison/MDI/property")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$[?(@.localName == 'Parent Property')]").doesNotExist()
+      .jsonPath("$[?(@.localName == 'Child Property')]").exists()
+  }
+}


### PR DESCRIPTION
## What
Adds `GET /locations/prison/{prisonId}/property` — the leaf locations that can hold prisoner property, each with the capacity of its PROPERTY non-residential usage.

## Why
The downstream property service previously treated storage locations as only `BOX`-typed locations, one container each. That is wrong: a location can hold property if it has a **PROPERTY** non-residential usage (any location type — BOX, AREA, STORE, ROOM, SHELF, …), and that usage carries a **capacity**. This endpoint surfaces the correct set + capacity so the property service and UI can become capacity-aware.

## Details
- Reuses the existing `findAllByPrisonIdAndNonResidentialUsages(prisonId, PROPERTY)` query.
- **Leaf-only**: a parent is dropped when a sub-location is also a property location, so capacity is not double-counted (same parent-filtering the existing usage endpoint uses, but intersected against the property set).
- Excludes inactive locations and the `RTU` code.
- Slim `PropertyLocationDto { id, prisonId, code, pathHierarchy, localName, locationType, capacity }`.
- Guarded by `ROLE_VIEW_LOCATIONS` (the role the property service already holds).

## Testing
New `PropertyLocationsIntTest` (returns non-BOX property locations with capacity; excludes non-property locations; leaf-only), OpenAPI docs test and ktlint all green.

## Rollout
This is the first of three PRs for MAPB-643. **Deploy this before** the property-api change (hmpps-prisoner-property-api) which calls this endpoint.