### PR TITLE
MAPB-694 Fix non-residential archiving and archived-child status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -97,6 +97,12 @@ class NonResidentialLocation(
 
   override fun hasDeactivatedParent() = false
 
+  // A non-residential location's status reflects only its own state, never an ancestor's. The base
+  // implementation walks up the tree and treats a location under an archived parent as archived,
+  // but non-residential children are independent of their parents (see MAPB-670, and
+  // hasDeactivatedParent above which already ignores inactive parents) - so consider only own status.
+  override fun isPermanentlyDeactivated() = isArchived()
+
   fun isHiddenFromList() = hiddenFromList
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
@@ -445,6 +445,21 @@ class ApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(NonResidentialParentCannotBeArchivedException::class)
+  fun handleNonResidentialParentCannotBeArchived(e: NonResidentialParentCannotBeArchivedException): ResponseEntity<ErrorResponse> {
+    log.debug("Attempt to archive a non-residential parent: {}", e.message)
+    return ResponseEntity
+      .status(CONFLICT)
+      .body(
+        ErrorResponse(
+          status = CONFLICT,
+          errorCode = ErrorCode.NonResidentialParentCannotBeArchived,
+          userMessage = "Non-residential parent cannot be archived: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
   @ExceptionHandler(ReasonForDeactivationMustBeProvidedException::class)
   fun handleReasonForDeactivationMustBeProvided(e: ReasonForDeactivationMustBeProvidedException): ResponseEntity<ErrorResponse> {
     log.debug("De-activating location requires a reason when using OTHER reason type: {}", e.message)
@@ -789,6 +804,7 @@ class ReasonForDeactivationMustBeProvidedException(key: String) : Exception("De-
 class LocationCannotBeReactivatedException(key: String) : Exception("Location cannot be reactivated if parent is deactivated = $key")
 class LocationCannotBeUnarchivedException(key: String) : Exception("Location is not archived so cannot be un-archived = $key")
 class LocationCannotBeHiddenFromListException(key: String, reason: String) : Exception("Location $key cannot be hidden from the non-residential list: $reason")
+class NonResidentialParentCannotBeArchivedException(key: String) : Exception("Non-residential parent $key cannot be archived - remove it from the list (hide) instead")
 class AlreadyDeactivatedLocationException(key: String) : ValidationException("$key: Cannot deactivate an already deactivated location")
 class CapacityException(val key: String, override val message: String, val errorCode: ErrorCode) : ValidationException("$key: [Error Code: $errorCode] - Capacity Exception: $message")
 class PermanentlyDeactivatedUpdateNotAllowedException(key: String) : ValidationException("Location $key cannot be updated as has been permanently deactivated")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
@@ -51,4 +51,5 @@ enum class ErrorCode(val errorCode: Int) {
   PendingApprovalExistsBelowLocation(142),
   LocationCannotBeUnarchived(143),
   LocationCannotBeHiddenFromList(144),
+  NonResidentialParentCannotBeArchived(145),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/LocationService.kt
@@ -77,6 +77,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationConta
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationPrefixNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.LocationResidentialResource.AllowedAccommodationTypeForConversion
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.NonResidentialParentCannotBeArchivedException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PendingApprovalOnLocationCannotBeUpdatedException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PermanentDeactivationRequiresApprovalException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PermanentlyDeactivatedUpdateNotAllowedException
@@ -1124,16 +1125,24 @@ class LocationService(
   ): List<LocationDTO> {
     val deactivatedLocations = mutableSetOf<Location>()
 
-    val prisonId = permanentDeactivationRequest.locations.firstOrNull()?.let { key ->
-      val prisonId = locationRepository.findOneByKey(key)?.prisonId ?: throw LocationNotFoundException(key)
-      val certificationApprovalRequired = activePrisonService.isCertificationApprovalRequired(prisonId)
+    // Resolve and validate the whole request up-front, before opening a transaction, so a bad key
+    // anywhere in the batch fails cleanly rather than after partial work.
+    val locations = permanentDeactivationRequest.locations
+      .ifEmpty { throw LocationNotFoundException("No location found in request") }
+      .map { key -> locationRepository.findOneByKey(key) ?: throw LocationNotFoundException(key) }
 
-      if (certificationApprovalRequired) {
-        throw BulkPermanentDeactivationNotAllowedException(prisonId)
-      }
+    // A non-residential parent must be hidden, not archived (MAPB-670) - reject if any key is one.
+    locations.firstOrNull { it.isNonResidential() && !it.isLeafLevel() }?.let {
+      throw NonResidentialParentCannotBeArchivedException(it.getKey())
+    }
 
-      prisonId
-    } ?: throw LocationNotFoundException("No location found in request")
+    val prisonId = locations.first().prisonId
+
+    // Certification approval is a residential-only concern, so it only blocks the batch when it
+    // contains a residential location; a purely non-residential batch is never gated by it.
+    if (locations.any { !it.isNonResidential() } && activePrisonService.isCertificationApprovalRequired(prisonId)) {
+      throw BulkPermanentDeactivationNotAllowedException(prisonId)
+    }
 
     val linkedTransaction = sharedLocationService.createLinkedTransaction(
       prisonId = prisonId,
@@ -1141,9 +1150,7 @@ class LocationService(
       "Permanently deactivating locations",
     )
 
-    permanentDeactivationRequest.locations.forEach { key ->
-      val locationToPermanentlyDeactivate = locationRepository.findOneByKey(key) ?: throw LocationNotFoundException(key)
-
+    locations.forEach { locationToPermanentlyDeactivate ->
       if (locationToPermanentlyDeactivate.permanentlyDeactivate(
           reason = permanentDeactivationRequest.reason,
           deactivatedDate = now(clock),
@@ -1261,7 +1268,14 @@ class LocationService(
     val locationToArchive = locationRepository.findById(id)
       .orElseThrow { LocationNotFoundException(id.toString()) }
 
-    if (activePrisonService.isCertificationApprovalRequired(locationToArchive.prisonId)) {
+    // A non-residential parent must be removed from the list (hidden), not archived - archiving is
+    // for leaf locations only (see MAPB-670).
+    if (locationToArchive.isNonResidential() && !locationToArchive.isLeafLevel()) {
+      throw NonResidentialParentCannotBeArchivedException(locationToArchive.getKey())
+    }
+
+    // Certification approval is a residential-only concern; non-residential archiving is never gated by it.
+    if (!locationToArchive.isNonResidential() && activePrisonService.isCertificationApprovalRequired(locationToArchive.prisonId)) {
       throw PermanentDeactivationRequiresApprovalException(locationToArchive.getKey())
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/NonResidentialHideFromListIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/NonResidentialHideFromListIntTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
 
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.LocationStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialLocation
@@ -209,6 +210,143 @@ class NonResidentialHideFromListIntTest : CommonDataTestBase() {
 
       summary("?status=ACTIVE").jsonPath("$.locations.content[?(@.localName == 'Child Location')]").doesNotExist()
       summary("?status=ARCHIVED").jsonPath("$.locations.content[?(@.localName == 'Child Location')]").exists()
+    }
+  }
+
+  @Nested
+  inner class Archiving {
+    private fun archive(id: Any) = webTestClient.put().uri("/locations/$id/deactivate/permanent")
+      .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("read", "write")))
+      .bodyValue(mapOf("reason" to "Demolished"))
+      .exchange()
+
+    @Test
+    fun `can archive a non-residential leaf in a prison that requires certification approval`() {
+      // LEI has certificationApprovalRequired = true. Certification is residential-only, so it must
+      // not block non-residential archiving (previously returned 400, errorCode 136).
+      val leaf = repository.save(
+        buildNonResidentialLocation(
+          prisonId = "LEI",
+          pathHierarchy = "GYM",
+          localName = "Gym",
+          serviceTypes = setOf(ServiceType.APPOINTMENT),
+        ),
+      )
+
+      archive(leaf.id!!).expectStatus().isOk
+    }
+
+    @Test
+    fun `cannot archive a non-residential parent - it must be hidden instead`() {
+      val (parent, _) = parentWithChild()
+
+      archive(parent.id!!)
+        .expectStatus().isEqualTo(409)
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(145)
+    }
+
+    @Test
+    fun `a non-residential leaf can still be archived`() {
+      val (_, child) = parentWithChild()
+
+      archive(child.id!!).expectStatus().isOk
+    }
+
+    private fun bulkArchive(vararg keys: String) = webTestClient.put().uri("/locations/bulk/deactivate/permanent")
+      .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS"), scopes = listOf("read", "write")))
+      .bodyValue(mapOf("reason" to "Demolished", "locations" to keys.toList()))
+      .exchange()
+
+    @Test
+    fun `cannot bulk-archive a non-residential parent`() {
+      val (parent, _) = parentWithChild()
+
+      bulkArchive(parent.getKey())
+        .expectStatus().isEqualTo(409)
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(145)
+    }
+
+    @Test
+    fun `a certification prison still blocks a bulk that includes a residential location, even behind a non-residential key`() {
+      // LEI requires certification approval. A non-residential key first must not let a residential
+      // location slip through the gate - the whole batch is validated, not just the first key.
+      val nonResiLeaf = repository.save(
+        buildNonResidentialLocation(
+          prisonId = "LEI",
+          pathHierarchy = "GYM",
+          localName = "Gym",
+          serviceTypes = setOf(ServiceType.APPOINTMENT),
+        ),
+      )
+      val residentialCell = leedsWing.findAllLeafLocations().first()
+
+      bulkArchive(nonResiLeaf.getKey(), residentialCell.getKey())
+        .expectStatus().isBadRequest
+        .expectBody()
+        .jsonPath("$.errorCode").isEqualTo(137)
+    }
+  }
+
+  @Nested
+  inner class ChildOfArchivedParentUsesOwnStatus {
+    private fun summary(query: String) = webTestClient.get().uri("/locations/non-residential/summary/MDI$query")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+
+    // Build the archived-parent state directly (the archive endpoint now refuses to archive a
+    // parent), so we can pin down how its still-active child is reported.
+    private fun archivedParentWithActiveChild(): NonResidentialLocation {
+      val parent = repository.save(
+        buildNonResidentialLocation(
+          prisonId = "MDI",
+          pathHierarchy = "PARENT",
+          localName = "Archived Parent",
+          locationType = LocationType.LOCATION,
+          status = LocationStatus.ARCHIVED,
+        ),
+      )
+      val child = repository.save(
+        buildNonResidentialLocation(
+          prisonId = "MDI",
+          pathHierarchy = "PARENT-CHILD",
+          localName = "Active Child",
+          locationType = LocationType.LOCATION,
+          status = LocationStatus.ACTIVE,
+          serviceTypes = setOf(ServiceType.APPOINTMENT),
+        ),
+      )
+      parent.addChildLocation(child)
+      repository.save(parent)
+      return child
+    }
+
+    @Test
+    fun `a child of an archived parent reports its own active status`() {
+      archivedParentWithActiveChild()
+
+      summary("?status=ACTIVE")
+        .jsonPath("$.locations.content[?(@.localName == 'Active Child')]").exists()
+        .jsonPath("$.locations.content[?(@.localName == 'Active Child')].status").isEqualTo("ACTIVE")
+        .jsonPath("$.locations.content[?(@.localName == 'Active Child')].permanentlyInactive").isEqualTo(false)
+    }
+
+    @Test
+    fun `a child of an archived parent does not appear under the archived filter`() {
+      archivedParentWithActiveChild()
+
+      summary("?status=ARCHIVED").jsonPath("$.locations.content[?(@.localName == 'Active Child')]").doesNotExist()
+    }
+
+    @Test
+    fun `the archived parent itself still appears only under archived`() {
+      archivedParentWithActiveChild()
+
+      summary("?status=ACTIVE").jsonPath("$.locations.content[?(@.localName == 'Archived Parent')]").doesNotExist()
+      summary("?status=ARCHIVED").jsonPath("$.locations.content[?(@.localName == 'Archived Parent')]").exists()
     }
   }
 


### PR DESCRIPTION
Three related non-residential fixes found testing on dev.

## 1. Archiving failed in certification prisons

`PUT /locations/{id}/deactivate/permanent` rejected with errorCode 136 whenever the prison had certification approval turned on — but certification is a residential-only concern (cell certificates), so non-residential archiving was wrongly blocked. Both the single (`permanentlyDeactivateLocation`) and the bulk (`permanentlyDeactivateLocations`, which the single path calls) certification checks are now gated to residential locations. Residential behaviour is unchanged.

## 2. Archived-looking children leaked into the Active list

A non-residential child of an **archived parent** derived status `ARCHIVED` (because `Location.isPermanentlyDeactivated()` walks *up* the tree) while its own `status` column stayed `ACTIVE`. The summary filters on the stored column, so the child appeared under the Active filter while showing an "Archived" tag ("Bledd Test").

`NonResidentialLocation` now overrides `isPermanentlyDeactivated()` to consider **only its own status**, never an ancestor's — completing the MAPB-670 model where non-residential children are independent of their parents (already true for *inactive* parents via `hasDeactivatedParent() = false`). The derived status now equals the stored column, so the existing filter is correct with no filter or data change. Accepted consequence: children of archived parents are treated as active throughout (including for consuming services), consistent with "children unaffected by parent".

## 3. Non-residential parents can no longer be archived

Archiving a non-residential **parent** is now rejected (new errorCode 145) — parents must be removed from the list (hidden-from-list, MAPB-670) instead. This is what created the archived-parent data behind #2; blocking it prevents recurrence. Existing archived parents need no data fix — #2 makes their children display correctly.

## Testing

- New integration tests in `NonResidentialHideFromListIntTest`: archive a non-resi leaf in a certification prison (LEI) succeeds; archiving a non-resi parent is a 409; a child of an archived parent reports its own `ACTIVE` status, sits under `?status=ACTIVE`, and is absent from `?status=ARCHIVED`, while the parent shows only under archived.
- Full suite green (938 tests) — #2 changes shared status derivation and nothing depended on the old inherited behaviour.