### PR TITLE
MAPB-670 Allow parent non-residential locations to be hidden from the list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LocationHistory.kt
@@ -110,6 +110,7 @@ enum class LocationAttribute(
   NON_RESIDENTIAL_CAPACITY(description = "Non residential capacity", display = true),
   INTERNAL_MOVEMENT_ALLOWED(description = "Internal movement allowed", display = true),
   USED_BY_SERVICE(description = "Use by service", display = true),
+  HIDDEN_FROM_LIST(description = "Hidden from list", display = true),
 
   // These are recorded but not returned as history changes
   CODE(description = "Code"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -50,6 +50,14 @@ class NonResidentialLocation(
   val services: SortedSet<ServiceUsage> = sortedSetOf(),
 
   private var internalMovementAllowed: Boolean? = false,
+
+  /**
+   * Whether this location has been removed from the non-residential locations list by a user.
+   * Purely a display concern for that service - see [hideFromList]. Non-null: the column is shared
+   * across the single location table, so it is nullable at DB level for non-non-residential rows,
+   * but a CHECK constraint keeps it populated for non-residential ones (see migration V1_98).
+   */
+  private var hiddenFromList: Boolean = false,
 ) : Location(
   id = id,
   code = code,
@@ -88,6 +96,44 @@ class NonResidentialLocation(
   override fun isNonResidential() = true
 
   override fun hasDeactivatedParent() = false
+
+  fun isHiddenFromList() = hiddenFromList
+
+  /**
+   * Whether a user may remove this location from the non-residential locations list. Only parent
+   * locations qualify, and only once nothing uses them: a leaf location that is genuinely finished
+   * with should be archived instead, and a location still used by a service must keep appearing in
+   * the list so it can be found and maintained.
+   */
+  fun canBeHiddenFromList() = !isLeafLevel() && services.isEmpty() && !isHiddenFromList()
+
+  /**
+   * Removes this location from the list shown in the non-residential locations UI.
+   *
+   * This is not a deactivation and must not be confused with one. Nothing about the location
+   * changes beyond the flag: its status is untouched, its children carry on exactly as before, and
+   * every service-facing endpoint keeps behaving the same way. Parent locations accumulate as
+   * services are migrated off them onto their children, and this lets a user finally put one out of
+   * sight once it has no services left.
+   */
+  fun hideFromList(
+    userOrSystemInContext: String,
+    clock: Clock,
+    linkedTransaction: LinkedTransaction,
+  ) {
+    val amendedDate = LocalDateTime.now(clock)
+    addHistory(
+      attributeName = LocationAttribute.HIDDEN_FROM_LIST,
+      oldValue = isHiddenFromList().toString(),
+      newValue = true.toString(),
+      amendedBy = userOrSystemInContext,
+      amendedDate = amendedDate,
+      linkedTransaction = linkedTransaction,
+    )
+    this.hiddenFromList = true
+    this.updatedBy = userOrSystemInContext
+    this.whenUpdated = amendedDate
+  }
 
   override fun findDeactivatedLocationInHierarchy(): Location? {
     if (isActive()) {
@@ -221,6 +267,8 @@ class NonResidentialLocation(
       deactivatedBy = deactivatedBy,
       usedByGroupedServices = serviceTypes.map { it.serviceFamily }.distinct().sortedBy { it.sequence },
       usedByServices = serviceTypes.sortedBy { it.sequence },
+      hiddenFromList = isHiddenFromList(),
+      canBeHiddenFromList = canBeHiddenFromList(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/specification/LocationSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/specification/LocationSpecification.kt
@@ -45,6 +45,21 @@ fun excludePropertyOnlyLocations(): Specification<NonResidentialLocation> = Spec
 fun filterByStatuses(statuses: Collection<LocationStatus>) = NonResidentialLocation::status.buildSpecForIn(statuses)
 fun filterByStatuses(vararg statuses: LocationStatus) = filterByStatuses(statuses.toList())
 
+/**
+ * Matches locations on their status, treating a location a user has hidden from the list as though
+ * it were archived: it is returned only when [LocationStatus.ARCHIVED] is asked for, and never
+ * under its own status. The location itself is untouched - this only governs where it shows up in
+ * the non-residential list.
+ */
+fun filterByStatusesTreatingHiddenAsArchived(statuses: Collection<LocationStatus>): Specification<NonResidentialLocation> = Specification { root, _, cb ->
+  val hiddenFromList = root.get<Boolean>("hiddenFromList")
+  val hidden = cb.isTrue(hiddenFromList)
+  val notHidden = cb.or(cb.isNull(hiddenFromList), cb.isFalse(hiddenFromList))
+  val matchesOwnStatus = cb.and(notHidden, root.get<LocationStatus>("status").`in`(statuses))
+
+  if (LocationStatus.ARCHIVED in statuses) cb.or(hidden, matchesOwnStatus) else matchesOwnStatus
+}
+
 fun filterByTypes(locationType: Collection<LocationType>) = NonResidentialLocation::locationType.buildSpecForIn(locationType)
 fun filterByTypes(vararg locationType: LocationType) = filterByTypes(locationType.toList())
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
@@ -430,6 +430,21 @@ class ApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(LocationCannotBeHiddenFromListException::class)
+  fun handleLocationCannotBeHiddenFromList(e: LocationCannotBeHiddenFromListException): ResponseEntity<ErrorResponse> {
+    log.debug("Attempt to hide a location that cannot be hidden: {}", e.message)
+    return ResponseEntity
+      .status(CONFLICT)
+      .body(
+        ErrorResponse(
+          status = CONFLICT,
+          errorCode = ErrorCode.LocationCannotBeHiddenFromList,
+          userMessage = "Hide from list exception: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
   @ExceptionHandler(ReasonForDeactivationMustBeProvidedException::class)
   fun handleReasonForDeactivationMustBeProvided(e: ReasonForDeactivationMustBeProvidedException): ResponseEntity<ErrorResponse> {
     log.debug("De-activating location requires a reason when using OTHER reason type: {}", e.message)
@@ -773,6 +788,7 @@ class LocationAlreadyExistsException(key: String) : Exception("Location already 
 class ReasonForDeactivationMustBeProvidedException(key: String) : Exception("De-activating location $key requires a reason when using OTHER reason type")
 class LocationCannotBeReactivatedException(key: String) : Exception("Location cannot be reactivated if parent is deactivated = $key")
 class LocationCannotBeUnarchivedException(key: String) : Exception("Location is not archived so cannot be un-archived = $key")
+class LocationCannotBeHiddenFromListException(key: String, reason: String) : Exception("Location $key cannot be hidden from the non-residential list: $reason")
 class AlreadyDeactivatedLocationException(key: String) : ValidationException("$key: Cannot deactivate an already deactivated location")
 class CapacityException(val key: String, override val message: String, val errorCode: ErrorCode) : ValidationException("$key: [Error Code: $errorCode] - Capacity Exception: $message")
 class PermanentlyDeactivatedUpdateNotAllowedException(key: String) : ValidationException("Location $key cannot be updated as has been permanently deactivated")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
@@ -50,4 +50,5 @@ enum class ErrorCode(val errorCode: Int) {
   WorkingCapacityCannotBeBelowOccupancyLevel(141),
   PendingApprovalExistsBelowLocation(142),
   LocationCannotBeUnarchived(143),
+  LocationCannotBeHiddenFromList(144),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
@@ -420,6 +420,52 @@ class LocationNonResidentialResource(
     return results.location
   }
 
+  @PutMapping("/non-residential/{id}/hide")
+  @PreAuthorize("hasRole('ROLE_MAINTAIN_LOCATIONS') and hasAuthority('SCOPE_write')")
+  @Operation(
+    summary = "Removes a parent non-residential location from the non-residential locations list",
+    description = "Hides the location from the list shown to users maintaining non-residential locations. " +
+      "This is not a deactivation: the location keeps its status, its child locations are unaffected and it " +
+      "remains available to anything that looks it up directly. Only permitted for a parent location that no " +
+      "service uses - archive a leaf location instead. Requires role MAINTAIN_LOCATIONS and write scope",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns the hidden location",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MAINTAIN_LOCATIONS role with write scope.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Data not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "Location is a leaf location, is still used by a service, or is already hidden",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun hideNonResidentialLocationFromList(
+    @Schema(description = "The non-residential location Id", example = "de91dfa7-821f-4552-a427-bf2f32eafeb0", required = true)
+    @PathVariable
+    id: UUID,
+  ): NonResidentialLocationDTO = eventPublishNonResiAndAudit(
+    // Amended rather than deactivated - nothing about the location's availability has changed
+    InternalLocationDomainEventType.LOCATION_AMENDED,
+  ) {
+    nonResidentialService.hideFromList(id)
+  }
+
   @GetMapping("/non-residential/prison/{prisonId}/local-name/{localName}")
   @PreAuthorize("hasRole('ROLE_VIEW_LOCATIONS')")
   @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -38,9 +38,10 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filt
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filterByLocalName
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filterByPrisonId
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filterByServiceTypes
-import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filterByStatuses
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filterByStatusesTreatingHiddenAsArchived
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.specification.filterByTypes
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.DuplicateNonResidentialLocalNameInPrisonException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationCannotBeHiddenFromListException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PermanentlyDeactivatedUpdateNotAllowedException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.LocationService.Companion.log
@@ -566,6 +567,46 @@ class NonResidentialService(
     }
   }
 
+  /**
+   * Removes a parent location from the non-residential locations list.
+   *
+   * Presented to users as archiving, but nothing is deactivated: the location keeps its status, its
+   * children are untouched and every service-facing endpoint carries on as before. Only permitted
+   * for a parent location that no service uses - a leaf location should be archived properly
+   * instead, and a location a service still uses has to stay visible so it can be maintained.
+   */
+  @Transactional
+  fun hideFromList(id: UUID): NonResidentialLocationDTO {
+    val location = nonResidentialLocationRepository.findById(id).orElseThrow { LocationNotFoundException(id.toString()) }
+
+    if (location.isLeafLevel()) {
+      throw LocationCannotBeHiddenFromListException(location.getKey(), "it is not a parent location, archive it instead")
+    }
+    if (location.isHiddenFromList()) {
+      throw LocationCannotBeHiddenFromListException(location.getKey(), "it is already hidden from the list")
+    }
+    if (location.services.isNotEmpty()) {
+      throw LocationCannotBeHiddenFromListException(
+        location.getKey(),
+        "it is still used by ${location.services.joinToString(", ") { it.serviceType.description }}",
+      )
+    }
+
+    val linkedTransaction = commonLocationService.createLinkedTransaction(
+      prisonId = location.prisonId,
+      TransactionType.LOCATION_UPDATE_NON_RESI,
+      "Hiding non-residential location ${location.getKey()} from the list",
+    )
+
+    location.hideFromList(commonLocationService.getUsername(), clock, linkedTransaction)
+
+    log.info("Non-residential location ${location.getKey()} hidden from the list")
+    commonLocationService.trackLocationUpdate(location, "Hid Non-Residential Location from the list")
+    linkedTransaction.txEndTime = LocalDateTime.now(clock)
+
+    return location.toNonResidentialDto()
+  }
+
   private fun getParentLocation(parentId: UUID?): Location? = parentId?.let {
     locationRepository.findById(parentId).getOrNull()
       ?: throw LocationNotFoundException(it.toString())
@@ -602,7 +643,7 @@ class NonResidentialService(
           }
         }
         if (statuses.isNotEmpty()) {
-          add(filterByStatuses(statuses))
+          add(filterByStatusesTreatingHiddenAsArchived(statuses))
         }
         if (locationTypes.isNotEmpty()) {
           add(filterByTypes(locationTypes.map { it.baseType }))
@@ -695,6 +736,22 @@ data class NonResidentialLocationDTO(
 
   @param:Schema(description = "Location hierarchy (ancestors and self), top to bottom", required = false)
   val locationHierarchy: List<LocationSummary>? = null,
+
+  @param:Schema(
+    description = "Indicates a user has removed this location from the non-residential locations list. " +
+      "Display only - the location is not deactivated and remains available to any service using it.",
+    example = "false",
+    required = true,
+  )
+  val hiddenFromList: Boolean = false,
+
+  @param:Schema(
+    description = "Indicates this location can be removed from the non-residential locations list, " +
+      "i.e. it is a parent location that no service uses",
+    example = "false",
+    required = true,
+  )
+  val canBeHiddenFromList: Boolean = false,
 ) {
   @Schema(description = "Key for a location", example = "MDI-ADJU", required = true)
   fun getKey(): String = "$prisonId-$pathHierarchy"

--- a/src/main/resources/db/migration/V1_98__add_hidden_from_list.sql
+++ b/src/main/resources/db/migration/V1_98__add_hidden_from_list.sql
@@ -1,0 +1,13 @@
+-- Lets a non-residential parent location be removed from the list shown in the
+-- non-residential locations UI once it has no services left using it.
+--
+-- This is deliberately NOT a deactivation. The location keeps its status, its children are
+-- untouched, and every service-facing endpoint behaves exactly as before - the flag only
+-- controls whether the location is offered in the non-residential summary listing.
+--
+-- NOT NULL DEFAULT FALSE: the column lives on the shared single-table-inheritance location table and
+-- is only mapped by non-residential locations. Defaulting it for every row - not just the
+-- non-residential ones - keeps it populated when a location is converted between types in place: the
+-- sync conversion issues a native UPDATE of the discriminator that does not touch this column, so it
+-- never ends up null on a row that has just become non-residential.
+ALTER TABLE location ADD COLUMN hidden_from_list BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/NonResidentialHideFromListIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/NonResidentialHideFromListIntTest.kt
@@ -1,0 +1,245 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocation
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ServiceType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.buildNonResidentialLocation
+
+/**
+ * Hiding a parent non-residential location removes it from the list users maintain, and nothing
+ * else. These tests pin down both halves of that: what changes in the listing, and what must
+ * stubbornly stay the same everywhere else.
+ */
+class NonResidentialHideFromListIntTest : CommonDataTestBase() {
+
+  private fun parentWithChild(
+    parentLocalName: String = "Parent Location",
+    childLocalName: String = "Child Location",
+    parentServiceTypes: Set<ServiceType> = emptySet(),
+    childServiceTypes: Set<ServiceType> = setOf(ServiceType.APPOINTMENT),
+  ): Pair<NonResidentialLocation, NonResidentialLocation> {
+    val parent = repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "PARENT",
+        localName = parentLocalName,
+        locationType = LocationType.LOCATION,
+        serviceTypes = parentServiceTypes,
+      ),
+    )
+    val child = repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "PARENT-CHILD",
+        localName = childLocalName,
+        locationType = LocationType.LOCATION,
+        serviceTypes = childServiceTypes,
+      ),
+    )
+    parent.addChildLocation(child)
+    return repository.save(parent) to child
+  }
+
+  private fun hide(id: Any) = webTestClient.put().uri("/locations/non-residential/$id/hide")
+    .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("read", "write")))
+    .exchange()
+
+  @Nested
+  inner class Security {
+    @Test
+    fun `requires authentication`() {
+      val (parent, _) = parentWithChild()
+
+      webTestClient.put().uri("/locations/non-residential/${parent.id}/hide")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `requires the MAINTAIN_LOCATIONS role`() {
+      val (parent, _) = parentWithChild()
+
+      webTestClient.put().uri("/locations/non-residential/${parent.id}/hide")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS"), scopes = listOf("read")))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+  }
+
+  @Nested
+  inner class Validation {
+    @Test
+    fun `returns not found for an unknown location`() {
+      hide("de91dfa7-821f-4552-a427-bf2f32eafeb0").expectStatus().isNotFound
+    }
+
+    @Test
+    fun `cannot hide a leaf location, which should be archived instead`() {
+      val (_, child) = parentWithChild()
+
+      hide(child.id!!)
+        .expectStatus().isEqualTo(409)
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(144)
+        .jsonPath("$.userMessage").value<String> { assert(it.contains("not a parent location")) }
+    }
+
+    @Test
+    fun `cannot hide a parent a service still uses`() {
+      val (parent, _) = parentWithChild(parentServiceTypes = setOf(ServiceType.APPOINTMENT))
+
+      hide(parent.id!!)
+        .expectStatus().isEqualTo(409)
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(144)
+        .jsonPath("$.userMessage").value<String> { assert(it.contains("still used by")) }
+    }
+
+    @Test
+    fun `cannot hide a parent that is already hidden`() {
+      val (parent, _) = parentWithChild()
+
+      hide(parent.id!!).expectStatus().isOk
+      hide(parent.id!!)
+        .expectStatus().isEqualTo(409)
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(144)
+        .jsonPath("$.userMessage").value<String> { assert(it.contains("already hidden")) }
+    }
+  }
+
+  @Nested
+  inner class Hiding {
+    @Test
+    fun `hides a parent with no services and reports it as hidden`() {
+      val (parent, _) = parentWithChild()
+
+      hide(parent.id!!)
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.hiddenFromList").isEqualTo(true)
+        .jsonPath("$.canBeHiddenFromList").isEqualTo(false)
+        // Crucially, the location is NOT deactivated
+        .jsonPath("$.status").isEqualTo("ACTIVE")
+        .jsonPath("$.permanentlyInactive").isEqualTo(false)
+    }
+
+    @Test
+    fun `flags a parent with no services as hideable, and a leaf or used parent as not`() {
+      val (parent, child) = parentWithChild()
+
+      webTestClient.get().uri("/locations/non-residential/${parent.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.canBeHiddenFromList").isEqualTo(true)
+        .jsonPath("$.hiddenFromList").isEqualTo(false)
+
+      // A leaf location is archived, never hidden
+      webTestClient.get().uri("/locations/non-residential/${child.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.canBeHiddenFromList").isEqualTo(false)
+    }
+
+    @Test
+    fun `a parent is not hideable while a service that does not show against it still uses it`() {
+      // ADJUDICATIONS is not editableInParent, so it never appears in usedByGroupedServices for a
+      // parent. The API must still refuse to hide the location, since the service really does use it.
+      val (parent, _) = parentWithChild(parentServiceTypes = setOf(ServiceType.HEARING_LOCATION))
+
+      webTestClient.get().uri("/locations/non-residential/${parent.id}")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.usedByGroupedServices").isEmpty
+        .jsonPath("$.canBeHiddenFromList").isEqualTo(false)
+    }
+  }
+
+  @Nested
+  inner class ListFiltering {
+    private fun summary(query: String) = webTestClient.get().uri("/locations/non-residential/summary/MDI$query")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+
+    @Test
+    fun `a hidden parent drops out of the active list and appears under archived`() {
+      val (parent, _) = parentWithChild()
+
+      summary("?status=ACTIVE").jsonPath("$.locations.content[?(@.localName == 'Parent Location')]").exists()
+
+      hide(parent.id!!).expectStatus().isOk
+
+      summary("?status=ACTIVE").jsonPath("$.locations.content[?(@.localName == 'Parent Location')]").doesNotExist()
+      summary("?status=INACTIVE").jsonPath("$.locations.content[?(@.localName == 'Parent Location')]").doesNotExist()
+      summary("?status=ARCHIVED").jsonPath("$.locations.content[?(@.localName == 'Parent Location')]").exists()
+    }
+
+    @Test
+    fun `hiding a parent leaves its children in the list, still active`() {
+      val (parent, _) = parentWithChild()
+
+      hide(parent.id!!).expectStatus().isOk
+
+      summary("?status=ACTIVE")
+        .jsonPath("$.locations.content[?(@.localName == 'Child Location')]").exists()
+        .jsonPath("$.locations.content[?(@.localName == 'Child Location')].status").isEqualTo("ACTIVE")
+        .jsonPath("$.locations.content[?(@.localName == 'Child Location')].permanentlyInactive").isEqualTo(false)
+    }
+
+    @Test
+    fun `a genuinely archived location is still only returned under archived`() {
+      val (_, child) = parentWithChild()
+
+      webTestClient.put().uri("/locations/${child.id}/deactivate/permanent")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("read", "write")))
+        .bodyValue(mapOf("reason" to "Demolished"))
+        .exchange()
+        .expectStatus().isOk
+
+      summary("?status=ACTIVE").jsonPath("$.locations.content[?(@.localName == 'Child Location')]").doesNotExist()
+      summary("?status=ARCHIVED").jsonPath("$.locations.content[?(@.localName == 'Child Location')]").exists()
+    }
+  }
+
+  @Nested
+  inner class ServicesAreUnaffected {
+    @Test
+    fun `a child of a hidden parent is still returned to the service that uses it`() {
+      val (parent, _) = parentWithChild()
+
+      hide(parent.id!!).expectStatus().isOk
+
+      webTestClient.get().uri("/locations/non-residential/prison/MDI/service/APPOINTMENT")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$[?(@.localName == 'Child Location')]").exists()
+    }
+
+    @Test
+    fun `a child of a hidden parent is still an active location for the prison`() {
+      val (parent, _) = parentWithChild()
+
+      hide(parent.id!!).expectStatus().isOk
+
+      webTestClient.get().uri("/locations/prison/MDI/non-residential")
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$[?(@.localName == 'Child Location')]").exists()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialServiceTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsag
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.ServiceType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LinkedTransactionRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.NonResidentialLocationRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationCannotBeHiddenFromListException
 import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
 import java.time.Clock
 import java.time.LocalDateTime
@@ -153,6 +154,58 @@ class NonResidentialServiceTest {
     verify(nonResidentialLocationRepository, times(1)).save(captor.capture())
     val savedLocation = captor.firstValue
     Assertions.assertThat(savedLocation.services.map { it.serviceType }).containsExactlyInAnyOrder(ServiceType.APPOINTMENT, ServiceType.PROGRAMMES_AND_ACTIVITIES)
+  }
+
+  @Test
+  fun `hideFromList hides a parent that has no services`() {
+    val parent = buildLocation("Parent")
+    val child = buildLocation("Child")
+    parent.addChildLocation(child)
+
+    whenever(nonResidentialLocationRepository.findById(parent.id!!)).thenReturn(Optional.of(parent))
+    whenever(sharedLocationService.getUsername()).thenReturn("test-user")
+    whenever(sharedLocationService.createLinkedTransaction(any(), any(), any(), anyOrNull())).thenReturn(mock())
+
+    val result = service.hideFromList(parent.id!!)
+
+    Assertions.assertThat(result.hiddenFromList).isTrue()
+    Assertions.assertThat(parent.isHiddenFromList()).isTrue()
+    // Not a deactivation
+    Assertions.assertThat(parent.status).isEqualTo(LocationStatus.ACTIVE)
+  }
+
+  @Test
+  fun `hideFromList rejects a leaf location`() {
+    val leaf = buildLocation("Leaf")
+    whenever(nonResidentialLocationRepository.findById(leaf.id!!)).thenReturn(Optional.of(leaf))
+
+    Assertions.assertThatThrownBy { service.hideFromList(leaf.id!!) }
+      .isInstanceOf(LocationCannotBeHiddenFromListException::class.java)
+      .hasMessageContaining("not a parent location")
+  }
+
+  @Test
+  fun `hideFromList rejects a parent still used by a service`() {
+    val parent = buildLocation("Parent")
+    parent.addChildLocation(buildLocation("Child"))
+    parent.addService(ServiceType.APPOINTMENT)
+    whenever(nonResidentialLocationRepository.findById(parent.id!!)).thenReturn(Optional.of(parent))
+
+    Assertions.assertThatThrownBy { service.hideFromList(parent.id!!) }
+      .isInstanceOf(LocationCannotBeHiddenFromListException::class.java)
+      .hasMessageContaining("still used by")
+  }
+
+  @Test
+  fun `hideFromList rejects a parent that is already hidden`() {
+    val parent = buildLocation("Parent")
+    parent.addChildLocation(buildLocation("Child"))
+    parent.hideFromList("someone", clock, mock())
+    whenever(nonResidentialLocationRepository.findById(parent.id!!)).thenReturn(Optional.of(parent))
+
+    Assertions.assertThatThrownBy { service.hideFromList(parent.id!!) }
+      .isInstanceOf(LocationCannotBeHiddenFromListException::class.java)
+      .hasMessageContaining("already hidden")
   }
 
   private fun buildLocation(localName: String): NonResidentialLocation = NonResidentialLocation(


### PR DESCRIPTION
## What

Adds a `hiddenFromList` flag on non-residential locations and a `PUT /locations/non-residential/{id}/hide` endpoint to set it.

This is deliberately **not** a deactivation. Parent locations accumulate as the Activities and Appointments team migrate bookings off them onto their children; once a parent has no services left it is dead weight in the non-residential locations list, and users need a way to put it out of sight. Hiding it changes nothing else — its status stays as it was, its children are untouched, and every service-facing endpoint behaves exactly as before.

- Only a parent location that no service uses can be hidden (enforced server-side; 409 otherwise). A leaf location is archived instead.
- The DTO gains `hiddenFromList` and `canBeHiddenFromList`. `canBeHiddenFromList` is computed here because a parent can carry services (e.g. ADJUDICATIONS) that never surface in `usedByGroupedServices`, so the UI cannot infer eligibility itself.
- In the summary listing, a hidden parent is treated as archived: it leaves the active/inactive results and appears under the archived filter, while remaining fully available to anything that looks it up directly (`getByPrisonAndServiceType`, `getActiveNonResidentialLocationsForPrison`, `getPropertyLocations` and the sync path are untouched).
- The change is emitted as `LOCATION_AMENDED`, not deactivated, because nothing was deactivated.

## Migration

`V1_98__add_hidden_from_list.sql` adds a nullable boolean, defaults existing non-residential rows to `FALSE`, and constrains it to non-residential rows only — same pattern as `internal_movement_allowed` (V1_66) and `temporarily_off_cell_cert` (V1_88).

## Testing

- New `NonResidentialHideFromListIntTest` covers security, the 409 guards (leaf / still-used / already hidden), the list filtering (hidden parent leaves active, appears under archived, children stay active and still served to consumers), and that a genuine archive still behaves as before.
- Unit tests in `NonResidentialServiceTest` for the guard conditions.
- Full test suite (112 in the affected classes) green locally.