### PR TITLE
MAPB-720 Reinstate a removed property location when added back by the same name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/NonResidentialLocation.kt
@@ -114,6 +114,23 @@ class NonResidentialLocation(
   fun canBeHiddenFromList() = !isLeafLevel() && services.isEmpty() && !isHiddenFromList()
 
   /**
+   * Whether this location may have a property designation put back on it (see
+   * NonResidentialService.createPropertyLocation). Removing a property location only drops its PROPERTY
+   * usage - the location itself lives on - so a user who removes one and then adds it again by the same
+   * name should get the original location back rather than a name clash.
+   *
+   * Deliberately narrow: only something that looks like a property location whose designation was removed
+   * qualifies - a BOX with no usages and no services left on it. That keeps an unrelated location which
+   * merely shares the name (a visit room, or a store a service still owns) from being quietly turned into
+   * property storage. Archived locations are excluded: they are genuinely finished with, and unarchiving is
+   * the deliberate route back.
+   */
+  fun canBeReinstatedAsPropertyLocation() = locationType == LocationType.BOX &&
+    toUsageTypes().isEmpty() &&
+    services.isEmpty() &&
+    !isArchived()
+
+  /**
    * Removes this location from the list shown in the non-residential locations UI.
    *
    * This is not a deactivation and must not be confused with one. Nothing about the location

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/LocationNonResidentialResource.kt
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -634,12 +635,15 @@ class LocationNonResidentialResource(
 
   @PostMapping("/prison/{prisonId}/property", produces = [MediaType.APPLICATION_JSON_VALUE])
   @PreAuthorize("hasRole('ROLE_MANAGE_PROPERTY_LOCATIONS') and hasAuthority('SCOPE_write')")
-  @ResponseStatus(HttpStatus.CREATED)
   @Operation(
-    summary = "Create a new property storage location for a prison",
+    summary = "Create a property storage location for a prison, or reinstate one that was removed",
     description = "Creates a top-level BOX location with an auto-generated code and a PROPERTY usage carrying the " +
-      "given capacity. Requires role MANAGE_PROPERTY_LOCATIONS and write scope",
+      "given capacity. Removing a property location only drops its PROPERTY usage, so where a location of this " +
+      "name had its designation removed it is reinstated with the given capacity - keeping its id, code and " +
+      "history - and 200 is returned instead of 201. " +
+      "Requires role MANAGE_PROPERTY_LOCATIONS and write scope",
     responses = [
+      ApiResponse(responseCode = "200", description = "Returns the property location that was reinstated"),
       ApiResponse(responseCode = "201", description = "Returns the created property location"),
       ApiResponse(
         responseCode = "400",
@@ -672,10 +676,18 @@ class LocationNonResidentialResource(
     @PathVariable
     prisonId: String,
     @RequestBody @Validated request: CreatePropertyLocationRequest,
-  ): PropertyLocationDto {
-    val (propertyLocation, location) = nonResidentialService.createPropertyLocation(prisonId, request)
-    eventPublishNonResiAndAudit(InternalLocationDomainEventType.LOCATION_CREATED) { location }
-    return propertyLocation
+  ): ResponseEntity<PropertyLocationDto> {
+    val result = nonResidentialService.createPropertyLocation(prisonId, request)
+    // A reinstated location already exists downstream, so it is amended rather than created - announcing a
+    // creation would have NOMIS try to add a location it already holds.
+    val event = if (result.reinstated) {
+      InternalLocationDomainEventType.LOCATION_AMENDED
+    } else {
+      InternalLocationDomainEventType.LOCATION_CREATED
+    }
+    eventPublishNonResiAndAudit(event) { result.location }
+    val status = if (result.reinstated) HttpStatus.OK else HttpStatus.CREATED
+    return ResponseEntity.status(status).body(result.propertyLocation)
   }
 
   @PutMapping("/property/{id}", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -241,10 +241,11 @@ class NonResidentialService(
    * or null when there is none. The name match is case-insensitive (in the query), and where more than one
    * candidate somehow shares the name the oldest is chosen so the outcome is deterministic.
    */
-  private fun findReinstatablePropertyLocation(prisonId: String, localName: String): NonResidentialLocation? = nonResidentialLocationRepository
-    .findAllByPrisonIdAndLocalName(prisonId = prisonId, localName = localName)
-    .filter { it.canBeReinstatedAsPropertyLocation() }
-    .minByOrNull { it.whenCreated }
+private fun findReinstatablePropertyLocation(prisonId: String, localName: String): NonResidentialLocation? = nonResidentialLocationRepository
+  .findAllByPrisonIdAndLocalName(prisonId = prisonId, localName = localName)
+  .asSequence()
+  .filter { it.canBeReinstatedAsPropertyLocation() }
+  .minWithOrNull(compareBy<NonResidentialLocation> { it.whenCreated }.thenBy { it.getKey() })
 
   /** Put the property designation back on [location], with the capacity from [request]. */
   private fun reinstatePropertyLocation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -241,11 +241,11 @@ class NonResidentialService(
    * or null when there is none. The name match is case-insensitive (in the query), and where more than one
    * candidate somehow shares the name the oldest is chosen so the outcome is deterministic.
    */
-private fun findReinstatablePropertyLocation(prisonId: String, localName: String): NonResidentialLocation? = nonResidentialLocationRepository
-  .findAllByPrisonIdAndLocalName(prisonId = prisonId, localName = localName)
-  .asSequence()
-  .filter { it.canBeReinstatedAsPropertyLocation() }
-  .minWithOrNull(compareBy<NonResidentialLocation> { it.whenCreated }.thenBy { it.getKey() })
+  private fun findReinstatablePropertyLocation(prisonId: String, localName: String): NonResidentialLocation? = nonResidentialLocationRepository
+    .findAllByPrisonIdAndLocalName(prisonId = prisonId, localName = localName)
+    .asSequence()
+    .filter { it.canBeReinstatedAsPropertyLocation() }
+    .minWithOrNull(compareBy<NonResidentialLocation> { it.whenCreated }.thenBy { it.getKey() })
 
   /** Put the property designation back on [location], with the capacity from [request]. */
   private fun reinstatePropertyLocation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/NonResidentialService.kt
@@ -174,15 +174,27 @@ class NonResidentialService(
   }
 
   /**
-   * Create a new top-level BOX property storage location with a generated code and a PROPERTY usage
-   * carrying the given capacity. Returns the slim property DTO for the caller plus the full
-   * non-residential DTO for the domain event (so NOMIS is notified of the new usage/capacity).
+   * Make a property storage location available in a prison, either by reinstating one or by creating a new one.
+   *
+   * Removing a property location only drops its PROPERTY usage - the location itself lives on - so a user who
+   * removes one and then adds it back by the same name is really asking for the original location again, not a
+   * second record. When such a location exists (see [NonResidentialLocation.canBeReinstatedAsPropertyLocation])
+   * its designation is put back with the newly requested capacity, keeping its id, code and history; otherwise
+   * a new top-level BOX location is created with a generated code. Reinstating also avoids the code drift a
+   * duplicate would suffer, since [generateUniqueNonResidentialCode] lengthens the code when the natural one
+   * is taken.
+   *
+   * [PropertyLocationWriteResult.reinstated] tells the caller which happened, so it can report the right
+   * status and raise an amended rather than a created event - NOMIS already knows about a reinstated location.
    */
   @Transactional
   fun createPropertyLocation(
     prisonId: String,
     request: CreatePropertyLocationRequest,
-  ): Pair<PropertyLocationDto, NonResidentialLocationDTO> {
+  ): PropertyLocationWriteResult {
+    findReinstatablePropertyLocation(prisonId, request.localName)
+      ?.let { return reinstatePropertyLocation(it, request) }
+
     validateLocalNameNotDuplicated(prisonId, request.localName)
 
     val code = generateUniqueNonResidentialCode(prisonId, request.localName)
@@ -221,7 +233,40 @@ class NonResidentialService(
     commonLocationService.trackLocationUpdate(created, "Created Property Location")
     linkedTransaction.txEndTime = LocalDateTime.now(clock)
 
-    return created.toPropertyLocationDto() to created.toNonResidentialDto()
+    return PropertyLocationWriteResult(created.toPropertyLocationDto(), created.toNonResidentialDto(), reinstated = false)
+  }
+
+  /**
+   * The location in [prisonId] named [localName] whose property designation was removed and can be put back,
+   * or null when there is none. The name match is case-insensitive (in the query), and where more than one
+   * candidate somehow shares the name the oldest is chosen so the outcome is deterministic.
+   */
+  private fun findReinstatablePropertyLocation(prisonId: String, localName: String): NonResidentialLocation? = nonResidentialLocationRepository
+    .findAllByPrisonIdAndLocalName(prisonId = prisonId, localName = localName)
+    .filter { it.canBeReinstatedAsPropertyLocation() }
+    .minByOrNull { it.whenCreated }
+
+  /** Put the property designation back on [location], with the capacity from [request]. */
+  private fun reinstatePropertyLocation(
+    location: NonResidentialLocation,
+    request: CreatePropertyLocationRequest,
+  ): PropertyLocationWriteResult {
+    val username = commonLocationService.getUsername()
+    val linkedTransaction = commonLocationService.createLinkedTransaction(
+      prisonId = location.prisonId,
+      TransactionType.LOCATION_UPDATE_NON_RESI,
+      "Reinstate property designation on ${location.getKey()}",
+    )
+
+    // Records the usage coming back (and any capacity change) in history; the location was not created now,
+    // so no LOCATION_CREATED history is added.
+    location.setPropertyCapacity(request.capacity, username, clock, linkedTransaction)
+
+    log.info("Property location ${location.id} reinstated in ${location.prisonId}")
+    commonLocationService.trackLocationUpdate(location, "Reinstated Property Location")
+    linkedTransaction.txEndTime = LocalDateTime.now(clock)
+
+    return PropertyLocationWriteResult(location.toPropertyLocationDto(), location.toNonResidentialDto(), reinstated = true)
   }
 
   /**
@@ -662,6 +707,18 @@ class NonResidentialService(
     return NonResidentialSummary(prisonId = prisonId, locations = locations)
   }
 }
+
+/**
+ * The outcome of making a property storage location available: the slim [propertyLocation] DTO for the
+ * caller, the full [location] DTO for the domain event, and whether an existing location's designation was
+ * [reinstated] rather than a new location created. The caller uses [reinstated] to report the right status and
+ * to raise an amended rather than a created event.
+ */
+data class PropertyLocationWriteResult(
+  val propertyLocation: PropertyLocationDto,
+  val location: NonResidentialLocationDTO,
+  val reinstated: Boolean,
+)
 
 @Schema(description = "Non Residential Summary")
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PropertyLocationManagementIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PropertyLocationManagementIntTest.kt
@@ -6,6 +6,8 @@ import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.PropertyLocationDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LocationType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.NonResidentialUsageType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.buildNonResidentialLocation
 
 class PropertyLocationManagementIntTest : CommonDataTestBase() {
 
@@ -20,6 +22,11 @@ class PropertyLocationManagementIntTest : CommonDataTestBase() {
     .expectStatus().isCreated
     .expectBody(PropertyLocationDto::class.java)
     .returnResult().responseBody!!
+
+  private fun removePropertyLocation(id: java.util.UUID) = webTestClient.delete().uri("/locations/property/$id")
+    .headers(manageHeaders())
+    .exchange()
+    .expectStatus().isOk
 
   @Test
   fun `create requires the MANAGE_PROPERTY_LOCATIONS role`() {
@@ -100,6 +107,100 @@ class PropertyLocationManagementIntTest : CommonDataTestBase() {
       .headers(manageHeaders())
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue("""{ "localName": "Duplicate store", "capacity": 10 }""")
+      .exchange()
+      .expectStatus().isEqualTo(409)
+  }
+
+  /**
+   * Removing a property location only drops its PROPERTY usage, so adding it back by the same name must give
+   * the original location again rather than a name clash - the user thinks they deleted it and are simply
+   * re-adding it.
+   */
+  @Test
+  fun `adding a removed property location back by the same name reinstates it`() {
+    val original = createPropertyLocation("Reception store", 10)
+    removePropertyLocation(original.id)
+
+    val reinstated = webTestClient.post().uri("/locations/prison/MDI/property")
+      .headers(manageHeaders())
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue("""{ "localName": "Reception store", "capacity": 25 }""")
+      .exchange()
+      // 200, not 201 - nothing was created
+      .expectStatus().isOk
+      .expectBody(PropertyLocationDto::class.java)
+      .returnResult().responseBody!!
+
+    // the same underlying location, keeping its id and code, with the newly requested capacity
+    assertThat(reinstated.id).isEqualTo(original.id)
+    assertThat(reinstated.code).isEqualTo(original.code)
+    assertThat(reinstated.capacity).isEqualTo(25)
+
+    // and it appears once in the property list, not twice
+    webTestClient.get().uri("/locations/prison/MDI/property")
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LOCATIONS")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$[?(@.localName == 'Reception Store')]").value<List<*>> { assertThat(it).hasSize(1) }
+      .jsonPath("$[?(@.localName == 'Reception Store')].capacity").isEqualTo(25)
+  }
+
+  @Test
+  fun `reinstates regardless of the case the name is typed in`() {
+    val original = createPropertyLocation("Reception store", 10)
+    removePropertyLocation(original.id)
+
+    webTestClient.post().uri("/locations/prison/MDI/property")
+      .headers(manageHeaders())
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue("""{ "localName": "reception STORE", "capacity": 15 }""")
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.id").isEqualTo(original.id.toString())
+      .jsonPath("$.capacity").isEqualTo(15)
+  }
+
+  /**
+   * A reinstated location already exists downstream, so it must be announced as amended. Publishing a
+   * creation would have NOMIS try to add a location it already holds.
+   */
+  @Test
+  fun `reinstating announces the location as amended, not created`() {
+    val original = createPropertyLocation("Reception store", 10)
+    removePropertyLocation(original.id)
+    purgeDomainEvents()
+
+    webTestClient.post().uri("/locations/prison/MDI/property")
+      .headers(manageHeaders())
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue("""{ "localName": "Reception store", "capacity": 25 }""")
+      .exchange()
+      .expectStatus().isOk
+
+    getDomainEvents(1).let { events ->
+      assertThat(events.map { it.eventType }).containsExactly("location.inside.prison.amended")
+    }
+  }
+
+  @Test
+  fun `still rejects a name held by a location that was never property storage`() {
+    // A visit room sharing the name must not be quietly turned into property storage.
+    repository.save(
+      buildNonResidentialLocation(
+        prisonId = "MDI",
+        pathHierarchy = "VISITRM",
+        localName = "Shared name",
+        locationType = LocationType.ROOM,
+        usageTypes = setOf(NonResidentialUsageType.VISIT),
+      ),
+    )
+
+    webTestClient.post().uri("/locations/prison/MDI/property")
+      .headers(manageHeaders())
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue("""{ "localName": "Shared name", "capacity": 10 }""")
       .exchange()
       .expectStatus().isEqualTo(409)
   }


### PR DESCRIPTION
Removing a property storage location only drops its `PROPERTY` usage — the `NonResidentialLocation` lives on, still `ACTIVE` and keeping its `localName`. But users experience "remove" as deleting it, so adding the same name back was rejected with *"a location with this name already exists in the prison"*, leaving them stuck with no way to re-add a location they had just removed.

(`validateLocalNameNotDuplicated` ignores only *archived* locations, so the still-active ex-property location blocks the name.)

## Change
Adding a property location now looks for one of that name whose designation was removed and **puts the designation back** with the newly requested capacity, keeping the original **id, code and history**. This also avoids the code drift a duplicate would suffer, since `generateUniqueNonResidentialCode` lengthens the code when the natural one is taken.

**Deliberately narrow about what may be reinstated** (`NonResidentialLocation.canBeReinstatedAsPropertyLocation`): a `BOX` with no non-residential usages and no service usages left on it, and not archived. That stops an unrelated location which merely shares the name — a visit room, or a store a service still owns — from being quietly turned into property storage. Those cases still conflict exactly as before, and archived locations are left to the existing `/unarchive` route. BOX locations can be children, so there is no top-level requirement.

**Domain event:** a reinstate is announced as `LOCATION_AMENDED`, not `LOCATION_CREATED` — the location already exists downstream, and announcing a creation would have NOMIS try to add one it already holds. This is the main correctness risk in the change, and is covered by a test.

**HTTP status:** `200` for a reinstate, `201` only when a location is genuinely created. The endpoint's OpenAPI documents both. (The one known consumer reads the body and ignores the status, so this is safe; its 409 handling also stays valid, since name clashes still occur.)

`validateLocalNameNotDuplicated` itself is untouched — it is shared with `createBasicNonResidentialLocation` and `updateNonResidentialLocation`, so the reinstate lookup sits alongside it rather than changing its semantics. `setPropertyCapacity` already writes the honest `USAGE: null -> Property` (+ capacity) history rows, so no new history attribute was needed and no `LOCATION_CREATED` history is added.

## Testing

Added to `PropertyLocationManagementIntTest`:
- remove then add back by the same name reinstates it — **200**, same `id` and `code`, new capacity, and it appears **once** in the property list
- reinstates regardless of the case typed (`"reception STORE"`)
- reinstating announces the location as **amended, not created**
- still **409s** when the name is held by a location that was never property storage (a visit room)
- the existing duplicate-name test (name held by a *live* property location) still passes unchanged