### PR TITLE
MAPB-645 Add GET /locations/property/{id} for a single property location

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
@@ -553,6 +553,40 @@ class LocationNonResidentialResource(
     prisonId: String,
   ): List<PropertyLocationDto> = nonResidentialService.getPropertyLocations(prisonId)
 
+  @GetMapping("/property/{id}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")
+  @Operation(
+    summary = "Return a single property storage location, with capacity, by id",
+    description = "Returns the property location if it can hold property (has a PROPERTY non-residential usage), " +
+      "otherwise 404. Lets callers confirm a location can store property without knowing how that is modelled " +
+      "here. Requires role VIEW_LOCATIONS",
+    responses = [
+      ApiResponse(responseCode = "200", description = "Returns the property location"),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the VIEW_LOCATIONS role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Not found, or the location cannot store property",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getPropertyLocation(
+    @Schema(description = "The location id", example = "de91dfa7-821f-4552-a427-bf2f32eafeb0", required = true)
+    @PathVariable
+    id: UUID,
+  ): PropertyLocationDto = nonResidentialService.getPropertyLocation(id)
+    ?: throw LocationNotFoundException(id.toString())
+
   @PostMapping("/prison/{prisonId}/property", produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasRole('ROLE_MANAGE_PROPERTY_LOCATIONS') and hasAuthority('SCOPE_write')")
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -165,6 +165,17 @@ class NonResidentialService(
   }
 
   /**
+   * A single property storage location by id, with its PROPERTY-usage capacity, or null if the id is
+   * unknown or the location cannot hold property (no PROPERTY non-residential usage). Callers use this to
+   * confirm a location can store property without needing to know how that is modelled here.
+   */
+  fun getPropertyLocation(id: UUID): PropertyLocationDto? {
+    val location = nonResidentialLocationRepository.findById(id).getOrNull() ?: return null
+    if (NonResidentialUsageType.PROPERTY !in location.toUsageTypes()) return null
+    return location.toPropertyLocationDto()
+  }
+
+  /**
    * Create a new top-level BOX property storage location with a generated code and a PROPERTY usage
    * carrying the given capacity. Returns the slim property DTO for the caller plus the full
    * non-residential DTO for the domain event (so NOMIS is notified of the new usage/capacity).

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PropertyLocationsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PropertyLocationsIntTest.kt
@@ -64,6 +64,63 @@ class PropertyLocationsIntTest : CommonDataTestBase() {
   }
 
   @Test
+  fun `get by id requires the VIEW_LOCATIONS role`() {
+    webTestClient.get().uri("/locations/property/${java.util.UUID.randomUUID()}")
+      .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  fun `get by id returns the property location with its capacity`() {
+    val box = buildNonResidentialLocation(
+      prisonId = "MDI",
+      pathHierarchy = "PBOX",
+      localName = "Property Box",
+      locationType = LocationType.BOX,
+      usageTypes = setOf(NonResidentialUsageType.PROPERTY),
+    )
+    box.addUsage(NonResidentialUsageType.PROPERTY, 12)
+    val saved = repository.save(box)
+
+    webTestClient.get().uri("/locations/property/${saved.id}")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.id").isEqualTo(saved.id.toString())
+      .jsonPath("$.localName").isEqualTo("Property Box")
+      .jsonPath("$.locationType").isEqualTo("BOX")
+      .jsonPath("$.capacity").isEqualTo(12)
+  }
+
+  @Test
+  fun `get by id returns 404 for a non-residential location that cannot store property`() {
+    val appt = repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "APPT",
+        localName = "Appointment Room",
+        locationType = LocationType.ROOM,
+        serviceTypes = setOf(ServiceType.APPOINTMENT),
+      ),
+    )
+
+    webTestClient.get().uri("/locations/property/${appt.id}")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `get by id returns 404 for an unknown id`() {
+    webTestClient.get().uri("/locations/property/${java.util.UUID.randomUUID()}")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  @Test
   fun `returns leaf property locations only - a property parent whose child is also property is dropped`() {
     val parent = repository.save(
       buildNonResidentialLocation(


### PR DESCRIPTION
## Why
property-api validates that a container's internal location can store property (and reads its capacity) by looking the location up. It was using `GET /locations/non-residential/{id}`, whose response (`toNonResidentialDto()`) carries **no non-residential usage** — only the newer `usedByServices` — so the PROPERTY-usage check could never succeed. Rather than switch property-api to the heavier `GET /locations/{id}` and duplicate the 'PROPERTY usage = property location' rule there, this adds a dedicated lookup that keeps that rule in one place (and survives a future move to a dedicated property-storage collection).

## What
`GET /locations/property/{id}` (sibling to `GET /locations/prison/{prisonId}/property` and `PUT/DELETE /locations/property/{id}`), role `ROLE_VIEW_LOCATIONS`:
- **200** `PropertyLocationDto` (id, code, localName, locationType, capacity) when the location has a PROPERTY non-residential usage.
- **404** when the id is unknown or the location has no PROPERTY usage (i.e. cannot store property).

Reuses `NonResidentialLocation.toPropertyLocationDto()` and the same PROPERTY-usage test used by `removePropertyLocation`.

## Tests
`PropertyLocationsIntTest`: 200-with-capacity, 404 for a non-property non-residential location, 404 for an unknown id, 403 without the role. `ResourceSecurityTest` + `OpenApiDocsTest` green; ktlint clean.

## Deploy note
Deploy before the paired property-api change (MAPB-646) that switches to this endpoint.