### PR TITLE
MAPB-647 Filter property-only locations out of the non-residential summary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/specification/LocationSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/specification/LocationSpecification.kt
@@ -1,10 +1,14 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification
 
 import jakarta.persistence.criteria.JoinType
+import jakarta.persistence.criteria.Predicate
 import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocation
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsage
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ServiceType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ServiceUsage
 
@@ -17,6 +21,26 @@ fun filterByIsLeaf() = buildSpecForIsEmpty<NonResidentialLocation>("childLocatio
 fun excludeByCode(code: String) = NonResidentialLocation::code.buildSpecForNotEqualTo(code)
 fun excludeByLocationType(locationType: LocationType) = NonResidentialLocation::locationType.buildSpecForNotEqualTo(locationType)
 fun excludeByStatus(status: LocationStatus) = NonResidentialLocation::status.buildSpecForNotEqualTo(status)
+
+/**
+ * Excludes locations that can only store property, i.e. those whose sole non-residential usage is
+ * [NonResidentialUsageType.PROPERTY]. A location is kept when it has no PROPERTY usage, or when it has
+ * a PROPERTY usage alongside at least one other usage (used for property *and* another service).
+ */
+fun excludePropertyOnlyLocations(): Specification<NonResidentialLocation> = Specification { root, query, cb ->
+  fun usageExists(propertyMatch: Boolean): Predicate {
+    val sub = query!!.subquery(Long::class.java)
+    val usage = sub.from(NonResidentialUsage::class.java)
+    sub.select(cb.literal(1L))
+    val typeMatch = cb.equal(usage.get<NonResidentialUsageType>("usageType"), NonResidentialUsageType.PROPERTY)
+    sub.where(
+      cb.equal(usage.get<Location>("location"), root),
+      if (propertyMatch) typeMatch else cb.not(typeMatch),
+    )
+    return cb.exists(sub)
+  }
+  cb.or(cb.not(usageExists(propertyMatch = true)), usageExists(propertyMatch = false))
+}
 
 fun filterByStatuses(statuses: Collection<LocationStatus>) = NonResidentialLocation::status.buildSpecForIn(statuses)
 fun filterByStatuses(vararg statuses: LocationStatus) = filterByStatuses(statuses.toList())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
@@ -553,6 +553,40 @@ class LocationNonResidentialResource(
     prisonId: String,
   ): List<PropertyLocationDto> = nonResidentialService.getPropertyLocations(prisonId)
 
+  @GetMapping("/property/{id}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")
+  @Operation(
+    summary = "Return a single property storage location, with capacity, by id",
+    description = "Returns the property location if it can hold property (has a PROPERTY non-residential usage), " +
+      "otherwise 404. Lets callers confirm a location can store property without knowing how that is modelled " +
+      "here. Requires role VIEW_LOCATIONS",
+    responses = [
+      ApiResponse(responseCode = "200", description = "Returns the property location"),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the VIEW_LOCATIONS role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Not found, or the location cannot store property",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getPropertyLocation(
+    @Schema(description = "The location id", example = "de91dfa7-821f-4552-a427-bf2f32eafeb0", required = true)
+    @PathVariable
+    id: UUID,
+  ): PropertyLocationDto = nonResidentialService.getPropertyLocation(id)
+    ?: throw LocationNotFoundException(id.toString())
+
   @PostMapping("/prison/{prisonId}/property", produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasRole('ROLE_MANAGE_PROPERTY_LOCATIONS') and hasAuthority('SCOPE_write')")
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
@@ -871,7 +871,7 @@ class LocationNonResidentialResource(
   @GetMapping("/non-residential/summary/{prisonId}")
   @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")
   @Operation(
-    summary = "Get a paged list of non-residential locations for a prison (excluding RTU and BOXes)",
+    summary = "Get a paged list of non-residential locations for a prison (excluding RTU and property-only locations)",
     description = "Requires role VIEW_LOCATIONS",
     responses = [
       ApiResponse(
@@ -932,13 +932,19 @@ class LocationNonResidentialResource(
     )
     @RequestParam(required = false)
     filterParents: Boolean = false,
-    @Schema(description = "Include BOX types of locations", example = "false", required = false, defaultValue = "false")
+    @Schema(
+      description = "Include locations that can only store property (sole usage of PROPERTY). " +
+        "Locations used for property alongside another service are always returned.",
+      example = "false",
+      required = false,
+      defaultValue = "false",
+    )
     @Parameter(
-      description = "Include box locations",
+      description = "Include property-only locations",
       example = "false",
     )
     @RequestParam(required = false)
-    includeBoxes: Boolean = false,
+    includeProperty: Boolean = false,
     @Schema(description = "Filter by given types", example = "[ADJUDICATION_ROOM,VIDEO_LINK]", required = false)
     @Parameter(
       description = "Filter by given types",
@@ -980,6 +986,6 @@ class LocationNonResidentialResource(
     locationTypes = locationType ?: emptyList(),
     searchByLocalName = localName,
     filterParents = filterParents,
-    includeBoxes = includeBoxes,
+    includeProperty = includeProperty,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -165,6 +165,17 @@ class NonResidentialService(
   }
 
   /**
+   * A single property storage location by id, with its PROPERTY-usage capacity, or null if the id is
+   * unknown or the location cannot hold property (no PROPERTY non-residential usage). Callers use this to
+   * confirm a location can store property without needing to know how that is modelled here.
+   */
+  fun getPropertyLocation(id: UUID): PropertyLocationDto? {
+    val location = nonResidentialLocationRepository.findById(id).getOrNull() ?: return null
+    if (NonResidentialUsageType.PROPERTY !in location.toUsageTypes()) return null
+    return location.toPropertyLocationDto()
+  }
+
+  /**
    * Create a new top-level BOX property storage location with a generated code and a PROPERTY usage
    * carrying the given capacity. Returns the slim property DTO for the caller plus the full
    * non-residential DTO for the domain event (so NOMIS is notified of the new usage/capacity).

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -33,7 +33,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LocationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.NonResidentialLocationRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.excludeByCode
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.excludeByLocationType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.excludePropertyOnlyLocations
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filterByIsLeaf
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filterByLocalName
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filterByPrisonId
@@ -577,7 +577,7 @@ class NonResidentialService(
     serviceFamilyTypes: List<ServiceFamilyType> = emptyList(),
     searchByLocalName: String? = null,
     filterParents: Boolean = false,
-    includeBoxes: Boolean = false,
+    includeProperty: Boolean = false,
     locationTypes: List<NonResidentialLocationType> = emptyList(),
     pageable: Pageable = PageRequest.of(0, 100, Sort.by("localName").ascending()),
   ): NonResidentialSummary {
@@ -588,8 +588,8 @@ class NonResidentialService(
           add(filterByIsLeaf())
         }
         add(excludeByCode("RTU"))
-        if (!includeBoxes) {
-          add(excludeByLocationType(LocationType.BOX))
+        if (!includeProperty) {
+          add(excludePropertyOnlyLocations())
         }
 
         searchByLocalName?.let {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/NonResidentialLeafFilteringIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/NonResidentialLeafFilteringIntTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.test.json.JsonCompareMode
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ServiceType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.buildNonResidentialLocation
 
@@ -43,32 +44,76 @@ class NonResidentialLeafFilteringIntTest : CommonDataTestBase() {
   }
 
   @Test
-  fun `can retrieve box locations locations`() {
-    val box = repository.save(
+  fun `property-only locations are excluded unless includeProperty is set`() {
+    // Solely used for property storage (its only usage is PROPERTY).
+    repository.save(
       buildNonResidentialLocation(
         prisonId = "MDI",
-        pathHierarchy = "BOX",
-        localName = "Box 1",
+        pathHierarchy = "PROPBOX",
+        localName = "Property Box",
         locationType = LocationType.BOX,
+        usageTypes = setOf(NonResidentialUsageType.PROPERTY),
       ),
     )
-    repository.save(box)
 
-    // The Box should be returned
-    webTestClient.get().uri("/locations/non-residential/summary/MDI?includeBoxes=true")
-      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
-      .exchange()
-      .expectStatus().isOk
-      .expectBody()
-      .jsonPath("$.locations.content[?(@.localName == 'Box 1')]").exists()
-
-    // The Box should NOT be returned
+    // Property storage is excluded by default...
     webTestClient.get().uri("/locations/non-residential/summary/MDI")
       .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
       .exchange()
       .expectStatus().isOk
       .expectBody()
-      .jsonPath("$.locations.content[?(@.localName == 'Box 1')]").doesNotExist()
+      .jsonPath("$.locations.content[?(@.localName == 'Property Box')]").doesNotExist()
+
+    // ...but returned when includeProperty=true.
+    webTestClient.get().uri("/locations/non-residential/summary/MDI?includeProperty=true")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.locations.content[?(@.localName == 'Property Box')]").exists()
+  }
+
+  @Test
+  fun `locations used for property and another service are always returned`() {
+    // Used for property AND appointments - should not be filtered out.
+    repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "MIXED",
+        localName = "Mixed Use",
+        locationType = LocationType.LOCATION,
+        serviceTypes = setOf(ServiceType.APPOINTMENT),
+        usageTypes = setOf(NonResidentialUsageType.PROPERTY),
+      ),
+    )
+
+    webTestClient.get().uri("/locations/non-residential/summary/MDI")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.locations.content[?(@.localName == 'Mixed Use')]").exists()
+  }
+
+  @Test
+  fun `box locations without a property usage are still returned`() {
+    // A BOX with no PROPERTY usage is not property storage, so location type alone must not exclude it.
+    repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "PLAINBOX",
+        localName = "Plain Box",
+        locationType = LocationType.BOX,
+        serviceTypes = setOf(ServiceType.APPOINTMENT),
+      ),
+    )
+
+    webTestClient.get().uri("/locations/non-residential/summary/MDI")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.locations.content[?(@.localName == 'Plain Box')]").exists()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PropertyLocationsIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PropertyLocationsIntTest.kt
@@ -64,6 +64,63 @@ class PropertyLocationsIntTest : CommonDataTestBase() {
   }
 
   @Test
+  fun `get by id requires the VIEW_LOCATIONS role`() {
+    webTestClient.get().uri("/locations/property/${java.util.UUID.randomUUID()}")
+      .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  fun `get by id returns the property location with its capacity`() {
+    val box = buildNonResidentialLocation(
+      prisonId = "MDI",
+      pathHierarchy = "PBOX",
+      localName = "Property Box",
+      locationType = LocationType.BOX,
+      usageTypes = setOf(NonResidentialUsageType.PROPERTY),
+    )
+    box.addUsage(NonResidentialUsageType.PROPERTY, 12)
+    val saved = repository.save(box)
+
+    webTestClient.get().uri("/locations/property/${saved.id}")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.id").isEqualTo(saved.id.toString())
+      .jsonPath("$.localName").isEqualTo("Property Box")
+      .jsonPath("$.locationType").isEqualTo("BOX")
+      .jsonPath("$.capacity").isEqualTo(12)
+  }
+
+  @Test
+  fun `get by id returns 404 for a non-residential location that cannot store property`() {
+    val appt = repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "APPT",
+        localName = "Appointment Room",
+        locationType = LocationType.ROOM,
+        serviceTypes = setOf(ServiceType.APPOINTMENT),
+      ),
+    )
+
+    webTestClient.get().uri("/locations/property/${appt.id}")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `get by id returns 404 for an unknown id`() {
+    webTestClient.get().uri("/locations/property/${java.util.UUID.randomUUID()}")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  @Test
   fun `returns leaf property locations only - a property parent whose child is also property is dropped`() {
     val parent = repository.save(
       buildNonResidentialLocation(


### PR DESCRIPTION
## What & why

The non-residential locations UI sometimes showed property storage locations it should not. The UI relies entirely on `GET /locations/non-residential/summary/{prisonId}`, which excluded property storage by **location type `BOX`** — the wrong criterion. A location can store property only when it has a `PROPERTY` non-residential usage, so some property locations slipped through and some non-property boxes were wrongly hidden.

## What changed

- **New spec `excludePropertyOnlyLocations()`** (`LocationSpecification.kt`): a correlated subquery that keeps a location unless it has a `PROPERTY` usage *and* no other usage.
  - property-only → excluded
  - property **+** another service → kept
  - no property → kept (unchanged)
- **`NonResidentialService.kt`**: replaced the `excludeByLocationType(BOX)` filter with `excludePropertyOnlyLocations()`; renamed the flag `includeBoxes` → `includeProperty`.
- **`LocationNonResidentialResource.kt`**: renamed the `includeProperty` query param (default `false`) and updated the Swagger descriptions.

Backend-only — the UI never sent `includeBoxes`/`locationType`, so the fix is transparent to it. Property management continues to use its dedicated `/prison/{prisonId}/property` endpoints.

## Tests

`NonResidentialLeafFilteringIntTest` reworked to cover: property-only excluded by default / included with `?includeProperty=true`, mixed-use always returned, and plain BOX (no property usage) returned. Target test classes pass (92 tests); `ktlintCheck` clean.

## Note

Stacked on `MAPB-645-get-property-location-by-id` (which also touches two of these files); base will auto-retarget to `main` once that merges.
