### PR TITLE
MAPB-651 Add location hierarchy to non-residential location DTO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -125,6 +125,7 @@ class NonResidentialLocation(
       isLeafLevel = isLeafLevel(),
       prisonId = prisonId,
       parentId = getParent()?.id,
+      locationHierarchy = getHierarchy().map { it.copy(localName = it.localName?.let(::formatLocation)) },
       level = getLevel(),
       permanentlyInactive = isPermanentlyDeactivated(),
       deactivatedDate = deactivatedLocation?.deactivatedDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationAttribute
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationSummary
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocationType
@@ -542,6 +543,9 @@ data class NonResidentialLocationDTO(
 
   @param:Schema(description = "Parent Location Id", example = "57718979-573c-433a-9e51-2d83f887c11c", required = false)
   val parentId: UUID?,
+
+  @param:Schema(description = "Location hierarchy (ancestors and self), top to bottom", required = false)
+  val locationHierarchy: List<LocationSummary>? = null,
 ) {
   @Schema(description = "Key for a location", example = "MDI-ADJU", required = true)
   fun getKey(): String = "$prisonId-$pathHierarchy"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
@@ -1694,7 +1694,11 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
                         "HEARING_LOCATION"
                       ],
                       "status": "ACTIVE",
-                      "level": 2
+                      "level": 2,
+                      "locationHierarchy": [
+                        { "code": "Z", "pathHierarchy": "Z", "level": 1, "type": "WING" },
+                        { "localName": "Adjudication Room", "code": "ADJUDICATION", "pathHierarchy": "Z-ADJUDICATION", "level": 2, "type": "ADJUDICATION_ROOM" }
+                      ]
                     },
                     {
                       "localName": "Visit Room",
@@ -1709,7 +1713,11 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
                         "OFFICIAL_VISITS"
                       ],
                       "status": "ACTIVE",
-                      "level": 2
+                      "level": 2,
+                      "locationHierarchy": [
+                        { "code": "Z", "pathHierarchy": "Z", "level": 1, "type": "WING" },
+                        { "localName": "Visit Room", "code": "VISIT", "pathHierarchy": "Z-VISIT", "level": 2, "type": "VISITS" }
+                      ]
                     }
                   ]
                 }
@@ -1746,7 +1754,11 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
                         "HEARING_LOCATION"
                       ],
                       "status": "ACTIVE",
-                      "level": 2
+                      "level": 2,
+                      "locationHierarchy": [
+                        { "code": "Z", "pathHierarchy": "Z", "level": 1, "type": "WING" },
+                        { "localName": "Adjudication Room", "code": "ADJUDICATION", "pathHierarchy": "Z-ADJUDICATION", "level": 2, "type": "ADJUDICATION_ROOM" }
+                      ]
                     },
                     {
                       "localName": "Visit Room",
@@ -1761,7 +1773,11 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
                         "OFFICIAL_VISITS"
                       ],
                       "status": "ACTIVE",
-                      "level": 2
+                      "level": 2,
+                      "locationHierarchy": [
+                        { "code": "Z", "pathHierarchy": "Z", "level": 1, "type": "WING" },
+                        { "localName": "Visit Room", "code": "VISIT", "pathHierarchy": "Z-VISIT", "level": 2, "type": "VISITS" }
+                      ]
                     }
                   ]
                 }


### PR DESCRIPTION
## What

Adds a `locationHierarchy` field to `NonResidentialLocationDTO` (ancestors **and** self, ordered top → bottom), populated from the existing `getHierarchy()` helper — mirroring how `ResidentialSummary` already exposes `locationHierarchy`.

It flows through the shared `NonResidentialLocation.toNonResidentialDto()` mapper, so all three read endpoints get it from one place:
- `GET /locations/non-residential/summary/{prisonId}`
- `GET /locations/non-residential/{id}`
- batch get-by-ids

Ancestor local names are passed through `formatLocation(...)` so they render title-cased, consistent with the DTO's own `localName` (rather than the raw upper-cased value `getHierarchy()` returns).

## Why

In the non-residential locations UI, parents and their children appear in a flat list and are often **named identically** (e.g. a parent "Gym" and a child "Gym"), so users can't tell them apart or decide which to archive. This field lets the UI show the readable parent/hierarchy path for each location.

## Testing

- Extended the summary happy-path assertions in `LocationNonResidentialResourceTest` to verify `locationHierarchy` (`[wingZ, adjRoom]`, with formatted names/levels).
- Full `LocationNonResidentialResourceTest` (84 tests) and `NonResidentialServiceTest` pass; ktlint clean.

## Related

Paired with the UI change in `hmpps-non-residential-locations-ui` (MAPB-651). **This PR should merge and deploy to dev first** so the field is populated before the UI consumes it.
