### PR TITLE
MAPB-679 Keep the adjudication room location type on non-residential updates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/LocationDto.kt
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.PositiveOrZero
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.AccommodationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ConvertedCellType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DEFAULT_NON_RESIDENTIAL_LOCATION_TYPE
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.DeactivatedReason
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationAttribute
@@ -646,7 +647,7 @@ data class CreateOrUpdateNonResidentialLocationRequest(
     id = null,
     prisonId = prisonId,
     code = code,
-    locationType = identifyNonResidentialLocationType(servicesUsingLocation).baseType,
+    locationType = (identifyNonResidentialLocationType(servicesUsingLocation) ?: DEFAULT_NON_RESIDENTIAL_LOCATION_TYPE).baseType,
     pathHierarchy = code,
     status = if (FALSE == active) LocationStatus.INACTIVE else LocationStatus.ACTIVE,
     localName = localName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -275,7 +275,10 @@ class NonResidentialLocation(
             linkedTransaction,
           )
         }
-        locationType = identifyNonResidentialLocationType(it).baseType
+        // only when a service maps to a type - otherwise keep the type NOMIS holds for this location
+        identifyNonResidentialLocationType(it)?.let { mappedType ->
+          locationType = mappedType.baseType
+        }
       }
       val internalMovementAllowedUpdate = services.find { it.serviceType == ServiceType.INTERNAL_MOVEMENTS } != null
       if (internalMovementAllowed != internalMovementAllowedUpdate) {
@@ -333,12 +336,15 @@ class NonResidentialLocation(
     upsert.toServiceTypes()?.let { serviceTypeForLocation.addAll(it) }
     serviceTypeForLocation.addAll(upsert.locationType.toMappedServiceTypes())
 
-    // if the oldLocationType is different to the upsert locationType, and it was a type that had a service type mapped then check if it needs to be removed
+    // if the oldLocationType is different to the upsert locationType, and it was a type that had a service type mapped then check if it needs to be removed.
+    // Only services derived solely from the location type are dropped - one that also has a usage type (e.g. HEARING_LOCATION)
+    // is still evidenced by the usage NOMIS sent, so it is kept.
     if (oldLocationType != upsert.locationType && oldLocationType.toMappedServiceTypes().isNotEmpty()) {
       serviceTypeForLocation.removeAll { serviceType ->
-        serviceType.nonResidentialLocationType?.baseType?.let { mappedLocationType ->
-          mappedLocationType != upsert.locationType
-        } ?: false
+        serviceType.nonResidentialUsageType == null &&
+          serviceType.nonResidentialLocationType?.baseType?.let { mappedLocationType ->
+            mappedLocationType != upsert.locationType
+          } ?: false
       }
     }
 
@@ -439,7 +445,13 @@ class NonResidentialLocation(
   }
 }
 
-private val DEFAULT_NON_RESIDENTIAL_LOCATION_TYPE = NonResidentialLocationType.LOCATION
+val DEFAULT_NON_RESIDENTIAL_LOCATION_TYPE = NonResidentialLocationType.LOCATION
 
-fun identifyNonResidentialLocationType(serviceTypes: Set<ServiceType>): NonResidentialLocationType = serviceTypes.firstNotNullOfOrNull(ServiceType::nonResidentialLocationType)
-  ?: DEFAULT_NON_RESIDENTIAL_LOCATION_TYPE
+/**
+ * The location type implied by the services using a location, or null when none of them map to one.
+ * Callers updating an existing location must leave its type alone when this is null, otherwise a type
+ * NOMIS owns (e.g. VISI, CLAS, ADJU) would be flattened to the default on every edit.
+ */
+fun identifyNonResidentialLocationType(serviceTypes: Set<ServiceType>): NonResidentialLocationType? = serviceTypes
+  .sortedBy { it.locationTypePrecedence }
+  .firstNotNullOfOrNull(ServiceType::nonResidentialLocationType)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ServiceUsage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ServiceUsage.kt
@@ -93,11 +93,17 @@ enum class ServiceType(
   val additionalInformation: String,
   val sequence: Int = 99,
   val nonResidentialLocationType: NonResidentialLocationType? = null,
+  /**
+   * Which [nonResidentialLocationType] wins when a location is used by more than one service that maps
+   * to a location type. Lowest wins. Adjudications takes precedence because NOMIS looks up adjudication
+   * hearing rooms by the ADJU location type and fails outright without one.
+   */
+  val locationTypePrecedence: Int = 99,
 ) {
   APPOINTMENT(description = "Appointments", NonResidentialUsageType.APPOINTMENT, ServiceFamilyType.ACTIVITIES_APPOINTMENTS, additionalInformation = "For example, a counselling session.", sequence = 1),
   PROGRAMMES_AND_ACTIVITIES(description = "Programmes and activities", NonResidentialUsageType.PROGRAMMES_ACTIVITIES, ServiceFamilyType.ACTIVITIES_APPOINTMENTS, additionalInformation = "For example, a workshop or lesson.", sequence = 2),
-  VIDEO_LINK(description = "Book a video link", nonResidentialUsageType = null, ServiceFamilyType.VIDEO_LINK_APPOINTMENTS, additionalInformation = "For example, managing a court hearing or probation meeting via video link.", sequence = 3, nonResidentialLocationType = NonResidentialLocationType.VIDEO_LINK),
-  HEARING_LOCATION(description = "Adjudications - hearing location", NonResidentialUsageType.ADJUDICATION_HEARING, ServiceFamilyType.ADJUDICATIONS, additionalInformation = "For adjudication hearings.", sequence = 4),
+  VIDEO_LINK(description = "Book a video link", nonResidentialUsageType = null, ServiceFamilyType.VIDEO_LINK_APPOINTMENTS, additionalInformation = "For example, managing a court hearing or probation meeting via video link.", sequence = 3, nonResidentialLocationType = NonResidentialLocationType.VIDEO_LINK, locationTypePrecedence = 2),
+  HEARING_LOCATION(description = "Adjudications - hearing location", NonResidentialUsageType.ADJUDICATION_HEARING, ServiceFamilyType.ADJUDICATIONS, additionalInformation = "For adjudication hearings.", sequence = 4, nonResidentialLocationType = NonResidentialLocationType.ADJUDICATION_ROOM, locationTypePrecedence = 1),
   LOCATION_OF_INCIDENT(description = "Adjudications - location of incident", NonResidentialUsageType.OCCURRENCE, ServiceFamilyType.ADJUDICATIONS, additionalInformation = "For example, a location where an occurrence led to an adjudication hearing.", sequence = 5),
   INTERNAL_MOVEMENTS(description = "Internal movements", NonResidentialUsageType.MOVEMENT, ServiceFamilyType.INTERNAL_MOVEMENTS, additionalInformation = "To record the location of unlocked prisoners within this establishment.", sequence = 6),
   OFFICIAL_VISITS(description = "Official visits", NonResidentialUsageType.VISIT, ServiceFamilyType.OFFICIAL_VISITS, additionalInformation = "For example, arranging a face to face visit with a solicitor.", sequence = 7),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
@@ -165,6 +165,60 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
       }
 
       @Test
+      fun `creating a hearing location sets the adjudication room location type`() {
+        webTestClient.post().uri("/locations/non-residential/MDI")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(createReq.copy(localName = "Adj Room 2")))
+          .exchange()
+          .expectStatus().isCreated
+          .expectBody().json(
+            // language=json
+            """
+             {
+              "localName": "Adj Room 2",
+              "locationType": "ADJUDICATION_ROOM",
+              "usedByServices": [
+                "HEARING_LOCATION",
+                "INTERNAL_MOVEMENTS"
+              ]
+            }
+          """,
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `adjudications takes precedence over video link when both services are used`() {
+        webTestClient.post().uri("/locations/non-residential/MDI")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(createReq.copy(localName = "Adj Bvl Room", servicesUsingLocation = setOf(ServiceType.VIDEO_LINK, ServiceType.HEARING_LOCATION))))
+          .exchange()
+          .expectStatus().isCreated
+          .expectBody().json(
+            // language=json
+            """{ "locationType": "ADJUDICATION_ROOM" }""",
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `creating a location with no type mapped services defaults to the location type`() {
+        webTestClient.post().uri("/locations/non-residential/MDI")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(jsonString(createReq.copy(localName = "Visits Room 9", servicesUsingLocation = setOf(ServiceType.OFFICIAL_VISITS))))
+          .exchange()
+          .expectStatus().isCreated
+          .expectBody().json(
+            // language=json
+            """{ "locationType": "LOCATION" }""",
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
       fun `can create details of a location with old archived name`() {
         webTestClient.post().uri("/locations/non-residential/MDI")
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
@@ -277,6 +331,52 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
 
     @Nested
     inner class HappyPath {
+
+      @Test
+      fun `updating a hearing location keeps the adjudication room location type`() {
+        val adjRoom = repository.save(
+          buildNonResidentialLocation(
+            localName = "Adj Room Four",
+            locationType = LocationType.ADJUDICATION_ROOM,
+            serviceTypes = setOf(ServiceType.HEARING_LOCATION),
+          ),
+        )
+
+        webTestClient.put().uri("/locations/non-residential/${adjRoom.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(updateReq.copy(localName = "Adj Room Four Renamed", servicesUsingLocation = setOf(ServiceType.HEARING_LOCATION, ServiceType.INTERNAL_MOVEMENTS)))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """{ "locationType": "ADJUDICATION_ROOM" }""",
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `updating a location does not overwrite a location type no service maps to`() {
+        val visitsRoom = repository.save(
+          buildNonResidentialLocation(
+            localName = "Visits Room Four",
+            locationType = LocationType.VISITS,
+            serviceTypes = setOf(ServiceType.OFFICIAL_VISITS),
+          ),
+        )
+
+        webTestClient.put().uri("/locations/non-residential/${visitsRoom.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(updateReq.copy(localName = "Visits Room Four Renamed", servicesUsingLocation = setOf(ServiceType.OFFICIAL_VISITS, ServiceType.INTERNAL_MOVEMENTS)))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """{ "locationType": "VISITS" }""",
+            JsonCompareMode.LENIENT,
+          )
+      }
 
       @Test
       fun `can deactivate a location`() {
@@ -392,7 +492,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
           "localName": "Visit Room 2",
           "code": "VISIT",
           "pathHierarchy": "Z-VISIT",
-          "locationType": "LOCATION",
+          "locationType": "VISITS",
           "permanentlyInactive": false,
           "usedByGroupedServices": [
             "OFFICIAL_VISITS"
@@ -426,7 +526,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "localName": "Visit Room 2",
               "code": "VISIT",
               "pathHierarchy": "Z-VISIT",
-              "locationType": "LOCATION",
+              "locationType": "VISITS",
               "permanentlyInactive": false,
               "usedByGroupedServices": [
                 "OFFICIAL_VISITS"
@@ -459,7 +559,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "localName": "Visit Room",
               "code": "VISIT",
               "pathHierarchy": "Z-VISIT",
-              "locationType": "LOCATION",
+              "locationType": "VISITS",
               "permanentlyInactive": false,
               "usedByGroupedServices": [],
               "usedByServices": [],
@@ -491,7 +591,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "localName": "Visit Room",
               "code": "VISIT",
               "pathHierarchy": "Z-VISIT",
-              "locationType": "LOCATION",
+              "locationType": "VISITS",
               "permanentlyInactive": false,
               "usedByGroupedServices": [],
               "usedByServices": [],
@@ -633,7 +733,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
             "localName": "Visit Room",
             "code": "VISIT",
             "pathHierarchy": "Z-VISIT",
-            "locationType": "LOCATION",
+            "locationType": "VISITS",
             "permanentlyInactive": false,
             "usedByGroupedServices": [
               "INTERNAL_MOVEMENTS"
@@ -669,7 +769,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
                 "localName": "Visit Room",
                 "code": "VISIT",
                 "pathHierarchy": "Z-VISIT",
-                "locationType": "LOCATION",
+                "locationType": "VISITS",
                 "permanentlyInactive": false,
                 "usedByGroupedServices": [
                   "INTERNAL_MOVEMENTS"
@@ -1076,7 +1176,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "prisonId": "MDI",
               "code": "VISIT",
               "pathHierarchy": "Z-VISIT",
-              "locationType": "LOCATION",
+              "locationType": "VISITS",
               "active": true,
               "key": "MDI-Z-VISIT",
               "servicesUsingLocation": [],
@@ -1098,7 +1198,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "prisonId": "MDI",
               "code": "VISIT",
               "pathHierarchy": "Z-VISIT",
-              "locationType": "LOCATION",
+              "locationType": "VISITS",
               "active": true,
               "key": "MDI-Z-VISIT",
               "usage": [
@@ -1148,7 +1248,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "prisonId": "MDI",
               "code": "VISIT",
               "pathHierarchy": "Z-VISIT",
-              "locationType": "LOCATION",
+              "locationType": "VISITS",
               "active": true,
               "key": "MDI-Z-VISIT",
               "servicesUsingLocation": [
@@ -1175,7 +1275,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "prisonId": "MDI",
               "code": "VISIT",
               "pathHierarchy": "Z-VISIT",
-              "locationType": "LOCATION",
+              "locationType": "VISITS",
               "active": true,
               "key": "MDI-Z-VISIT",
               "usage": [
@@ -1446,7 +1546,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "prisonId": "MDI",
               "code": "VISIT",
               "pathHierarchy": "Z-VISIT",
-              "locationType": "LOCATION",
+              "locationType": "VISITS",
               "active": true,
               "key": "MDI-Z-VISIT",
               "usage": [
@@ -1479,7 +1579,7 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
               "prisonId": "MDI",
               "code": "VISIT",
               "pathHierarchy": "Z-VISIT",
-              "locationType": "LOCATION",
+              "locationType": "VISITS",
               "active": true,
               "key": "MDI-Z-VISIT",
               "usage": [

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResourceTest.kt
@@ -333,6 +333,36 @@ class LocationNonResidentialResourceTest : CommonDataTestBase() {
     inner class HappyPath {
 
       @Test
+      fun `re-saving a hearing location that was flattened to LOCATION restores the adjudication room type`() {
+        // a room left as LOCATION by the previous defaulting behaviour, still used for hearings
+        val flattenedRoom = repository.save(
+          buildNonResidentialLocation(
+            localName = "Flattened Adj Room",
+            locationType = LocationType.LOCATION,
+            serviceTypes = setOf(ServiceType.HEARING_LOCATION),
+          ),
+        )
+
+        webTestClient.put().uri("/locations/non-residential/${flattenedRoom.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(updateReq.copy(localName = null, servicesUsingLocation = setOf(ServiceType.HEARING_LOCATION)))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """{ "locationType": "ADJUDICATION_ROOM" }""",
+            JsonCompareMode.LENIENT,
+          )
+
+        getDomainEvents(1).let {
+          assertThat(it.map { message -> message.eventType to message.additionalInformation?.key }).containsExactlyInAnyOrder(
+            "location.inside.prison.amended" to flattenedRoom.getKey(),
+          )
+        }
+      }
+
+      @Test
       fun `updating a hearing location keeps the adjudication room location type`() {
         val adjRoom = repository.save(
           buildNonResidentialLocation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/SyncAndMigrateResourceIntTest.kt
@@ -1089,6 +1089,144 @@ class SyncAndMigrateResourceIntTest : SqsIntegrationTestBase() {
             JsonCompareMode.LENIENT,
           )
       }
+
+      @Test
+      fun `can sync a new non res location and add mapped service from adjudication room location type`() {
+        webTestClient.post().uri("/sync/upsert")
+          .headers(setAuthorisation(roles = listOf("ROLE_SYNC_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              syncNonResRequest.copy(
+                code = "ADJ-ROOM",
+                locationType = LocationType.ADJUDICATION_ROOM,
+                localName = "Adjudication Room",
+                internalMovementAllowed = false,
+                usage = emptySet(),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isCreated
+
+        webTestClient.get().uri("/locations/key/ZZGHI-ADJ-ROOM")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+             {
+              "key": "ZZGHI-ADJ-ROOM",
+              "locationType": "ADJUDICATION_ROOM",
+              "localName": "Adjudication Room",
+              "servicesUsingLocation": [
+                {
+                  "serviceType": "HEARING_LOCATION",
+                  "serviceFamilyType": "ADJUDICATIONS"
+                }
+              ]
+             }
+          """,
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `can sync an existing non res location and add mapped service when location type changes to adjudication room`() {
+        webTestClient.post().uri("/sync/upsert")
+          .headers(setAuthorisation(roles = listOf("ROLE_SYNC_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              syncNonResRequest.copy(
+                id = nonRes.id,
+                code = "VISIT",
+                locationType = LocationType.ADJUDICATION_ROOM,
+                localName = "Visit Hall converted to an adjudication room",
+                internalMovementAllowed = false,
+                usage = emptySet(),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+
+        webTestClient.get().uri("/locations/${nonRes.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+             {
+              "key": "ZZGHI-B-1-VISIT",
+              "locationType": "ADJUDICATION_ROOM",
+              "servicesUsingLocation": [
+                {
+                  "serviceType": "HEARING_LOCATION",
+                  "serviceFamilyType": "ADJUDICATIONS"
+                }
+              ]
+             }
+          """,
+            JsonCompareMode.LENIENT,
+          )
+      }
+
+      @Test
+      fun `sync keeps the hearing location service when the usage still says so but the location type changes`() {
+        val adjudicationRoom = repository.save(
+          buildNonResidentialLocation(
+            localName = "Hearing Room",
+            prisonId = "ZZGHI",
+            pathHierarchy = "B-1-HEARING",
+            locationType = LocationType.ADJUDICATION_ROOM,
+            serviceTypes = setOf(ServiceType.HEARING_LOCATION),
+          ),
+        )
+
+        webTestClient.post().uri("/sync/upsert")
+          .headers(setAuthorisation(roles = listOf("ROLE_SYNC_LOCATIONS"), scopes = listOf("write")))
+          .header("Content-Type", "application/json")
+          .bodyValue(
+            jsonString(
+              syncNonResRequest.copy(
+                id = adjudicationRoom.id,
+                code = "HEARING",
+                locationType = LocationType.LOCATION,
+                localName = "Hearing Room",
+                usage = setOf(NonResidentialUsageDto(NonResidentialUsageType.ADJUDICATION_HEARING, 10, 1)),
+                internalMovementAllowed = false,
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isOk
+
+        webTestClient.get().uri("/locations/${adjudicationRoom.id}")
+          .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+          .header("Content-Type", "application/json")
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            // language=json
+            """
+             {
+              "locationType": "LOCATION",
+              "servicesUsingLocation": [
+                {
+                  "serviceType": "HEARING_LOCATION",
+                  "serviceFamilyType": "ADJUDICATIONS"
+                }
+              ]
+             }
+          """,
+            JsonCompareMode.LENIENT,
+          )
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Adjudication outcome sync from DPS Adjudications into NOMIS was failing at FDI (5 messages on the DLQ). The sync looks up an adjudication hearing room by NOMIS location type `ADJU`; FDI no longer had one. `agy_int_loc_amendments` showed ~80 FDI locations changed to `LOCA` over 15–16 July, originating in DPS.

## Cause

MAPB-229 mapped `HEARING_LOCATION → ADJUDICATION_ROOM` and shipped `V1_82` enforcing the `ADJU ⟺ HEARING_LOCATION` invariant.

MAPB-344, BVL location type sync - made `nonResidentialLocationType` nullable to add `VIDEO_LINK`, and dropped the `ADJUDICATION_ROOM` mapping in the process. The test asserting `"locationType": "ADJUDICATION_ROOM"` on create was rewritten into a BVL/`VIDEO_LINK` test rather than kept alongside, so CI stayed green.

`NonResidentialLocation.update()` re-derives the location type from the selected services on **every** non-residential edit. With no mapping, adjudication rooms derived the `LOCATION` default and the domain event pushed `LOCA` into NOMIS.

This was not adjudication-specific: the same line flattened every unmapped type (`VISI`, `CLAS`, `WORK`, `OFFI`…) to `LOCA` the moment anyone touched a location's services. Nothing is special about FDI — it is live on non-resi and someone worked through its rooms.

## Changes

- Restore `HEARING_LOCATION → ADJUDICATION_ROOM`. This also re-enables the reverse direction: a NOMIS `ADJU` room syncing in gets the hearing-location service added again.
- `identifyNonResidentialLocationType` now returns null rather than defaulting. On **update** the type is only overwritten when a selected service maps to one, so types NOMIS owns are left alone. **Create** still defaults to `LOCATION`.
- New `locationTypePrecedence` makes the derivation deterministic — it previously depended on JSON field order. Adjudications beat video link, because NOMIS hard-fails hearing lookups without `ADJU` and BVL has no equivalent dependency.
- On sync, only services derived *solely* from the location type are dropped when the type changes. `HEARING_LOCATION` also has a usage type, so it survives while NOMIS is still sending `ADJUDICATION_HEARING`.

## Tests

New coverage for: creating a hearing location as `ADJUDICATION_ROOM`; the ADJU/VIDL tie-break; unmapped services still defaulting to `LOCATION` on create; an adjudication room keeping its type through an update; a `VISITS` room keeping its type through an update; and three sync cases mirroring the existing BVL ones.

Eleven existing assertions encoded the buggy behaviour — `visitRoom` is a `VISITS` location and the tests asserted it became `LOCATION` after a rename or service change. Corrected to `VISITS`.

## Notes

- No data migration, by decision. FDI's already-flipped rooms stay `LOCA` until edited in DPS or re-synced from NOMIS; the adjudications sync service has a fallback in place meanwhile.
- A derived location type change still records no `LOCATION_TYPE` history row, which is why the DPS-side changes were only traceable through NOMIS. Left out to keep this focused; happy to add.
