### PR TITLE
MAPA-262: Add notification mailboxes endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,12 @@ dps-gradle-spring-boot-suppressions.xml
 .editorconfig
 sonar-project.properties
 
-#Helm
+# Helm
 **/Chart.lock
 
-#Synk
+# Synk
 .snyk
+
+# VSCode
+bin
+.vscode

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LinkedTransaction.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/LinkedTransaction.kt
@@ -113,4 +113,6 @@ enum class TransactionType(val description: String) {
   REJECT_CERTIFICATION_REQUEST("Reject request"),
   WITHDRAW_CERTIFICATION_REQUEST("Withdraw request"),
   CERTIFICATE_BASELINE("Certificate baseline"),
+  NOTIFICATION_MAILBOX_UPDATE("Notification mailbox updated"),
+  NOTIFICATION_MAILBOX_DELETE("Notification mailbox deleted"),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/PrisonNotificationMailbox.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/PrisonNotificationMailbox.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import org.hibernate.Hibernate
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.helper.GeneratedUuidV7
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.NotificationGroup
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+class PrisonNotificationMailbox(
+  @Id
+  @GeneratedUuidV7
+  @Column(name = "id", updatable = false, nullable = false)
+  val id: UUID? = null,
+
+  val prisonId: String,
+
+  @Enumerated(EnumType.STRING)
+  val notificationGroup: NotificationGroup,
+
+  val emailAddress: String,
+
+  var whenUpdated: LocalDateTime,
+  var updatedBy: String,
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+
+    other as PrisonNotificationMailbox
+
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = id?.hashCode() ?: 0
+
+  override fun toString(): String = "PrisonNotificationMailbox(prisonId='$prisonId', notificationGroup=$notificationGroup)"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/PrisonNotificationMailboxRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/PrisonNotificationMailboxRepository.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.PrisonNotificationMailbox
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.NotificationGroup
+import java.util.UUID
+
+@Repository
+interface PrisonNotificationMailboxRepository : JpaRepository<PrisonNotificationMailbox, UUID> {
+  fun findByPrisonIdAndNotificationGroup(prisonId: String, notificationGroup: NotificationGroup): List<PrisonNotificationMailbox>
+
+  fun deleteByPrisonIdAndNotificationGroup(prisonId: String, notificationGroup: NotificationGroup): List<PrisonNotificationMailbox>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
@@ -19,6 +19,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.NotificationGroup
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.Prisoner
 import java.util.UUID
 
@@ -350,6 +351,21 @@ class ApiExceptionHandler {
           status = HttpStatus.NOT_FOUND,
           errorCode = ErrorCode.LocationNotFound,
           userMessage = "Prison not found: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(PrisonNotificationMailboxNotFoundException::class)
+  fun handlePrisonNotificationMailboxNotFound(e: PrisonNotificationMailboxNotFoundException): ResponseEntity<ErrorResponse> {
+    log.debug("Prison notification mailbox not found exception caught: {}", e.message)
+    return ResponseEntity
+      .status(HttpStatus.NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = HttpStatus.NOT_FOUND,
+          errorCode = ErrorCode.PrisonNotificationMailboxNotFound,
+          userMessage = "Notification mailbox not found: ${e.message}",
           developerMessage = e.message,
         ),
       )
@@ -798,6 +814,7 @@ class PrisonNotFoundException(id: String) : Exception("There is no prison found 
 class LocationNotFoundException(id: String) : Exception("There is no location found for ID = $id")
 class TransactionNotFoundException(txId: UUID) : Exception("There is no transaction found for txId = $txId")
 class LocationPrefixNotFoundException(id: String) : Exception("Location prefix not found for $id")
+class PrisonNotificationMailboxNotFoundException(prisonId: String, notificationGroup: NotificationGroup) : Exception("There is no notification mailbox found for prisonId = $prisonId, notificationGroup = $notificationGroup")
 class SignedOperationCapacityNotFoundException(prisonId: String) : Exception("There is no signed operation capacity found for prison ID = $prisonId")
 class LocationAlreadyExistsException(key: String) : Exception("Location already exists = $key")
 class ReasonForDeactivationMustBeProvidedException(key: String) : Exception("De-activating location $key requires a reason when using OTHER reason type")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ErrorCode.kt
@@ -52,4 +52,5 @@ enum class ErrorCode(val errorCode: Int) {
   LocationCannotBeUnarchived(143),
   LocationCannotBeHiddenFromList(144),
   NonResidentialParentCannotBeArchived(145),
+  PrisonNotificationMailboxNotFound(146),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResource.kt
@@ -1,0 +1,180 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.NotificationGroup
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.PrisonNotificationMailboxService
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.UpdateNotificationMailboxRequest
+
+@RestController
+@Validated
+@RequestMapping("/prison-configuration", produces = [MediaType.APPLICATION_JSON_VALUE])
+@Tag(
+  name = "Prison Configuration",
+  description = "Allows views and updates on prison configuration",
+)
+class PrisonNotificationMailboxResource(
+  private val prisonNotificationMailboxService: PrisonNotificationMailboxService,
+) {
+
+  @GetMapping("/{prisonId}/notification-mailboxes/{notificationGroup}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_LOCATION_CONFIG_ADMIN')")
+  @Operation(
+    summary = "Get notification mailbox email addresses for a prison",
+    description = "Requires role LOCATION_CONFIG_ADMIN",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns notification mailbox",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the LOCATION_CONFIG_ADMIN role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No notification mailbox found for this prison and notification group",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getNotificationMailbox(
+    @Schema(
+      description = "Prison ID",
+      required = true,
+      example = "MDI",
+      minLength = 3,
+      maxLength = 5,
+      pattern = "^[A-Z]{2}I|ZZGHI$",
+    )
+    @Size(min = 3, message = "Prison ID cannot be blank")
+    @Size(max = 5, message = "Prison ID must be 3 characters or ZZGHI")
+    @Pattern(regexp = "^[A-Z]{2}I|ZZGHI$", message = "Prison ID must be 3 characters or ZZGHI")
+    @PathVariable
+    prisonId: String,
+    @Schema(description = "Notification group", example = "CERT_ADMIN", required = true)
+    @PathVariable
+    notificationGroup: NotificationGroup,
+  ) = prisonNotificationMailboxService.getMailboxes(prisonId, notificationGroup)
+
+  @PutMapping("/{prisonId}/notification-mailboxes/{notificationGroup}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_LOCATION_CONFIG_ADMIN')")
+  @Operation(
+    summary = "Replace all notification mailbox email addresses for a prison",
+    description = "Overwrites any existing email addresses for this prison and notification group. Requires role LOCATION_CONFIG_ADMIN",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns updated notification mailbox",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the LOCATION_CONFIG_ADMIN role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Prison not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun replaceNotificationMailbox(
+    @Schema(
+      description = "Prison ID",
+      required = true,
+      example = "MDI",
+      minLength = 3,
+      maxLength = 5,
+      pattern = "^[A-Z]{2}I|ZZGHI$",
+    )
+    @Size(min = 3, message = "Prison ID cannot be blank")
+    @Size(max = 5, message = "Prison ID must be 3 characters or ZZGHI")
+    @Pattern(regexp = "^[A-Z]{2}I|ZZGHI$", message = "Prison ID must be 3 characters or ZZGHI")
+    @PathVariable
+    prisonId: String,
+    @Schema(description = "Notification group", example = "CERT_ADMIN", required = true)
+    @PathVariable
+    notificationGroup: NotificationGroup,
+    @RequestBody @Valid
+    request: UpdateNotificationMailboxRequest,
+  ) = prisonNotificationMailboxService.replaceMailboxes(prisonId, notificationGroup, request.emailAddresses)
+
+  @DeleteMapping("/{prisonId}/notification-mailboxes/{notificationGroup}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize("hasRole('ROLE_LOCATION_CONFIG_ADMIN')")
+  @Operation(
+    summary = "Delete all notification mailbox email addresses for a prison",
+    description = "Requires role LOCATION_CONFIG_ADMIN",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Notification mailbox deleted",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the LOCATION_CONFIG_ADMIN role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No notification mailbox found for this prison and notification group",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun deleteNotificationMailbox(
+    @Schema(
+      description = "Prison ID",
+      required = true,
+      example = "MDI",
+      minLength = 3,
+      maxLength = 5,
+      pattern = "^[A-Z]{2}I|ZZGHI$",
+    )
+    @Size(min = 3, message = "Prison ID cannot be blank")
+    @Size(max = 5, message = "Prison ID must be 3 characters or ZZGHI")
+    @Pattern(regexp = "^[A-Z]{2}I|ZZGHI$", message = "Prison ID must be 3 characters or ZZGHI")
+    @PathVariable
+    prisonId: String,
+    @Schema(description = "Notification group", example = "CERT_ADMIN", required = true)
+    @PathVariable
+    notificationGroup: NotificationGroup,
+  ) = prisonNotificationMailboxService.deleteMailboxes(prisonId, notificationGroup)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxService.kt
@@ -1,0 +1,162 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.service
+
+import com.microsoft.applicationinsights.TelemetryClient
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.ValidationException
+import jakarta.validation.constraints.Size
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.locationsinsideprison.SYSTEM_USERNAME
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.PrisonNotificationMailbox
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LinkedTransactionRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.PrisonNotificationMailboxRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PrisonNotFoundException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PrisonNotificationMailboxNotFoundException
+import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class PrisonNotificationMailboxService(
+  private val prisonNotificationMailboxRepository: PrisonNotificationMailboxRepository,
+  private val activePrisonService: ActivePrisonService,
+  private val linkedTransactionRepository: LinkedTransactionRepository,
+  private val authenticationHolder: HmppsAuthenticationHolder,
+  private val clock: Clock,
+  private val telemetryClient: TelemetryClient,
+) {
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(PrisonNotificationMailboxService::class.java)
+
+    // basic sanity check for "local-part@domain" shape; deliberately not exhaustive RFC 5322 validation
+    private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
+  }
+
+  fun getMailboxes(prisonId: String, notificationGroup: NotificationGroup): PrisonNotificationMailboxDto {
+    val mailboxes = prisonNotificationMailboxRepository.findByPrisonIdAndNotificationGroup(prisonId, notificationGroup)
+    if (mailboxes.isEmpty()) {
+      throw PrisonNotificationMailboxNotFoundException(prisonId, notificationGroup)
+    }
+    return mailboxes.toDto(prisonId, notificationGroup)
+  }
+
+  @Transactional
+  fun replaceMailboxes(prisonId: String, notificationGroup: NotificationGroup, emailAddresses: List<String>): PrisonNotificationMailboxDto {
+    activePrisonService.getPrisonConfiguration(prisonId) ?: throw PrisonNotFoundException(prisonId)
+
+    val normalisedEmails = emailAddresses.map { it.trim().lowercase() }.distinct()
+    normalisedEmails.filterNot { EMAIL_REGEX.matches(it) }.also {
+      if (it.isNotEmpty()) throw ValidationException("${it.size} email address(es) are not valid")
+    }
+
+    prisonNotificationMailboxRepository.deleteByPrisonIdAndNotificationGroup(prisonId, notificationGroup)
+
+    val updatedBy = authenticationHolder.username ?: SYSTEM_USERNAME
+    val now = LocalDateTime.now(clock)
+    val saved = prisonNotificationMailboxRepository.saveAll(
+      normalisedEmails.map { email ->
+        PrisonNotificationMailbox(
+          prisonId = prisonId,
+          notificationGroup = notificationGroup,
+          emailAddress = email,
+          whenUpdated = now,
+          updatedBy = updatedBy,
+        )
+      },
+    )
+
+    val tx = LinkedTransaction(
+      transactionType = TransactionType.NOTIFICATION_MAILBOX_UPDATE,
+      prisonId = prisonId,
+      // NB: never include the actual email addresses here - this is PII and must not appear in audit/telemetry/logs
+      transactionDetail = "Notification mailbox updated for group $notificationGroup (${normalisedEmails.size} address(es))",
+      transactionInvokedBy = updatedBy,
+      txStartTime = now,
+      txEndTime = now,
+    )
+    linkedTransactionRepository.save(tx)
+
+    telemetryClient.trackEvent(
+      "Notification mailbox update",
+      mapOf(
+        "prisonId" to prisonId,
+        "notificationGroup" to notificationGroup.name,
+        "count" to normalisedEmails.size.toString(),
+        "tx" to tx.transactionId.toString(),
+      ),
+      null,
+    )
+    log.info("Updated notification mailbox for prisonId=$prisonId, notificationGroup=$notificationGroup, count=${normalisedEmails.size} [$tx]")
+
+    return saved.toDto(prisonId, notificationGroup)
+  }
+
+  @Transactional
+  fun deleteMailboxes(prisonId: String, notificationGroup: NotificationGroup) {
+    val existing = prisonNotificationMailboxRepository.findByPrisonIdAndNotificationGroup(prisonId, notificationGroup)
+    if (existing.isEmpty()) {
+      throw PrisonNotificationMailboxNotFoundException(prisonId, notificationGroup)
+    }
+
+    prisonNotificationMailboxRepository.deleteAll(existing)
+
+    val updatedBy = authenticationHolder.username ?: SYSTEM_USERNAME
+    val now = LocalDateTime.now(clock)
+    val tx = LinkedTransaction(
+      transactionType = TransactionType.NOTIFICATION_MAILBOX_DELETE,
+      prisonId = prisonId,
+      transactionDetail = "Notification mailbox deleted for group $notificationGroup (${existing.size} address(es))",
+      transactionInvokedBy = updatedBy,
+      txStartTime = now,
+      txEndTime = now,
+    )
+    linkedTransactionRepository.save(tx)
+
+    telemetryClient.trackEvent(
+      "Notification mailbox delete",
+      mapOf(
+        "prisonId" to prisonId,
+        "notificationGroup" to notificationGroup.name,
+        "count" to existing.size.toString(),
+        "tx" to tx.transactionId.toString(),
+      ),
+      null,
+    )
+    log.info("Deleted notification mailbox for prisonId=$prisonId, notificationGroup=$notificationGroup, count=${existing.size} [$tx]")
+  }
+
+  private fun List<PrisonNotificationMailbox>.toDto(prisonId: String, notificationGroup: NotificationGroup) = PrisonNotificationMailboxDto(
+    prisonId = prisonId,
+    notificationGroup = notificationGroup,
+    emailAddresses = map { it.emailAddress }.sorted(),
+  )
+}
+
+@Schema(description = "Prison notification mailbox")
+data class PrisonNotificationMailboxDto(
+  @param:Schema(description = "Prison ID", example = "MDI", required = true)
+  val prisonId: String,
+  @param:Schema(description = "Notification group", example = "CERT_ADMIN", required = true)
+  val notificationGroup: NotificationGroup,
+  @param:Schema(description = "Email addresses registered for this prison and notification group", required = true)
+  val emailAddresses: List<String>,
+)
+
+@Schema(description = "Request to replace all email addresses for a prison notification mailbox")
+data class UpdateNotificationMailboxRequest(
+  @param:Schema(description = "Email addresses to store, replacing any existing addresses for this prison and notification group", required = true)
+  @field:Size(min = 1, message = "At least one email address is required")
+  val emailAddresses: List<String>,
+)
+
+enum class NotificationGroup {
+  CERT_ADMIN,
+  CERT_VIEWER,
+  CERT_REVIEWER,
+}

--- a/src/main/resources/db/migration/V1_99__add_prison_notification_mailbox.sql
+++ b/src/main/resources/db/migration/V1_99__add_prison_notification_mailbox.sql
@@ -1,0 +1,19 @@
+-- Functional mailbox email addresses for a prison, grouped by notification purpose
+-- (e.g. certification admin/viewer/reviewer). One row per email address.
+CREATE TABLE prison_notification_mailbox
+(
+    id                  UUID PRIMARY KEY,
+    prison_id           VARCHAR(5)   NOT NULL,
+    notification_group  VARCHAR(20)  NOT NULL,
+    email_address       VARCHAR(255) NOT NULL,
+    when_updated        TIMESTAMP    NOT NULL,
+    updated_by          VARCHAR(255) NOT NULL
+);
+
+-- Case-insensitive uniqueness so the same address can't be added twice with different casing
+CREATE UNIQUE INDEX prison_notification_mailbox_unique_idx
+    ON prison_notification_mailbox (prison_id, notification_group, lower(email_address));
+
+insert into constant_transaction_type(sequence, code, description)
+values (24, 'NOTIFICATION_MAILBOX_UPDATE', 'Notification mailbox updated'),
+       (25, 'NOTIFICATION_MAILBOX_DELETE', 'Notification mailbox deleted');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/PrisonNotificationMailboxRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/PrisonNotificationMailboxRepositoryTest.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.TestBase
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.PrisonNotificationMailbox
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.NotificationGroup
+import java.time.LocalDateTime
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+class PrisonNotificationMailboxRepositoryTest : TestBase() {
+
+  val testPrisonId = "MDI"
+  val testUser = "USER"
+
+  @Autowired
+  lateinit var repository: PrisonNotificationMailboxRepository
+
+  @BeforeEach
+  fun setup() {
+    repository.deleteAll()
+  }
+
+  private fun mailbox(email: String, group: NotificationGroup = NotificationGroup.CERT_ADMIN, prisonId: String = testPrisonId) = PrisonNotificationMailbox(
+    prisonId = prisonId,
+    notificationGroup = group,
+    emailAddress = email,
+    whenUpdated = LocalDateTime.now(clock),
+    updatedBy = testUser,
+  )
+
+  @Test
+  fun `returns empty list when no mailboxes exist for prison and group`() {
+    val result = repository.findByPrisonIdAndNotificationGroup(testPrisonId, NotificationGroup.CERT_ADMIN)
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `returns mailboxes only for the matching prison and group`() {
+    repository.save(mailbox("cert.admin@justice.gov.uk", NotificationGroup.CERT_ADMIN))
+    repository.save(mailbox("cert.viewer@justice.gov.uk", NotificationGroup.CERT_VIEWER))
+    repository.save(mailbox("other.prison@justice.gov.uk", NotificationGroup.CERT_ADMIN, prisonId = "LEI"))
+
+    val result = repository.findByPrisonIdAndNotificationGroup(testPrisonId, NotificationGroup.CERT_ADMIN)
+
+    assertThat(result).hasSize(1)
+    assertThat(result[0].emailAddress).isEqualTo("cert.admin@justice.gov.uk")
+  }
+
+  @Test
+  fun `rejects duplicate email address for the same prison and group regardless of case`() {
+    repository.saveAndFlush(mailbox("duplicate@justice.gov.uk"))
+
+    assertThatThrownBy {
+      repository.saveAndFlush(mailbox("DUPLICATE@justice.gov.uk"))
+    }.isInstanceOf(DataIntegrityViolationException::class.java)
+  }
+
+  @Test
+  fun `deletes all mailboxes for a prison and group`() {
+    repository.save(mailbox("one@justice.gov.uk"))
+    repository.save(mailbox("two@justice.gov.uk"))
+
+    val deleted = repository.deleteByPrisonIdAndNotificationGroup(testPrisonId, NotificationGroup.CERT_ADMIN)
+
+    assertThat(deleted).hasSize(2)
+    assertThat(repository.findByPrisonIdAndNotificationGroup(testPrisonId, NotificationGroup.CERT_ADMIN)).isEmpty()
+  }
+
+  private fun assertThatThrownBy(block: () -> Unit) = org.assertj.core.api.Assertions.assertThatThrownBy(block)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResourceTest.kt
@@ -1,0 +1,293 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.resource
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.json.JsonCompareMode
+import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.SqsIntegrationTestBase
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.PrisonConfiguration
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.PrisonNotificationMailbox
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.PrisonConfigurationRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.PrisonNotificationMailboxRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.service.NotificationGroup
+import java.time.LocalDateTime
+
+class PrisonNotificationMailboxResourceTest : SqsIntegrationTestBase() {
+
+  @Autowired
+  lateinit var prisonConfigurationRepository: PrisonConfigurationRepository
+
+  @Autowired
+  lateinit var prisonNotificationMailboxRepository: PrisonNotificationMailboxRepository
+
+  val prisonId = "LEI"
+
+  @BeforeEach
+  fun setUp() {
+    prisonConfigurationRepository.save(
+      PrisonConfiguration(
+        id = prisonId,
+        whenUpdated = LocalDateTime.now(clock),
+        updatedBy = "TEST",
+      ),
+    )
+  }
+
+  @AfterEach
+  fun cleanUp() {
+    prisonNotificationMailboxRepository.deleteAll()
+  }
+
+  @DisplayName("GET /prison-configuration/{prisonId}/notification-mailboxes/{notificationGroup}")
+  @Nested
+  inner class GetNotificationMailboxTest {
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `access forbidden when no authority`() {
+        webTestClient.get().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.get().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class Validation {
+
+      @Test
+      fun `error occurs when invalid notification group used`() {
+        webTestClient.get().uri("/prison-configuration/$prisonId/notification-mailboxes/XXXXX")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .exchange()
+          .expectStatus().is4xxClientError
+      }
+
+      @Test
+      fun `not found when no mailbox exists for this prison and group`() {
+        webTestClient.get().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .exchange()
+          .expectStatus().isNotFound
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `can get notification mailbox`() {
+        prisonNotificationMailboxRepository.save(
+          PrisonNotificationMailbox(
+            prisonId = prisonId,
+            notificationGroup = NotificationGroup.CERT_ADMIN,
+            emailAddress = "cert.admin@justice.gov.uk",
+            whenUpdated = LocalDateTime.now(clock),
+            updatedBy = "TEST",
+          ),
+        )
+
+        webTestClient.get().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            """
+              {
+                "prisonId": "$prisonId",
+                "notificationGroup": "CERT_ADMIN",
+                "emailAddresses": ["cert.admin@justice.gov.uk"]
+              }
+            """.trimIndent(),
+            JsonCompareMode.STRICT,
+          )
+      }
+    }
+  }
+
+  @DisplayName("PUT /prison-configuration/{prisonId}/notification-mailboxes/{notificationGroup}")
+  @Nested
+  inner class ReplaceNotificationMailboxTest {
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `access forbidden when no authority`() {
+        webTestClient.put().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .bodyValue(mapOf("emailAddresses" to listOf("cert.admin@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.put().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf()))
+          .bodyValue(mapOf("emailAddresses" to listOf("cert.admin@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.put().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .bodyValue(mapOf("emailAddresses" to listOf("cert.admin@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class Validation {
+
+      @Test
+      fun `error occurs when non existent prison used`() {
+        webTestClient.put().uri("/prison-configuration/JJI/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .bodyValue(mapOf("emailAddresses" to listOf("cert.admin@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isNotFound
+      }
+
+      @Test
+      fun `error occurs when email address is invalid`() {
+        webTestClient.put().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .bodyValue(mapOf("emailAddresses" to listOf("not-an-email")))
+          .exchange()
+          .expectStatus().isBadRequest
+      }
+
+      @Test
+      fun `error occurs when email list is empty`() {
+        webTestClient.put().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .bodyValue(mapOf("emailAddresses" to emptyList<String>()))
+          .exchange()
+          .expectStatus().isBadRequest
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `can replace notification mailbox and overwrites existing addresses`() {
+        webTestClient.put().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .bodyValue(mapOf("emailAddresses" to listOf("first@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isOk
+
+        webTestClient.put().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .bodyValue(mapOf("emailAddresses" to listOf("second@justice.gov.uk", "third@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            """
+              {
+                "prisonId": "$prisonId",
+                "notificationGroup": "CERT_ADMIN",
+                "emailAddresses": ["second@justice.gov.uk", "third@justice.gov.uk"]
+              }
+            """.trimIndent(),
+            JsonCompareMode.STRICT,
+          )
+      }
+    }
+  }
+
+  @DisplayName("DELETE /prison-configuration/{prisonId}/notification-mailboxes/{notificationGroup}")
+  @Nested
+  inner class DeleteNotificationMailboxTest {
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `access forbidden when no authority`() {
+        webTestClient.delete().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.delete().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.delete().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class Validation {
+
+      @Test
+      fun `not found when no mailbox exists for this prison and group`() {
+        webTestClient.delete().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .exchange()
+          .expectStatus().isNotFound
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+
+      @Test
+      fun `can delete notification mailbox`() {
+        prisonNotificationMailboxRepository.save(
+          PrisonNotificationMailbox(
+            prisonId = prisonId,
+            notificationGroup = NotificationGroup.CERT_ADMIN,
+            emailAddress = "cert.admin@justice.gov.uk",
+            whenUpdated = LocalDateTime.now(clock),
+            updatedBy = "TEST",
+          ),
+        )
+
+        webTestClient.delete().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .exchange()
+          .expectStatus().isNoContent
+
+        webTestClient.get().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .exchange()
+          .expectStatus().isNotFound
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxServiceTest.kt
@@ -1,0 +1,133 @@
+package uk.gov.justice.digital.hmpps.locationsinsideprison.service
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.TestBase.Companion.clock
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.PrisonConfiguration
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.PrisonNotificationMailbox
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LinkedTransactionRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.PrisonNotificationMailboxRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PrisonNotFoundException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PrisonNotificationMailboxNotFoundException
+import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
+import java.time.LocalDateTime
+
+class PrisonNotificationMailboxServiceTest {
+  private val prisonNotificationMailboxRepository: PrisonNotificationMailboxRepository = mock()
+  private val activePrisonService: ActivePrisonService = mock()
+  private val linkedTransactionRepository: LinkedTransactionRepository = mock()
+  private val authenticationHolder: HmppsAuthenticationHolder = mock()
+  private val telemetryClient: TelemetryClient = mock()
+  private val service = PrisonNotificationMailboxService(
+    prisonNotificationMailboxRepository,
+    activePrisonService,
+    linkedTransactionRepository,
+    authenticationHolder,
+    clock,
+    telemetryClient,
+  )
+
+  private val prisonId = "MDI"
+  private val secretEmail = "governor.secret.address@justice.gov.uk"
+
+  @BeforeEach
+  fun setUp() {
+    whenever(authenticationHolder.username).thenReturn("TEST_USER")
+    whenever(linkedTransactionRepository.save(any<LinkedTransaction>())).thenReturn(Mockito.mock())
+    whenever(activePrisonService.getPrisonConfiguration(any())).thenReturn(
+      PrisonConfiguration(id = prisonId, whenUpdated = LocalDateTime.now(clock), updatedBy = "TEST_USER"),
+    )
+  }
+
+  @Test
+  fun `throws not found when no mailboxes exist for prison and group`() {
+    whenever(prisonNotificationMailboxRepository.findByPrisonIdAndNotificationGroup(prisonId, NotificationGroup.CERT_ADMIN)).thenReturn(emptyList())
+
+    assertThatThrownBy { service.getMailboxes(prisonId, NotificationGroup.CERT_ADMIN) }
+      .isInstanceOf(PrisonNotificationMailboxNotFoundException::class.java)
+  }
+
+  @Test
+  fun `returns email addresses when mailboxes exist`() {
+    whenever(prisonNotificationMailboxRepository.findByPrisonIdAndNotificationGroup(prisonId, NotificationGroup.CERT_ADMIN)).thenReturn(
+      listOf(
+        PrisonNotificationMailbox(prisonId = prisonId, notificationGroup = NotificationGroup.CERT_ADMIN, emailAddress = secretEmail, whenUpdated = LocalDateTime.now(clock), updatedBy = "TEST_USER"),
+      ),
+    )
+
+    val result = service.getMailboxes(prisonId, NotificationGroup.CERT_ADMIN)
+
+    assertThat(result.emailAddresses).containsExactly(secretEmail)
+  }
+
+  @Test
+  fun `replace fails when prison does not exist`() {
+    whenever(activePrisonService.getPrisonConfiguration(any())).thenReturn(null)
+
+    assertThatThrownBy { service.replaceMailboxes(prisonId, NotificationGroup.CERT_ADMIN, listOf(secretEmail)) }
+      .isInstanceOf(PrisonNotFoundException::class.java)
+  }
+
+  @Test
+  fun `replace normalises and dedupes email addresses then overwrites existing rows`() {
+    whenever(prisonNotificationMailboxRepository.saveAll(any<List<PrisonNotificationMailbox>>())).thenAnswer { it.arguments[0] }
+
+    val result = service.replaceMailboxes(
+      prisonId,
+      NotificationGroup.CERT_ADMIN,
+      listOf(" $secretEmail ", secretEmail.uppercase()),
+    )
+
+    verify(prisonNotificationMailboxRepository).deleteByPrisonIdAndNotificationGroup(prisonId, NotificationGroup.CERT_ADMIN)
+    assertThat(result.emailAddresses).containsExactly(secretEmail)
+  }
+
+  @Test
+  fun `replace does not leak email addresses into linked transaction or telemetry`() {
+    whenever(prisonNotificationMailboxRepository.saveAll(any<List<PrisonNotificationMailbox>>())).thenAnswer { it.arguments[0] }
+
+    service.replaceMailboxes(prisonId, NotificationGroup.CERT_ADMIN, listOf(secretEmail))
+
+    val txCaptor = argumentCaptor<LinkedTransaction>()
+    verify(linkedTransactionRepository).save(txCaptor.capture())
+    assertThat(txCaptor.firstValue.transactionDetail).doesNotContain(secretEmail)
+
+    val propertiesCaptor = argumentCaptor<Map<String, String>>()
+    verify(telemetryClient).trackEvent(any(), propertiesCaptor.capture(), anyOrNull())
+    assertThat(propertiesCaptor.firstValue.values).noneMatch { it.contains(secretEmail) }
+  }
+
+  @Test
+  fun `delete fails when no mailboxes exist`() {
+    whenever(prisonNotificationMailboxRepository.findByPrisonIdAndNotificationGroup(prisonId, NotificationGroup.CERT_ADMIN)).thenReturn(emptyList())
+
+    assertThatThrownBy { service.deleteMailboxes(prisonId, NotificationGroup.CERT_ADMIN) }
+      .isInstanceOf(PrisonNotificationMailboxNotFoundException::class.java)
+  }
+
+  @Test
+  fun `delete removes existing mailboxes and records redacted linked transaction`() {
+    whenever(prisonNotificationMailboxRepository.findByPrisonIdAndNotificationGroup(prisonId, NotificationGroup.CERT_ADMIN)).thenReturn(
+      listOf(
+        PrisonNotificationMailbox(prisonId = prisonId, notificationGroup = NotificationGroup.CERT_ADMIN, emailAddress = secretEmail, whenUpdated = LocalDateTime.now(clock), updatedBy = "TEST_USER"),
+      ),
+    )
+
+    service.deleteMailboxes(prisonId, NotificationGroup.CERT_ADMIN)
+
+    val txCaptor = argumentCaptor<LinkedTransaction>()
+    verify(linkedTransactionRepository).save(txCaptor.capture())
+    assertThat(txCaptor.firstValue.transactionDetail).doesNotContain(secretEmail)
+  }
+}


### PR DESCRIPTION
## MAPA-262: Prison notification mailboxes

Adds functional mailbox email addresses per prison, scoped to a notification group (`CERT_ADMIN`, `CERT_VIEWER`, `CERT_REVIEWER`), so services can look up which addresses to notify for certification-related events.

### API

New endpoints under `/prison-configuration/{prisonId}/notification-mailboxes/{notificationGroup}`, all requiring `ROLE_LOCATION_CONFIG_ADMIN`:

- `GET` — returns the email addresses for a prison + group, or `404` if none are configured
- `PUT` — replaces the entire list of email addresses for a prison + group (normalises/dedupes, validates prison exists, `400` on invalid email format or empty list)
- `DELETE` — removes all email addresses for a prison + group, `404` if none exist

### Data model

- New `prison_notification_mailbox` table (migration `V1_99`) — one row per email address, with a case-insensitive unique constraint on `(prison_id, notification_group, email_address)`
- Two new `TransactionType` values (`NOTIFICATION_MAILBOX_UPDATE`/`_DELETE`) so changes are recorded in the existing `LinkedTransaction` audit log

### Notes

- Audit/telemetry/log entries deliberately never include the actual email addresses (PII) — only counts and metadata
- Followed existing `PrisonConfiguration` conventions for entity/repository/service/resource structure

### Testing

- Unit tests for the service, including explicit assertions that no email address leaks into `LinkedTransaction` or telemetry
- Repository test covering the unique constraint
- Integration tests covering security, validation, and happy-path scenarios for all three endpoints
- Full existing test suite passes (973 tests)

### Ticket

[MAPA-262](https://dsdmoj.atlassian.net/browse/MAPA-262)

[MAPA-262]: https://dsdmoj.atlassian.net/browse/MAPA-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ