### PR TITLE
MAPA-262: Prevent error when new emails collide with old ones

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxService.kt
@@ -56,6 +56,8 @@ class PrisonNotificationMailboxService(
     }
 
     prisonNotificationMailboxRepository.deleteByPrisonIdAndNotificationGroup(prisonId, notificationGroup)
+    // Hibernate flushes inserts before deletes regardless of call order, so without this the re-added rows can collide with the not-yet-deleted old ones
+    prisonNotificationMailboxRepository.flush()
 
     val updatedBy = authenticationHolder.username ?: SYSTEM_USERNAME
     val now = LocalDateTime.now(clock)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResourceTest.kt
@@ -217,6 +217,31 @@ class PrisonNotificationMailboxResourceTest : SqsIntegrationTestBase() {
             JsonCompareMode.STRICT,
           )
       }
+
+      @Test
+      fun `can replace notification mailbox when new list overlaps with existing addresses`() {
+        webTestClient.put().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .bodyValue(mapOf("emailAddresses" to listOf("first@justice.gov.uk", "second@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isOk
+
+        webTestClient.put().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_ADMIN")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .bodyValue(mapOf("emailAddresses" to listOf("first@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            """
+              {
+                "prisonId": "$prisonId",
+                "notificationGroup": "CERT_ADMIN",
+                "emailAddresses": ["first@justice.gov.uk"]
+              }
+            """.trimIndent(),
+            JsonCompareMode.STRICT,
+          )
+      }
     }
   }
 


### PR DESCRIPTION
## Fix: duplicate key error when replacing notification mailbox with an overlapping address

`PUT /prison-configuration/{prisonId}/notification-mailboxes/{notificationGroup}` returned a 500 when the new list of email addresses overlapped with the existing ones (e.g. re-submitting the same address, or adding one email to an existing list).

### Root cause

`replaceMailboxes` deletes the existing rows for the prison + group, then inserts the new set, within a single transaction. Hibernate's flush always executes queued **inserts before deletes**, regardless of call order — so the new `INSERT`s ran before the old rows were actually removed, tripping the `prison_notification_mailbox_unique_idx` constraint whenever an address appeared in both the old and new lists.

### Fix

Call `prisonNotificationMailboxRepository.flush()` immediately after the delete, forcing the removal to hit the database before the new rows are inserted.

### Testing

- Added an integration test (`can replace notification mailbox when new list overlaps with existing addresses`) reproducing the reported scenario
- Full test suite passes (973 tests)