### PR TITLE
MAPA-262: Allow for all-prisons mailbox

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/PrisonNotificationMailbox.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/PrisonNotificationMailbox.kt
@@ -18,7 +18,7 @@ class PrisonNotificationMailbox(
   @Column(name = "id", updatable = false, nullable = false)
   val id: UUID? = null,
 
-  val prisonId: String,
+  val prisonId: String? = null,
 
   @Enumerated(EnumType.STRING)
   val notificationGroup: NotificationGroup,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/PrisonNotificationMailboxRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/PrisonNotificationMailboxRepository.kt
@@ -10,5 +10,9 @@ import java.util.UUID
 interface PrisonNotificationMailboxRepository : JpaRepository<PrisonNotificationMailbox, UUID> {
   fun findByPrisonIdAndNotificationGroup(prisonId: String, notificationGroup: NotificationGroup): List<PrisonNotificationMailbox>
 
+  fun findByPrisonIdIsNullAndNotificationGroup(notificationGroup: NotificationGroup): List<PrisonNotificationMailbox>
+
   fun deleteByPrisonIdAndNotificationGroup(prisonId: String, notificationGroup: NotificationGroup): List<PrisonNotificationMailbox>
+
+  fun deleteByPrisonIdIsNullAndNotificationGroup(notificationGroup: NotificationGroup): List<PrisonNotificationMailbox>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
@@ -814,7 +814,13 @@ class PrisonNotFoundException(id: String) : Exception("There is no prison found 
 class LocationNotFoundException(id: String) : Exception("There is no location found for ID = $id")
 class TransactionNotFoundException(txId: UUID) : Exception("There is no transaction found for txId = $txId")
 class LocationPrefixNotFoundException(id: String) : Exception("Location prefix not found for $id")
-class PrisonNotificationMailboxNotFoundException(prisonId: String, notificationGroup: NotificationGroup) : Exception("There is no notification mailbox found for prisonId = $prisonId, notificationGroup = $notificationGroup")
+class PrisonNotificationMailboxNotFoundException private constructor(message: String) : Exception(message) {
+  constructor(prisonId: String, notificationGroup: NotificationGroup) : this("There is no notification mailbox found for prisonId = $prisonId, notificationGroup = $notificationGroup")
+
+  companion object {
+    fun default(notificationGroup: NotificationGroup) = PrisonNotificationMailboxNotFoundException("There is no default notification mailbox found for notificationGroup = $notificationGroup")
+  }
+}
 class SignedOperationCapacityNotFoundException(prisonId: String) : Exception("There is no signed operation capacity found for prison ID = $prisonId")
 class LocationAlreadyExistsException(key: String) : Exception("Location already exists = $key")
 class ReasonForDeactivationMustBeProvidedException(key: String) : Exception("De-activating location $key requires a reason when using OTHER reason type")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResource.kt
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.locationsinsideprison.service.NotificationGroup
@@ -34,6 +35,105 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.service.UpdateNotifica
 class PrisonNotificationMailboxResource(
   private val prisonNotificationMailboxService: PrisonNotificationMailboxService,
 ) {
+
+  @GetMapping("/notification-mailboxes/defaults/{notificationGroup}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_LOCATION_CONFIG_ADMIN')")
+  @Operation(
+    summary = "Get default notification mailbox email addresses",
+    description = "Requires role LOCATION_CONFIG_ADMIN",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns default notification mailbox",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the LOCATION_CONFIG_ADMIN role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No default notification mailbox found for this notification group",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getDefaultNotificationMailbox(
+    @Schema(description = "Notification group", example = "CERT_VIEWER", required = true)
+    @PathVariable
+    notificationGroup: NotificationGroup,
+  ) = prisonNotificationMailboxService.getDefaultMailboxes(notificationGroup)
+
+  @PutMapping("/notification-mailboxes/defaults/{notificationGroup}")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_LOCATION_CONFIG_ADMIN')")
+  @Operation(
+    summary = "Replace all default notification mailbox email addresses",
+    description = "Overwrites any existing default email addresses for this notification group. Requires role LOCATION_CONFIG_ADMIN",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns updated default notification mailbox",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the LOCATION_CONFIG_ADMIN role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun replaceDefaultNotificationMailbox(
+    @Schema(description = "Notification group", example = "CERT_VIEWER", required = true)
+    @PathVariable
+    notificationGroup: NotificationGroup,
+    @RequestBody @Valid
+    request: UpdateNotificationMailboxRequest,
+  ) = prisonNotificationMailboxService.replaceDefaultMailboxes(notificationGroup, request.emailAddresses)
+
+  @DeleteMapping("/notification-mailboxes/defaults/{notificationGroup}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PreAuthorize("hasRole('ROLE_LOCATION_CONFIG_ADMIN')")
+  @Operation(
+    summary = "Delete all default notification mailbox email addresses",
+    description = "Requires role LOCATION_CONFIG_ADMIN",
+    responses = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Default notification mailbox deleted",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the LOCATION_CONFIG_ADMIN role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No default notification mailbox found for this notification group",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun deleteDefaultNotificationMailbox(
+    @Schema(description = "Notification group", example = "CERT_VIEWER", required = true)
+    @PathVariable
+    notificationGroup: NotificationGroup,
+  ) = prisonNotificationMailboxService.deleteDefaultMailboxes(notificationGroup)
 
   @GetMapping("/{prisonId}/notification-mailboxes/{notificationGroup}")
   @ResponseStatus(HttpStatus.OK)
@@ -80,7 +180,10 @@ class PrisonNotificationMailboxResource(
     @Schema(description = "Notification group", example = "CERT_ADMIN", required = true)
     @PathVariable
     notificationGroup: NotificationGroup,
-  ) = prisonNotificationMailboxService.getMailboxes(prisonId, notificationGroup)
+    @Schema(description = "Include default mailbox when no prison-specific mailbox exists", example = "true")
+    @RequestParam(defaultValue = "true")
+    includeDefault: Boolean,
+  ) = prisonNotificationMailboxService.getMailboxes(prisonId, notificationGroup, includeDefault)
 
   @PutMapping("/{prisonId}/notification-mailboxes/{notificationGroup}")
   @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.locationsinsideprison.service
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.microsoft.applicationinsights.TelemetryClient
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.ValidationException
@@ -33,29 +34,80 @@ class PrisonNotificationMailboxService(
 
   companion object {
     val log: Logger = LoggerFactory.getLogger(PrisonNotificationMailboxService::class.java)
+    private const val DEFAULT_MAILBOX_AUDIT_PRISON_ID = "N/A"
 
     // basic sanity check for "local-part@domain" shape; deliberately not exhaustive RFC 5322 validation
     private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
   }
 
-  fun getMailboxes(prisonId: String, notificationGroup: NotificationGroup): PrisonNotificationMailboxDto {
+  fun getMailboxes(prisonId: String, notificationGroup: NotificationGroup, includeDefault: Boolean = true): PrisonNotificationMailboxDto {
     val mailboxes = prisonNotificationMailboxRepository.findByPrisonIdAndNotificationGroup(prisonId, notificationGroup)
-    if (mailboxes.isEmpty()) {
+    if (mailboxes.isNotEmpty()) {
+      return mailboxes.toDto(prisonId, notificationGroup, NotificationMailboxSource.PRISON)
+    }
+
+    if (!includeDefault) {
       throw PrisonNotificationMailboxNotFoundException(prisonId, notificationGroup)
     }
-    return mailboxes.toDto(prisonId, notificationGroup)
+
+    val defaultMailboxes = prisonNotificationMailboxRepository.findByPrisonIdIsNullAndNotificationGroup(notificationGroup)
+    if (defaultMailboxes.isEmpty()) {
+      throw PrisonNotificationMailboxNotFoundException(prisonId, notificationGroup)
+    }
+    return defaultMailboxes.toDto(prisonId, notificationGroup, NotificationMailboxSource.DEFAULT)
+  }
+
+  fun getDefaultMailboxes(notificationGroup: NotificationGroup): PrisonNotificationMailboxDto {
+    val mailboxes = prisonNotificationMailboxRepository.findByPrisonIdIsNullAndNotificationGroup(notificationGroup)
+    if (mailboxes.isEmpty()) {
+      throw PrisonNotificationMailboxNotFoundException.default(notificationGroup)
+    }
+    return mailboxes.toDto(null, notificationGroup, NotificationMailboxSource.DEFAULT)
   }
 
   @Transactional
   fun replaceMailboxes(prisonId: String, notificationGroup: NotificationGroup, emailAddresses: List<String>): PrisonNotificationMailboxDto {
     activePrisonService.getPrisonConfiguration(prisonId) ?: throw PrisonNotFoundException(prisonId)
 
+    val saved = replaceMailboxRows(prisonId, notificationGroup, emailAddresses)
+
+    recordTransaction(
+      transactionType = TransactionType.NOTIFICATION_MAILBOX_UPDATE,
+      prisonId = prisonId,
+      notificationGroup = notificationGroup,
+      count = saved.size,
+      action = "updated",
+    )
+
+    return saved.toDto(prisonId, notificationGroup, NotificationMailboxSource.PRISON)
+  }
+
+  @Transactional
+  fun replaceDefaultMailboxes(notificationGroup: NotificationGroup, emailAddresses: List<String>): PrisonNotificationMailboxDto {
+    val saved = replaceMailboxRows(null, notificationGroup, emailAddresses)
+
+    recordTransaction(
+      transactionType = TransactionType.NOTIFICATION_MAILBOX_UPDATE,
+      prisonId = DEFAULT_MAILBOX_AUDIT_PRISON_ID,
+      notificationGroup = notificationGroup,
+      count = saved.size,
+      action = "updated default",
+    )
+
+    return saved.toDto(null, notificationGroup, NotificationMailboxSource.DEFAULT)
+  }
+
+  private fun replaceMailboxRows(prisonId: String?, notificationGroup: NotificationGroup, emailAddresses: List<String>): List<PrisonNotificationMailbox> {
     val normalisedEmails = emailAddresses.map { it.trim().lowercase() }.distinct()
     normalisedEmails.filterNot { EMAIL_REGEX.matches(it) }.also {
       if (it.isNotEmpty()) throw ValidationException("${it.size} email address(es) are not valid")
     }
 
-    prisonNotificationMailboxRepository.deleteByPrisonIdAndNotificationGroup(prisonId, notificationGroup)
+    if (prisonId == null) {
+      prisonNotificationMailboxRepository.deleteByPrisonIdIsNullAndNotificationGroup(notificationGroup)
+    } else {
+      prisonNotificationMailboxRepository.deleteByPrisonIdAndNotificationGroup(prisonId, notificationGroup)
+    }
     // Hibernate flushes inserts before deletes regardless of call order, so without this the re-added rows can collide with the not-yet-deleted old ones
     prisonNotificationMailboxRepository.flush()
 
@@ -73,11 +125,17 @@ class PrisonNotificationMailboxService(
       },
     )
 
+    return saved.toList()
+  }
+
+  private fun recordTransaction(transactionType: TransactionType, prisonId: String, notificationGroup: NotificationGroup, count: Int, action: String) {
+    val updatedBy = authenticationHolder.username ?: SYSTEM_USERNAME
+    val now = LocalDateTime.now(clock)
     val tx = LinkedTransaction(
-      transactionType = TransactionType.NOTIFICATION_MAILBOX_UPDATE,
+      transactionType = transactionType,
       prisonId = prisonId,
       // NB: never include the actual email addresses here - this is PII and must not appear in audit/telemetry/logs
-      transactionDetail = "Notification mailbox updated for group $notificationGroup (${normalisedEmails.size} address(es))",
+      transactionDetail = "Notification mailbox $action for group $notificationGroup ($count address(es))",
       transactionInvokedBy = updatedBy,
       txStartTime = now,
       txEndTime = now,
@@ -85,18 +143,16 @@ class PrisonNotificationMailboxService(
     linkedTransactionRepository.save(tx)
 
     telemetryClient.trackEvent(
-      "Notification mailbox update",
+      "Notification mailbox $action",
       mapOf(
         "prisonId" to prisonId,
         "notificationGroup" to notificationGroup.name,
-        "count" to normalisedEmails.size.toString(),
+        "count" to count.toString(),
         "tx" to tx.transactionId.toString(),
       ),
       null,
     )
-    log.info("Updated notification mailbox for prisonId=$prisonId, notificationGroup=$notificationGroup, count=${normalisedEmails.size} [$tx]")
-
-    return saved.toDto(prisonId, notificationGroup)
+    log.info("Notification mailbox $action for prisonId=$prisonId, notificationGroup=$notificationGroup, count=$count [$tx]")
   }
 
   @Transactional
@@ -108,46 +164,52 @@ class PrisonNotificationMailboxService(
 
     prisonNotificationMailboxRepository.deleteAll(existing)
 
-    val updatedBy = authenticationHolder.username ?: SYSTEM_USERNAME
-    val now = LocalDateTime.now(clock)
-    val tx = LinkedTransaction(
+    recordTransaction(
       transactionType = TransactionType.NOTIFICATION_MAILBOX_DELETE,
       prisonId = prisonId,
-      transactionDetail = "Notification mailbox deleted for group $notificationGroup (${existing.size} address(es))",
-      transactionInvokedBy = updatedBy,
-      txStartTime = now,
-      txEndTime = now,
+      notificationGroup = notificationGroup,
+      count = existing.size,
+      action = "deleted",
     )
-    linkedTransactionRepository.save(tx)
-
-    telemetryClient.trackEvent(
-      "Notification mailbox delete",
-      mapOf(
-        "prisonId" to prisonId,
-        "notificationGroup" to notificationGroup.name,
-        "count" to existing.size.toString(),
-        "tx" to tx.transactionId.toString(),
-      ),
-      null,
-    )
-    log.info("Deleted notification mailbox for prisonId=$prisonId, notificationGroup=$notificationGroup, count=${existing.size} [$tx]")
   }
 
-  private fun List<PrisonNotificationMailbox>.toDto(prisonId: String, notificationGroup: NotificationGroup) = PrisonNotificationMailboxDto(
+  @Transactional
+  fun deleteDefaultMailboxes(notificationGroup: NotificationGroup) {
+    val existing = prisonNotificationMailboxRepository.findByPrisonIdIsNullAndNotificationGroup(notificationGroup)
+    if (existing.isEmpty()) {
+      throw PrisonNotificationMailboxNotFoundException.default(notificationGroup)
+    }
+
+    prisonNotificationMailboxRepository.deleteAll(existing)
+
+    recordTransaction(
+      transactionType = TransactionType.NOTIFICATION_MAILBOX_DELETE,
+      prisonId = DEFAULT_MAILBOX_AUDIT_PRISON_ID,
+      notificationGroup = notificationGroup,
+      count = existing.size,
+      action = "deleted default",
+    )
+  }
+
+  private fun List<PrisonNotificationMailbox>.toDto(prisonId: String?, notificationGroup: NotificationGroup, source: NotificationMailboxSource) = PrisonNotificationMailboxDto(
     prisonId = prisonId,
     notificationGroup = notificationGroup,
     emailAddresses = map { it.emailAddress }.sorted(),
+    source = source,
   )
 }
 
 @Schema(description = "Prison notification mailbox")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class PrisonNotificationMailboxDto(
-  @param:Schema(description = "Prison ID", example = "MDI", required = true)
-  val prisonId: String,
+  @param:Schema(description = "Prison ID, omitted for default notification mailboxes", example = "MDI", required = false)
+  val prisonId: String?,
   @param:Schema(description = "Notification group", example = "CERT_ADMIN", required = true)
   val notificationGroup: NotificationGroup,
   @param:Schema(description = "Email addresses registered for this prison and notification group", required = true)
   val emailAddresses: List<String>,
+  @param:Schema(description = "Indicates whether the response came from a prison-specific or default mailbox", example = "PRISON", required = true)
+  val source: NotificationMailboxSource,
 )
 
 @Schema(description = "Request to replace all email addresses for a prison notification mailbox")
@@ -161,4 +223,9 @@ enum class NotificationGroup {
   CERT_ADMIN,
   CERT_VIEWER,
   CERT_REVIEWER,
+}
+
+enum class NotificationMailboxSource {
+  PRISON,
+  DEFAULT,
 }

--- a/src/main/resources/db/migration/V1_100__add_default_prison_notification_mailboxes.sql
+++ b/src/main/resources/db/migration/V1_100__add_default_prison_notification_mailboxes.sql
@@ -1,0 +1,12 @@
+-- Allow notification mailboxes to be configured globally for a notification group.
+ALTER TABLE prison_notification_mailbox ALTER COLUMN prison_id DROP NOT NULL;
+
+DROP INDEX prison_notification_mailbox_unique_idx;
+
+CREATE UNIQUE INDEX prison_notification_mailbox_prison_unique_idx
+    ON prison_notification_mailbox (prison_id, notification_group, lower(email_address))
+    WHERE prison_id IS NOT NULL;
+
+CREATE UNIQUE INDEX prison_notification_mailbox_default_unique_idx
+    ON prison_notification_mailbox (notification_group, lower(email_address))
+    WHERE prison_id IS NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/PrisonNotificationMailboxRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/PrisonNotificationMailboxRepositoryTest.kt
@@ -29,7 +29,7 @@ class PrisonNotificationMailboxRepositoryTest : TestBase() {
     repository.deleteAll()
   }
 
-  private fun mailbox(email: String, group: NotificationGroup = NotificationGroup.CERT_ADMIN, prisonId: String = testPrisonId) = PrisonNotificationMailbox(
+  private fun mailbox(email: String, group: NotificationGroup = NotificationGroup.CERT_ADMIN, prisonId: String? = testPrisonId) = PrisonNotificationMailbox(
     prisonId = prisonId,
     notificationGroup = group,
     emailAddress = email,
@@ -56,11 +56,31 @@ class PrisonNotificationMailboxRepositoryTest : TestBase() {
   }
 
   @Test
+  fun `returns default mailboxes when prison id is null`() {
+    repository.save(mailbox("default.viewer@justice.gov.uk", NotificationGroup.CERT_VIEWER, prisonId = null))
+    repository.save(mailbox("prison.viewer@justice.gov.uk", NotificationGroup.CERT_VIEWER))
+
+    val result = repository.findByPrisonIdIsNullAndNotificationGroup(NotificationGroup.CERT_VIEWER)
+
+    assertThat(result).hasSize(1)
+    assertThat(result[0].emailAddress).isEqualTo("default.viewer@justice.gov.uk")
+  }
+
+  @Test
   fun `rejects duplicate email address for the same prison and group regardless of case`() {
     repository.saveAndFlush(mailbox("duplicate@justice.gov.uk"))
 
     assertThatThrownBy {
       repository.saveAndFlush(mailbox("DUPLICATE@justice.gov.uk"))
+    }.isInstanceOf(DataIntegrityViolationException::class.java)
+  }
+
+  @Test
+  fun `rejects duplicate default email address for the same group regardless of case`() {
+    repository.saveAndFlush(mailbox("duplicate.default@justice.gov.uk", prisonId = null))
+
+    assertThatThrownBy {
+      repository.saveAndFlush(mailbox("DUPLICATE.DEFAULT@justice.gov.uk", prisonId = null))
     }.isInstanceOf(DataIntegrityViolationException::class.java)
   }
 
@@ -73,6 +93,17 @@ class PrisonNotificationMailboxRepositoryTest : TestBase() {
 
     assertThat(deleted).hasSize(2)
     assertThat(repository.findByPrisonIdAndNotificationGroup(testPrisonId, NotificationGroup.CERT_ADMIN)).isEmpty()
+  }
+
+  @Test
+  fun `deletes all default mailboxes for a group`() {
+    repository.save(mailbox("one.default@justice.gov.uk", prisonId = null))
+    repository.save(mailbox("two.default@justice.gov.uk", prisonId = null))
+
+    val deleted = repository.deleteByPrisonIdIsNullAndNotificationGroup(NotificationGroup.CERT_ADMIN)
+
+    assertThat(deleted).hasSize(2)
+    assertThat(repository.findByPrisonIdIsNullAndNotificationGroup(NotificationGroup.CERT_ADMIN)).isEmpty()
   }
 
   private fun assertThatThrownBy(block: () -> Unit) = org.assertj.core.api.Assertions.assertThatThrownBy(block)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/PrisonNotificationMailboxResourceTest.kt
@@ -116,11 +116,59 @@ class PrisonNotificationMailboxResourceTest : SqsIntegrationTestBase() {
               {
                 "prisonId": "$prisonId",
                 "notificationGroup": "CERT_ADMIN",
-                "emailAddresses": ["cert.admin@justice.gov.uk"]
+                "emailAddresses": ["cert.admin@justice.gov.uk"],
+                "source": "PRISON"
               }
             """.trimIndent(),
             JsonCompareMode.STRICT,
           )
+      }
+
+      @Test
+      fun `can get default notification mailbox when no prison-specific mailbox exists`() {
+        prisonNotificationMailboxRepository.save(
+          PrisonNotificationMailbox(
+            prisonId = null,
+            notificationGroup = NotificationGroup.CERT_VIEWER,
+            emailAddress = "default.viewer@justice.gov.uk",
+            whenUpdated = LocalDateTime.now(clock),
+            updatedBy = "TEST",
+          ),
+        )
+
+        webTestClient.get().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_VIEWER")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody().json(
+            """
+              {
+                "prisonId": "$prisonId",
+                "notificationGroup": "CERT_VIEWER",
+                "emailAddresses": ["default.viewer@justice.gov.uk"],
+                "source": "DEFAULT"
+              }
+            """.trimIndent(),
+            JsonCompareMode.STRICT,
+          )
+      }
+
+      @Test
+      fun `can exclude default notification mailbox when no prison-specific mailbox exists`() {
+        prisonNotificationMailboxRepository.save(
+          PrisonNotificationMailbox(
+            prisonId = null,
+            notificationGroup = NotificationGroup.CERT_VIEWER,
+            emailAddress = "default.viewer@justice.gov.uk",
+            whenUpdated = LocalDateTime.now(clock),
+            updatedBy = "TEST",
+          ),
+        )
+
+        webTestClient.get().uri("/prison-configuration/$prisonId/notification-mailboxes/CERT_VIEWER?includeDefault=false")
+          .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+          .exchange()
+          .expectStatus().isNotFound
       }
     }
   }
@@ -211,7 +259,8 @@ class PrisonNotificationMailboxResourceTest : SqsIntegrationTestBase() {
               {
                 "prisonId": "$prisonId",
                 "notificationGroup": "CERT_ADMIN",
-                "emailAddresses": ["second@justice.gov.uk", "third@justice.gov.uk"]
+                "emailAddresses": ["second@justice.gov.uk", "third@justice.gov.uk"],
+                "source": "PRISON"
               }
             """.trimIndent(),
             JsonCompareMode.STRICT,
@@ -236,12 +285,151 @@ class PrisonNotificationMailboxResourceTest : SqsIntegrationTestBase() {
               {
                 "prisonId": "$prisonId",
                 "notificationGroup": "CERT_ADMIN",
-                "emailAddresses": ["first@justice.gov.uk"]
+                "emailAddresses": ["first@justice.gov.uk"],
+                "source": "PRISON"
               }
             """.trimIndent(),
             JsonCompareMode.STRICT,
           )
       }
+    }
+  }
+
+  @DisplayName("/prison-configuration/notification-mailboxes/defaults/{notificationGroup}")
+  @Nested
+  inner class DefaultNotificationMailboxTest {
+
+    @Nested
+    inner class Security {
+
+      @Test
+      fun `get access forbidden when no authority`() {
+        webTestClient.get().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `get access forbidden when no role`() {
+        webTestClient.get().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `get access forbidden with wrong role`() {
+        webTestClient.get().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `put access forbidden when no authority`() {
+        webTestClient.put().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+          .bodyValue(mapOf("emailAddresses" to listOf("default.viewer@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `put access forbidden when no role`() {
+        webTestClient.put().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+          .headers(setAuthorisation(roles = listOf()))
+          .bodyValue(mapOf("emailAddresses" to listOf("default.viewer@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `put access forbidden with wrong role`() {
+        webTestClient.put().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .bodyValue(mapOf("emailAddresses" to listOf("default.viewer@justice.gov.uk")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `delete access forbidden when no authority`() {
+        webTestClient.delete().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `delete access forbidden when no role`() {
+        webTestClient.delete().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `delete access forbidden with wrong role`() {
+        webTestClient.delete().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Test
+    fun `can replace and get default notification mailbox`() {
+      webTestClient.put().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+        .bodyValue(mapOf("emailAddresses" to listOf("default.viewer@justice.gov.uk")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          """
+            {
+              "notificationGroup": "CERT_VIEWER",
+              "emailAddresses": ["default.viewer@justice.gov.uk"],
+              "source": "DEFAULT"
+            }
+          """.trimIndent(),
+          JsonCompareMode.STRICT,
+        )
+
+      webTestClient.get().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().json(
+          """
+            {
+              "notificationGroup": "CERT_VIEWER",
+              "emailAddresses": ["default.viewer@justice.gov.uk"],
+              "source": "DEFAULT"
+            }
+          """.trimIndent(),
+          JsonCompareMode.STRICT,
+        )
+    }
+
+    @Test
+    fun `can delete default notification mailbox`() {
+      prisonNotificationMailboxRepository.save(
+        PrisonNotificationMailbox(
+          prisonId = null,
+          notificationGroup = NotificationGroup.CERT_VIEWER,
+          emailAddress = "default.viewer@justice.gov.uk",
+          whenUpdated = LocalDateTime.now(clock),
+          updatedBy = "TEST",
+        ),
+      )
+
+      webTestClient.delete().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+        .exchange()
+        .expectStatus().isNoContent
+
+      webTestClient.get().uri("/prison-configuration/notification-mailboxes/defaults/CERT_VIEWER")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CONFIG_ADMIN")))
+        .exchange()
+        .expectStatus().isNotFound
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/PrisonNotificationMailboxServiceTest.kt
@@ -45,6 +45,7 @@ class PrisonNotificationMailboxServiceTest {
   fun setUp() {
     whenever(authenticationHolder.username).thenReturn("TEST_USER")
     whenever(linkedTransactionRepository.save(any<LinkedTransaction>())).thenReturn(Mockito.mock())
+    whenever(prisonNotificationMailboxRepository.findByPrisonIdIsNullAndNotificationGroup(any())).thenReturn(emptyList())
     whenever(activePrisonService.getPrisonConfiguration(any())).thenReturn(
       PrisonConfiguration(id = prisonId, whenUpdated = LocalDateTime.now(clock), updatedBy = "TEST_USER"),
     )
@@ -69,6 +70,31 @@ class PrisonNotificationMailboxServiceTest {
     val result = service.getMailboxes(prisonId, NotificationGroup.CERT_ADMIN)
 
     assertThat(result.emailAddresses).containsExactly(secretEmail)
+    assertThat(result.source).isEqualTo(NotificationMailboxSource.PRISON)
+  }
+
+  @Test
+  fun `returns default email addresses when no prison mailboxes exist`() {
+    whenever(prisonNotificationMailboxRepository.findByPrisonIdAndNotificationGroup(prisonId, NotificationGroup.CERT_VIEWER)).thenReturn(emptyList())
+    whenever(prisonNotificationMailboxRepository.findByPrisonIdIsNullAndNotificationGroup(NotificationGroup.CERT_VIEWER)).thenReturn(
+      listOf(
+        PrisonNotificationMailbox(prisonId = null, notificationGroup = NotificationGroup.CERT_VIEWER, emailAddress = secretEmail, whenUpdated = LocalDateTime.now(clock), updatedBy = "TEST_USER"),
+      ),
+    )
+
+    val result = service.getMailboxes(prisonId, NotificationGroup.CERT_VIEWER)
+
+    assertThat(result.prisonId).isEqualTo(prisonId)
+    assertThat(result.emailAddresses).containsExactly(secretEmail)
+    assertThat(result.source).isEqualTo(NotificationMailboxSource.DEFAULT)
+  }
+
+  @Test
+  fun `does not return default email addresses when includeDefault is false`() {
+    whenever(prisonNotificationMailboxRepository.findByPrisonIdAndNotificationGroup(prisonId, NotificationGroup.CERT_VIEWER)).thenReturn(emptyList())
+
+    assertThatThrownBy { service.getMailboxes(prisonId, NotificationGroup.CERT_VIEWER, includeDefault = false) }
+      .isInstanceOf(PrisonNotificationMailboxNotFoundException::class.java)
   }
 
   @Test
@@ -94,6 +120,18 @@ class PrisonNotificationMailboxServiceTest {
   }
 
   @Test
+  fun `replace default mailboxes stores rows without a prison id`() {
+    whenever(prisonNotificationMailboxRepository.saveAll(any<List<PrisonNotificationMailbox>>())).thenAnswer { it.arguments[0] }
+
+    val result = service.replaceDefaultMailboxes(NotificationGroup.CERT_VIEWER, listOf(secretEmail))
+
+    verify(prisonNotificationMailboxRepository).deleteByPrisonIdIsNullAndNotificationGroup(NotificationGroup.CERT_VIEWER)
+    assertThat(result.prisonId).isNull()
+    assertThat(result.emailAddresses).containsExactly(secretEmail)
+    assertThat(result.source).isEqualTo(NotificationMailboxSource.DEFAULT)
+  }
+
+  @Test
   fun `replace does not leak email addresses into linked transaction or telemetry`() {
     whenever(prisonNotificationMailboxRepository.saveAll(any<List<PrisonNotificationMailbox>>())).thenAnswer { it.arguments[0] }
 
@@ -114,6 +152,15 @@ class PrisonNotificationMailboxServiceTest {
 
     assertThatThrownBy { service.deleteMailboxes(prisonId, NotificationGroup.CERT_ADMIN) }
       .isInstanceOf(PrisonNotificationMailboxNotFoundException::class.java)
+  }
+
+  @Test
+  fun `delete default fails with a default-specific not found message when no mailboxes exist`() {
+    whenever(prisonNotificationMailboxRepository.findByPrisonIdIsNullAndNotificationGroup(NotificationGroup.CERT_VIEWER)).thenReturn(emptyList())
+
+    assertThatThrownBy { service.deleteDefaultMailboxes(NotificationGroup.CERT_VIEWER) }
+      .isInstanceOf(PrisonNotificationMailboxNotFoundException::class.java)
+      .hasMessage("There is no default notification mailbox found for notificationGroup = CERT_VIEWER")
   }
 
   @Test


### PR DESCRIPTION
## Add default notification mailboxes

Adds support for global/default notification mailboxes alongside prison-specific mailbox configuration.

### What changed

- Added support for default mailbox rows using `prison_id = null`
- Added default mailbox endpoints:
  - `GET /prison-configuration/notification-mailboxes/defaults/{notificationGroup}`
  - `PUT /prison-configuration/notification-mailboxes/defaults/{notificationGroup}`
  - `DELETE /prison-configuration/notification-mailboxes/defaults/{notificationGroup}`
- Updated prison-specific mailbox lookup to fall back to the default mailbox when no prison-specific rows exist
- Added `source` to mailbox responses to indicate whether the result came from `PRISON` or `DEFAULT`
- Added a migration to allow nullable `prison_id` and separate unique constraints for prison-specific vs default mailboxes
- Kept audit, telemetry, and log entries redacted so email addresses are not written to those sinks

### Testing

- Added repository coverage for default mailbox rows and uniqueness
- Added service coverage for default fallback and default replacement
- Added integration coverage for default mailbox endpoints and fallback behaviour
- Full test suite passes