### PR TITLE
MAPA-319: Retain working capacity on ingestion and certify the uploaded values

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateUploadDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateUploadDto.kt
@@ -31,6 +31,13 @@ data class CellCertificateUploadDto(
   @param:Schema(description = "Number of records that failed", example = "0", required = true)
   val failedRecords: Int,
 
+  @param:Schema(
+    description = "Number of cells whose certified capacity does not match the capacity the location kept, needing review",
+    example = "0",
+    required = true,
+  )
+  val discrepancyRecords: Int = 0,
+
   @param:Schema(description = "Who requested the upload", example = "MALEXANDER_GEN", required = true)
   val requestedBy: String,
 
@@ -97,4 +104,25 @@ data class CellCertificateUploadLocationDto(
 
   @param:Schema(description = "In-cell sanitation before the change")
   val previousInCellSanitation: Boolean? = null,
+
+  @param:Schema(
+    description = "The certificate holds the uploaded working capacity but the location kept its own, so the two do not match",
+    example = "false",
+    required = true,
+  )
+  val workingCapacityMismatch: Boolean = false,
+
+  @param:Schema(
+    description = "The certificate holds the uploaded max capacity but the location kept its own, so the two do not match",
+    example = "false",
+    required = true,
+  )
+  val maxCapacityMismatch: Boolean = false,
+
+  @param:Schema(
+    description = "The certificate holds the uploaded certified normal accommodation but the location kept its own, so the two do not match",
+    example = "false",
+    required = true,
+  )
+  val certifiedNormalAccommodationMismatch: Boolean = false,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/CellCertificate.kt
@@ -135,6 +135,17 @@ open class CellCertificate(
   )
 }
 
+/**
+ * The certified capacity to record for a cell, supplied by a cell certificate upload rather than derived
+ * from the cell's current state. Ingestion never forces a cell's working (or max) capacity, so the
+ * certificate has to be told what the uploaded certificate said.
+ */
+data class CertifiedCapacity(
+  val maxCapacity: Int,
+  val workingCapacity: Int,
+  val certifiedNormalAccommodation: Int,
+)
+
 @Entity
 open class CellCertificateLocation(
   @Id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/ResidentialLocation.kt
@@ -632,15 +632,28 @@ open class ResidentialLocation(
     return this
   }
 
-  fun toCellCertificateLocation(approvalRequest: CertificationApprovalRequest, currentCellCertificate: CellCertificate?): CellCertificateLocation {
+  /**
+   * [certifiedCapacityOverrides], keyed by cell path hierarchy, supplies the certified capacity for cells
+   * that came from a cell certificate upload. Ingestion no longer forces the uploaded working (or max)
+   * capacity onto the location, so the certificate must record the uploaded values rather than derive
+   * them from current state. While overrides are in play, structural locations total their own certificate
+   * rows so wing/landing figures agree with the cells listed beneath them.
+   */
+  fun toCellCertificateLocation(
+    approvalRequest: CertificationApprovalRequest,
+    currentCellCertificate: CellCertificate?,
+    certifiedCapacityOverrides: Map<String, CertifiedCapacity> = emptyMap(),
+  ): CellCertificateLocation {
     val subLocations: List<CellCertificateLocation> = getResidentialLocationsBelowThisLevel()
       .filter { !it.isDraft() && (it.isStructural() || it.isCell() || it.isConvertedCell()) }
-      .map { it.toCellCertificateLocation(approvalRequest, currentCellCertificate) }
+      .map { it.toCellCertificateLocation(approvalRequest, currentCellCertificate, certifiedCapacityOverrides) }
 
     val locationInExistingCertificate = currentCellCertificate?.findLocationInCertificate(getPathHierarchy())
     // A cell certificate upload re-certifies every location directly from current state, so always build
     // fresh rows rather than cloning the previous certificate (which would keep stale capacities).
     if (approvalRequest is CellCertificateUploadApprovalRequest || approvalLocationIsPartOfHierarchy(approvalRequest) || locationInExistingCertificate == null) {
+      val certifiedCapacity = certifiedCapacityOverrides[getPathHierarchy()]
+      val totalFromCertificateRows = certifiedCapacityOverrides.isNotEmpty() && isStructural()
       return CellCertificateLocation(
         locationType = getDerivedLocationType(),
         locationCode = getLocationCode(),
@@ -657,13 +670,17 @@ open class ResidentialLocation(
         } else {
           null
         },
-        maxCapacity = calcMaxCapacity(),
-        workingCapacity = if (approvalRequest is DraftChangeApprovalRequest) {
+        maxCapacity = certifiedCapacity?.maxCapacity
+          ?: if (totalFromCertificateRows) subLocations.sumOf { it.maxCapacity ?: 0 } else calcMaxCapacity(),
+        workingCapacity = certifiedCapacity?.workingCapacity ?: if (totalFromCertificateRows) {
+          subLocations.sumOf { it.workingCapacity ?: 0 }
+        } else if (approvalRequest is DraftChangeApprovalRequest) {
           getWorkingCapacityIgnoringInactiveStatus()
         } else {
           calcWorkingCapacityForCertificate()
         },
-        certifiedNormalAccommodation = calcCertifiedNormalAccommodation(),
+        certifiedNormalAccommodation = certifiedCapacity?.certifiedNormalAccommodation
+          ?: if (totalFromCertificateRows) subLocations.sumOf { it.certifiedNormalAccommodation ?: 0 } else calcCertifiedNormalAccommodation(),
         usedForTypes = getUsedForValuesAsCSV(),
         accommodationTypes = getAccommodationTypesAsCSV(),
         specialistCellTypes = getSpecialistCellTypesAsCSV(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/cellcertupload/CellCertificateUpload.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/cellcertupload/CellCertificateUpload.kt
@@ -59,6 +59,10 @@ open class CellCertificateUpload(
   @Column(nullable = false)
   open var failedRecords: Int = 0,
 
+  /** Rows whose certified capacity differs from the capacity the location kept, needing review. */
+  @Column(nullable = false)
+  open var discrepancyRecords: Int = 0,
+
   open var reasonForChange: String? = null,
 
   /** Set once the certificate has been generated from this upload (later step). */
@@ -83,6 +87,7 @@ open class CellCertificateUpload(
     processedRecords = processedRecords,
     skippedRecords = skippedRecords,
     failedRecords = failedRecords,
+    discrepancyRecords = discrepancyRecords,
     requestedBy = requestedBy,
     requestedDate = requestedDate,
     startTime = startTime,
@@ -133,6 +138,18 @@ open class CellCertificateUploadLocation(
 
   open var previousInCellSanitation: Boolean? = null,
 
+  /** The certificate holds the uploaded working capacity but the location kept its own. */
+  @Column(nullable = false)
+  open var workingCapacityMismatch: Boolean = false,
+
+  /** The certificate holds the uploaded max capacity but the location kept its own. */
+  @Column(nullable = false)
+  open var maxCapacityMismatch: Boolean = false,
+
+  /** The certificate holds the uploaded CNA but the location kept its own. */
+  @Column(nullable = false)
+  open var certifiedNormalAccommodationMismatch: Boolean = false,
+
   open var message: String? = null,
 
   open var processedDate: LocalDateTime? = null,
@@ -151,6 +168,22 @@ open class CellCertificateUploadLocation(
     this.previousCellMark = previousCellMark
     this.previousInCellSanitation = previousInCellSanitation
   }
+
+  /**
+   * Records that the uploaded certified capacity could not be (or must not be) applied to the location,
+   * so the certificate and the location now hold different values for review.
+   */
+  fun recordDiscrepancy(
+    workingCapacityMismatch: Boolean,
+    maxCapacityMismatch: Boolean,
+    certifiedNormalAccommodationMismatch: Boolean,
+  ) {
+    this.workingCapacityMismatch = workingCapacityMismatch
+    this.maxCapacityMismatch = maxCapacityMismatch
+    this.certifiedNormalAccommodationMismatch = certifiedNormalAccommodationMismatch
+  }
+
+  fun hasDiscrepancy() = workingCapacityMismatch || maxCapacityMismatch || certifiedNormalAccommodationMismatch
 
   fun markProcessed(processedDate: LocalDateTime) {
     this.status = CellCertificateUploadLocationStatus.PROCESSED
@@ -190,6 +223,9 @@ open class CellCertificateUploadLocation(
     previousCertifiedNormalAccommodation = previousCertifiedNormalAccommodation,
     previousCellMark = previousCellMark,
     previousInCellSanitation = previousInCellSanitation,
+    workingCapacityMismatch = workingCapacityMismatch,
+    maxCapacityMismatch = maxCapacityMismatch,
+    certifiedNormalAccommodationMismatch = certifiedNormalAccommodationMismatch,
   )
 
   override fun toString(): String = "CellCertificateUploadLocation(locationKey='$locationKey', status=$status)"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateUploadRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateUploadRepository.kt
@@ -38,6 +38,10 @@ interface CellCertificateUploadRepository : JpaRepository<CellCertificateUpload,
   @Query("update CellCertificateUpload u set u.failedRecords = u.failedRecords + 1 where u.id = :id")
   fun incrementFailedRecords(@Param("id") id: UUID)
 
+  @Modifying
+  @Query("update CellCertificateUpload u set u.discrepancyRecords = u.discrepancyRecords + 1 where u.id = :id")
+  fun incrementDiscrepancyRecords(@Param("id") id: UUID)
+
   fun findByPrisonIdOrderByRequestedDateDesc(prisonId: String): List<CellCertificateUpload>
 
   fun findByPrisonIdAndStatusInOrderByRequestedDateDesc(prisonId: String, statuses: Collection<CellCertificateUploadStatus>): List<CellCertificateUpload>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.CellCertificateDto
 import uk.gov.justice.digital.hmpps.locationsinsideprison.dto.capitalizeWords
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.CellCertificate
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.CertifiedCapacity
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Location
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.ApprovalRequestStatus
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CertificationApprovalRequest
@@ -32,11 +33,16 @@ class CellCertificateService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  /**
+   * [certifiedCapacityOverrides], keyed by cell path hierarchy, lets a cell certificate upload record the
+   * capacities the uploaded certificate stated, rather than the capacities the locations ended up with.
+   */
   fun createCellCertificate(
     approvedBy: String,
     approvedDate: LocalDateTime,
     approvalRequest: CertificationApprovalRequest,
     signedOperationCapacity: Int,
+    certifiedCapacityOverrides: Map<String, CertifiedCapacity> = emptyMap(),
   ): CellCertificateDto {
     val currentCellCertificate = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(approvalRequest.prisonId)
 
@@ -51,7 +57,7 @@ class CellCertificateService(
         locations = residentialLocationRepository.findAllByPrisonIdAndParentIsNull(approvalRequest.prisonId)
           .filter { !it.isPermanentlyDeactivated() && !it.isDraft() && it.isStructural() }
           .map {
-            it.toCellCertificateLocation(approvalRequest, currentCellCertificate)
+            it.toCellCertificateLocation(approvalRequest, currentCellCertificate, certifiedCapacityOverrides)
           }.toSortedSet(),
       ).apply {
         totalWorkingCapacity = locations.sumOf { it.workingCapacity ?: 0 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
@@ -7,6 +7,7 @@ import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.CertifiedCapacity
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.LinkedTransaction
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.TransactionType
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.approvalrequest.CellCertificateUploadApprovalRequest
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellLoc
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CertificationApprovalRequestRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.LinkedTransactionRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.SignedOperationCapacityRepository
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CapacityException
 import java.time.Clock
 import java.time.Duration
 import java.time.LocalDateTime
@@ -167,7 +169,7 @@ class CellCertificateUploadProcessingService(
       if (cell == null) {
         row.markFailed(LOCATION_NOT_FOUND_MESSAGE, now)
       } else if (cell.isPermanentlyDeactivated()) {
-        row.markSkipped("Archived location", now)
+        row.markSkipped(ARCHIVED_LOCATION_MESSAGE, now)
       } else {
         val linkedTransaction = linkedTransactionRepository.findById(linkedTransactionId).orElseThrow()
         if (applyToCell(cell, row, requestedBy, now, linkedTransaction)) {
@@ -180,6 +182,9 @@ class CellCertificateUploadProcessingService(
     }
     cellCertificateUploadLocationRepository.save(row)
     incrementRunningCount(uploadId, row.status)
+    if (row.hasDiscrepancy()) {
+      cellCertificateUploadRepository.incrementDiscrepancyRecords(uploadId)
+    }
     return capacityChangedLocationId
   }
 
@@ -211,26 +216,54 @@ class CellCertificateUploadProcessingService(
     val oldCellMark = cell.getDoorCellMark()
     val oldInCellSanitation = cell.getSanitationOfCell()
 
-    val cna = row.certifiedNormalAccommodation ?: oldCertifiedNormalAccommodation ?: 0
+    // An ingestion never moves the prison's working capacity: a difference between it and the uploaded
+    // certified working capacity does not tell us which of the two is correct. The certificate records the
+    // uploaded value, the location keeps its own, and the difference is reported for a user to resolve.
+    val retainedWorkingCapacity = oldWorkingCapacity ?: 0
+    val currentMaxCapacity = oldMaxCapacity ?: 0
+    val currentCertifiedNormalAccommodation = oldCertifiedNormalAccommodation ?: 0
+    val requestedCna = row.certifiedNormalAccommodation ?: currentCertifiedNormalAccommodation
 
+    var appliedMaxCapacity = currentMaxCapacity
+    var appliedCertifiedNormalAccommodation = currentCertifiedNormalAccommodation
     var changed = false
     var capacityChanged = false
 
-    if (oldMaxCapacity != row.maxCapacity || oldWorkingCapacity != row.workingCapacity || oldCertifiedNormalAccommodation != cna) {
+    if (row.maxCapacity != currentMaxCapacity || requestedCna != currentCertifiedNormalAccommodation) {
       // Look up occupancy via the non-transactional search service directly: a failure here must mark just this
-      // row FAILED (caught below), not roll back the per-row transaction the way a throwing @Transactional bean would.
+      // row FAILED (caught by the caller), not roll back the per-row transaction the way a throwing
+      // @Transactional bean would.
       val occupancy = prisonerSearchService.findPrisonersInLocations(cell.prisonId, listOf(cell.getPathHierarchy())).size
-      validateCapacityNotBelowOccupancy(cell, occupancy, row.maxCapacity, row.workingCapacity)
-      cell.setCapacity(
-        maxCapacity = row.maxCapacity,
-        workingCapacity = row.workingCapacity,
-        certifiedNormalAccommodation = cna,
-        userOrSystemInContext = requestedBy,
-        amendedDate = now,
-        linkedTransaction = linkedTransaction,
-      )
-      changed = true
-      capacityChanged = true
+
+      // Prefer everything the upload asked for, then degrade one value at a time, so a single value the cell
+      // cannot take (max capacity below occupancy, a CNA of zero on normal accommodation) no longer discards
+      // the rest of the row. setCapacity validates before it mutates, so a rejected attempt changes nothing.
+      val candidates = listOf(
+        row.maxCapacity to requestedCna,
+        currentMaxCapacity to requestedCna,
+        row.maxCapacity to currentCertifiedNormalAccommodation,
+      ).distinct()
+      for ((maxCapacity, cna) in candidates) {
+        if (maxCapacity == currentMaxCapacity && cna == currentCertifiedNormalAccommodation) continue
+        try {
+          validateCapacityNotBelowOccupancy(cell, occupancy, maxCapacity, retainedWorkingCapacity)
+          cell.setCapacity(
+            maxCapacity = maxCapacity,
+            workingCapacity = retainedWorkingCapacity,
+            certifiedNormalAccommodation = cna,
+            userOrSystemInContext = requestedBy,
+            amendedDate = now,
+            linkedTransaction = linkedTransaction,
+          )
+          appliedMaxCapacity = maxCapacity
+          appliedCertifiedNormalAccommodation = cna
+          changed = true
+          capacityChanged = true
+          break
+        } catch (e: CapacityException) {
+          log.info("${cell.getKey()}: cannot certify max capacity $maxCapacity / CNA $cna on the location: ${e.message}")
+        }
+      }
     }
 
     if (row.cellMark != null && row.cellMark != oldCellMark) {
@@ -262,10 +295,25 @@ class CellCertificateUploadProcessingService(
       previousCellMark = oldCellMark,
       previousInCellSanitation = oldInCellSanitation,
     )
+    row.recordDiscrepancy(
+      // A temporarily deactivated cell holds a working capacity of zero by definition, so comparing it with
+      // the certified value says nothing - the INACTIVE_TEMP handling above already covers those cells.
+      workingCapacityMismatch = !cell.isTemporarilyDeactivated() && row.workingCapacity != retainedWorkingCapacity,
+      maxCapacityMismatch = row.maxCapacity != appliedMaxCapacity,
+      certifiedNormalAccommodationMismatch = requestedCna != appliedCertifiedNormalAccommodation,
+    )
+
     if (changed) {
       row.markProcessed(now)
     } else {
-      row.markSkipped("No changes required", now)
+      row.markSkipped(NO_CHANGES_REQUIRED_MESSAGE, now)
+    }
+    // A discrepancy is orthogonal to whether the location changed - a cell can keep every value it already
+    // had and still be certified at a different working capacity - so it overwrites the outcome message.
+    if (row.workingCapacityMismatch) {
+      row.message = WORKING_CAPACITY_MISMATCH_MESSAGE
+    } else if (row.hasDiscrepancy()) {
+      row.message = CERTIFIED_CAPACITY_MISMATCH_MESSAGE
     }
     return capacityChanged
   }
@@ -279,6 +327,7 @@ class CellCertificateUploadProcessingService(
     upload.processedRecords = upload.locations.count { it.status == CellCertificateUploadLocationStatus.PROCESSED }
     upload.skippedRecords = upload.locations.count { it.status == CellCertificateUploadLocationStatus.SKIPPED }
     upload.failedRecords = upload.locations.count { it.status == CellCertificateUploadLocationStatus.FAILED }
+    upload.discrepancyRecords = upload.locations.count { it.hasDiscrepancy() }
 
     val now = LocalDateTime.now(clock)
     val approvalRequest = certificationApprovalRequestRepository.save(
@@ -297,6 +346,7 @@ class CellCertificateUploadProcessingService(
       approvedDate = now,
       approvalRequest = approvalRequest,
       signedOperationCapacity = signedOperationCapacityRepository.findByPrisonId(upload.prisonId)?.signedOperationCapacity ?: 0,
+      certifiedCapacityOverrides = certifiedCapacityOverrides(upload),
     )
 
     upload.cellCertificateId = cellCertificate.id
@@ -304,8 +354,25 @@ class CellCertificateUploadProcessingService(
     upload.endTime = now
     linkedTransaction.txEndTime = now
 
-    log.info("Finished cell certificate upload ${upload.id}: processed=${upload.processedRecords}, skipped=${upload.skippedRecords}, failed=${upload.failedRecords}, certificate=${cellCertificate.id}")
+    log.info("Finished cell certificate upload ${upload.id}: processed=${upload.processedRecords}, skipped=${upload.skippedRecords}, failed=${upload.failedRecords}, needingReview=${upload.discrepancyRecords}, certificate=${cellCertificate.id}")
   }
+
+  /**
+   * The certified capacity to record for each cell the upload covered, keyed by path hierarchy. These are the
+   * values the uploaded certificate stated, which are not necessarily the values the locations ended up with -
+   * the certificate must reflect the upload. Rows that could not be matched to a live cell (FAILED) contribute
+   * nothing and those cells fall back to their current state; archived locations are left out of the
+   * certificate altogether by [CellCertificateService.createCellCertificate].
+   */
+  private fun certifiedCapacityOverrides(upload: CellCertificateUpload): Map<String, CertifiedCapacity> = upload.locations
+    .filter { it.status == CellCertificateUploadLocationStatus.PROCESSED || it.status == CellCertificateUploadLocationStatus.SKIPPED }
+    .associate { row ->
+      row.locationKey.removePrefix("${upload.prisonId}-") to CertifiedCapacity(
+        maxCapacity = row.maxCapacity,
+        workingCapacity = row.workingCapacity,
+        certifiedNormalAccommodation = row.certifiedNormalAccommodation ?: row.previousCertifiedNormalAccommodation ?: 0,
+      )
+    }
 
   /**
    * A STARTED claim is considered stale (its consumer crashed) once its startTime is older than
@@ -330,6 +397,18 @@ class CellCertificateUploadProcessingService(
 
     /** Failure message shown when an uploaded cell certificate row references a location we do not hold. */
     const val LOCATION_NOT_FOUND_MESSAGE = "Location not found on Residential locations"
+
+    /** Skip message for a row whose location has been permanently deactivated. */
+    const val ARCHIVED_LOCATION_MESSAGE = "Archived location"
+
+    /** Skip message for a row that asked for nothing the location did not already hold. */
+    const val NO_CHANGES_REQUIRED_MESSAGE = "No changes required"
+
+    /** Reported against a cell that kept its own working capacity while the certificate took the uploaded one. */
+    const val WORKING_CAPACITY_MISMATCH_MESSAGE = "Working capacity and certified working capacity do not match"
+
+    /** Reported when the max capacity or CNA on the certificate could not be applied to the location. */
+    const val CERTIFIED_CAPACITY_MISMATCH_MESSAGE = "Certified capacity does not match the cell's capacity"
 
     /** Fixed explanation recorded against the approval request generated by a cell certificate upload. */
     const val UPLOAD_REASON_FOR_CHANGE =

--- a/src/main/resources/db/migration/V1_101__cell_cert_upload_discrepancy.sql
+++ b/src/main/resources/db/migration/V1_101__cell_cert_upload_discrepancy.sql
@@ -1,0 +1,11 @@
+-- MAPA-319: ingestion no longer forces a cell's working capacity (or max capacity) to the uploaded
+-- value. Where the uploaded certified value is retained on the certificate but the location keeps
+-- its own value, the row records the difference so it can be reviewed later.
+
+ALTER TABLE cell_certificate_upload
+    ADD COLUMN discrepancy_records INT NOT NULL DEFAULT 0;
+
+ALTER TABLE cell_certificate_upload_location
+    ADD COLUMN working_capacity_mismatch BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN max_capacity_mismatch     BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN certified_normal_accommodation_mismatch BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
@@ -10,6 +10,7 @@ import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import uk.gov.justice.digital.hmpps.locationsinsideprison.integration.CommonDataTestBase
+import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.Cell
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUpload
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUploadLocation
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.CellCertificateUploadLocationStatus
@@ -53,8 +54,9 @@ class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
     val body = jsonString(
       UpdateCapacityRequest(
         locations = mapOf(
-          // active cell, working capacity reduced 2 -> 1
-          cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 1, certifiedNormalAccommodation = 2),
+          // active cell, max capacity raised 2 -> 3 and certified working capacity reduced 2 -> 1. The max
+          // capacity is applied; the working capacity is not, but the certificate still records it.
+          cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 3, workingCapacity = 1, certifiedNormalAccommodation = 2),
           // active cell, no change
           cell2.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 2, certifiedNormalAccommodation = 2),
           // temporarily inactive cell that keeps a working capacity -> must become INACTIVE_TEMP
@@ -82,19 +84,30 @@ class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
       assertThat(upload.processedRecords).isEqualTo(2) // cell1 changed + inactive cell flagged
       assertThat(upload.skippedRecords).isEqualTo(1) // cell2 unchanged
       assertThat(upload.failedRecords).isEqualTo(0)
+      assertThat(upload.discrepancyRecords).isEqualTo(1) // cell1 keeps a working capacity of 2, certified at 1
 
       val rows = upload.locations.associateBy { it.locationKey }
       with(rows.getValue(cell1.getKey())) {
         assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.PROCESSED)
         assertThat(previousWorkingCapacity).isEqualTo(2)
         assertThat(workingCapacity).isEqualTo(1)
+        assertThat(workingCapacityMismatch).isTrue()
+        assertThat(maxCapacityMismatch).isFalse()
+        assertThat(message).isEqualTo(CellCertificateUploadProcessingService.WORKING_CAPACITY_MISMATCH_MESSAGE)
       }
       with(rows.getValue(cell2.getKey())) {
         assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.SKIPPED)
+        assertThat(workingCapacityMismatch).isFalse()
       }
       with(rows.getValue(inactiveCellB3001.getKey())) {
         assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.PROCESSED)
       }
+    }
+
+    // the upload applied the max capacity but left the prison's own working capacity alone
+    withReloadedCell1 {
+      assertThat(getMaxCapacity()).isEqualTo(3)
+      assertThat(getCurrentlyHeldWorkingCapacity()).isEqualTo(2)
     }
 
     // the temporarily inactive cell is now flagged INACTIVE_TEMP
@@ -106,6 +119,11 @@ class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
     assertThat(certificate).isNotNull
     val inactiveCellOnCert = certificate!!.findLocationInCertificate(inactiveCellB3001.getPathHierarchy())
     assertThat(inactiveCellOnCert?.workingCapacity).isEqualTo(2)
+    // the certificate records what the upload said, not what the location kept
+    with(certificate.findLocationInCertificate(cell1.getPathHierarchy())!!) {
+      assertThat(workingCapacity).isEqualTo(1)
+      assertThat(maxCapacity).isEqualTo(3)
+    }
     // total working capacity = cell1 (1) + cell2 (2) + temp-inactive cell (2)
     assertThat(certificate.totalWorkingCapacity).isEqualTo(5)
 
@@ -224,12 +242,14 @@ class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
 
     TransactionTemplate(transactionManager).execute {
       val upload = cellCertificateUploadRepository.findAll().first()
-      assertThat(upload.processedRecords).isEqualTo(1) // cell1 changed
-      assertThat(upload.skippedRecords).isEqualTo(0)
+      // cell1's only change was its working capacity, which an ingestion never applies
+      assertThat(upload.processedRecords).isEqualTo(0)
+      assertThat(upload.skippedRecords).isEqualTo(1)
       assertThat(upload.failedRecords).isEqualTo(1) // the missing location
       with(upload.locations.associateBy { it.locationKey }.getValue("MDI-Z-9-999")) {
         assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.FAILED)
         assertThat(message).isEqualTo("Location not found on Residential locations")
+        assertThat(hasDiscrepancy()).isFalse()
       }
     }
   }
@@ -267,35 +287,172 @@ class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
   }
 
   @Test
-  fun `working capacity cannot be set below occupancy for a normal accommodation cell but is allowed for non-normal`() {
-    // cell1 (NORMAL_ACCOMMODATION) and cell2 (CARE_AND_SEPARATION) each hold 2 prisoners
-    prisonerSearchMockServer.stubSearchByLocations("MDI", listOf(cell1.getPathHierarchy()), true, numberOfPrisonersInCell = 2)
-    prisonerSearchMockServer.stubSearchByLocations("MDI", listOf(cell2.getPathHierarchy()), true, numberOfPrisonersInCell = 2)
+  fun `an ingestion never moves the working capacity but the certificate takes the uploaded value`() {
+    // Jira scenario 1: occupancy would allow the reduction, but ingestion must not make it anyway
+    prisonerSearchMockServer.stubSearchByLocations("MDI", listOf(cell1.getPathHierarchy()), true, numberOfPrisonersInCell = 1)
 
     postCellCertificateUpdate(
       mapOf(
-        // normal cell: working capacity 1 < occupancy 2 -> must FAIL (max 2 is still >= occupancy)
-        cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 1, certifiedNormalAccommodation = 2),
-        // care & separation cell: working capacity 0 with occupancy 2 -> allowed (only max capacity is checked)
-        cell2.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 0, certifiedNormalAccommodation = 0),
+        cell1.getKey() to CellCapacityUpdateDetail(
+          maxCapacity = 2,
+          workingCapacity = 1,
+          certifiedNormalAccommodation = 1,
+          cellMark = "Z1-NEW",
+          inCellSanitation = true,
+        ),
       ),
     )
-
-    await untilAsserted {
-      assertThat(cellCertificateUploadRepository.findAll().firstOrNull()?.status).isEqualTo(CellCertificateUploadStatus.FINISHED)
-    }
+    awaitUploadFinished()
 
     TransactionTemplate(transactionManager).execute {
-      val rows = cellCertificateUploadRepository.findAll().first().locations.associateBy { it.locationKey }
-      with(rows.getValue(cell1.getKey())) {
-        assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.FAILED)
-        assertThat(message).contains("Working capacity (1) cannot be decreased below current cell occupancy (2)")
-      }
-      with(rows.getValue(cell2.getKey())) {
+      val upload = cellCertificateUploadRepository.findAll().first()
+      assertThat(upload.discrepancyRecords).isEqualTo(1)
+      with(upload.locations.first()) {
         assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.PROCESSED)
+        assertThat(workingCapacityMismatch).isTrue()
+        assertThat(maxCapacityMismatch).isFalse()
+        assertThat(certifiedNormalAccommodationMismatch).isFalse()
+        assertThat(previousWorkingCapacity).isEqualTo(2)
+        assertThat(message).isEqualTo(CellCertificateUploadProcessingService.WORKING_CAPACITY_MISMATCH_MESSAGE)
+      }
+    }
+
+    // the location keeps its working capacity, but everything else the upload asked for is applied
+    withReloadedCell1 {
+      assertThat(getCurrentlyHeldWorkingCapacity()).isEqualTo(2)
+      assertThat(getCertifiedNormalAccommodation()).isEqualTo(1)
+      assertThat(getDoorCellMark()).isEqualTo("Z1-NEW")
+      assertThat(getSanitationOfCell()).isTrue()
+    }
+
+    with(currentCertificateFor(cell1)) {
+      assertThat(workingCapacity).isEqualTo(1)
+      assertThat(maxCapacity).isEqualTo(2)
+      assertThat(certifiedNormalAccommodation).isEqualTo(1)
+    }
+  }
+
+  @Test
+  fun `the rest of the row is still applied when the cell holds more prisoners than the uploaded working capacity`() {
+    // Jira scenario 2: this row used to fail outright, discarding the CNA, cell mark and sanitation with it
+    prisonerSearchMockServer.stubSearchByLocations("MDI", listOf(cell1.getPathHierarchy()), true, numberOfPrisonersInCell = 2)
+
+    postCellCertificateUpdate(
+      mapOf(
+        cell1.getKey() to CellCapacityUpdateDetail(
+          maxCapacity = 2,
+          workingCapacity = 1,
+          certifiedNormalAccommodation = 1,
+          cellMark = "Z1-NEW",
+          inCellSanitation = true,
+        ),
+      ),
+    )
+    awaitUploadFinished()
+
+    TransactionTemplate(transactionManager).execute {
+      with(cellCertificateUploadRepository.findAll().first().locations.first()) {
+        assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.PROCESSED)
+        assertThat(workingCapacityMismatch).isTrue()
+        assertThat(message).isEqualTo(CellCertificateUploadProcessingService.WORKING_CAPACITY_MISMATCH_MESSAGE)
+      }
+    }
+
+    withReloadedCell1 {
+      assertThat(getCurrentlyHeldWorkingCapacity()).isEqualTo(2)
+      assertThat(getCertifiedNormalAccommodation()).isEqualTo(1)
+      assertThat(getDoorCellMark()).isEqualTo("Z1-NEW")
+      assertThat(getSanitationOfCell()).isTrue()
+    }
+
+    assertThat(currentCertificateFor(cell1).workingCapacity).isEqualTo(1)
+  }
+
+  @Test
+  fun `a max capacity that would fall below occupancy is retained but still certified`() {
+    prisonerSearchMockServer.stubSearchByLocations("MDI", listOf(cell1.getPathHierarchy()), true, numberOfPrisonersInCell = 2)
+
+    postCellCertificateUpdate(
+      mapOf(cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 1, workingCapacity = 1, certifiedNormalAccommodation = 1)),
+    )
+    awaitUploadFinished()
+
+    TransactionTemplate(transactionManager).execute {
+      with(cellCertificateUploadRepository.findAll().first().locations.first()) {
+        assertThat(maxCapacityMismatch).isTrue()
+        assertThat(workingCapacityMismatch).isTrue()
+        // the CNA the upload asked for was still applied
+        assertThat(certifiedNormalAccommodationMismatch).isFalse()
+      }
+    }
+
+    withReloadedCell1 {
+      assertThat(getMaxCapacity()).isEqualTo(2)
+      assertThat(getCurrentlyHeldWorkingCapacity()).isEqualTo(2)
+      assertThat(getCertifiedNormalAccommodation()).isEqualTo(1)
+    }
+
+    with(currentCertificateFor(cell1)) {
+      assertThat(maxCapacity).isEqualTo(1)
+      assertThat(workingCapacity).isEqualTo(1)
+    }
+  }
+
+  @Test
+  fun `cells whose working capacity already matches the uploaded value are not flagged`() {
+    postCellCertificateUpdate(
+      mapOf(cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 2, certifiedNormalAccommodation = 2)),
+    )
+    awaitUploadFinished()
+
+    TransactionTemplate(transactionManager).execute {
+      val upload = cellCertificateUploadRepository.findAll().first()
+      assertThat(upload.discrepancyRecords).isEqualTo(0)
+      with(upload.locations.first()) {
+        assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.SKIPPED)
+        assertThat(hasDiscrepancy()).isFalse()
+        assertThat(message).isEqualTo(CellCertificateUploadProcessingService.NO_CHANGES_REQUIRED_MESSAGE)
       }
     }
   }
+
+  @Test
+  fun `a cell that only differs on working capacity is counted as needing review even though nothing changed`() {
+    postCellCertificateUpdate(
+      mapOf(cell1.getKey() to CellCapacityUpdateDetail(maxCapacity = 2, workingCapacity = 1, certifiedNormalAccommodation = 2)),
+    )
+    awaitUploadFinished()
+
+    TransactionTemplate(transactionManager).execute {
+      val upload = cellCertificateUploadRepository.findAll().first()
+      assertThat(upload.processedRecords).isEqualTo(0)
+      assertThat(upload.skippedRecords).isEqualTo(1)
+      assertThat(upload.discrepancyRecords).isEqualTo(1)
+      with(upload.locations.first()) {
+        assertThat(status).isEqualTo(CellCertificateUploadLocationStatus.SKIPPED)
+        assertThat(workingCapacityMismatch).isTrue()
+        assertThat(message).isEqualTo(CellCertificateUploadProcessingService.WORKING_CAPACITY_MISMATCH_MESSAGE)
+      }
+    }
+
+    assertThat(currentCertificateFor(cell1).workingCapacity).isEqualTo(1)
+  }
+
+  /** A cell's capacity is a lazy association, so re-reading it needs an open session. */
+  private fun withReloadedCell1(assertions: Cell.() -> Unit) {
+    TransactionTemplate(transactionManager).executeWithoutResult {
+      cellRepository.findById(cell1.id!!).get().assertions()
+    }
+  }
+
+  private fun awaitUploadFinished() {
+    await untilAsserted {
+      assertThat(cellCertificateUploadRepository.findAll().firstOrNull()?.status).isEqualTo(CellCertificateUploadStatus.FINISHED)
+    }
+  }
+
+  private fun currentCertificateFor(cell: Cell) = cellCertificateRepository.findByPrisonIdAndCurrentIsTrue(cell.prisonId)!!
+    .findLocationInCertificate(cell.getPathHierarchy())!!
 
   private fun postCellCertificateUpdate(locations: Map<String, CellCapacityUpdateDetail>) {
     webTestClient.post().uri("/locations/bulk/update-cell-certificate/MDI")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadResourceIntTest.kt
@@ -176,13 +176,20 @@ class CellCertificateUploadResourceIntTest : CommonDataTestBase() {
 
   @Nested
   inner class ListAndDrillDown {
-    private fun saveUpload(prisonId: String, status: CellCertificateUploadStatus, daysAgo: Long, rows: List<CellCertificateUploadLocation> = emptyList()) = cellCertificateUploadRepository.saveAndFlush(
+    private fun saveUpload(
+      prisonId: String,
+      status: CellCertificateUploadStatus,
+      daysAgo: Long,
+      rows: List<CellCertificateUploadLocation> = emptyList(),
+      discrepancyRecords: Int = 0,
+    ) = cellCertificateUploadRepository.saveAndFlush(
       CellCertificateUpload(
         prisonId = prisonId,
         status = status,
         requestedBy = EXPECTED_USERNAME,
         requestedDate = LocalDateTime.now(clock).minusDays(daysAgo),
         totalRecords = rows.size,
+        discrepancyRecords = discrepancyRecords,
       ).apply { rows.forEach { addLocation(it) } },
     )
 
@@ -233,9 +240,14 @@ class CellCertificateUploadResourceIntTest : CommonDataTestBase() {
           previousCellMark = null,
           previousInCellSanitation = null,
         )
+        recordDiscrepancy(
+          workingCapacityMismatch = true,
+          maxCapacityMismatch = false,
+          certifiedNormalAccommodationMismatch = false,
+        )
         markProcessed(LocalDateTime.now(clock))
       }
-      val upload = saveUpload("MDI", CellCertificateUploadStatus.FINISHED, daysAgo = 0, rows = listOf(row))
+      val upload = saveUpload("MDI", CellCertificateUploadStatus.FINISHED, daysAgo = 0, rows = listOf(row), discrepancyRecords = 1)
 
       webTestClient.get().uri("/locations/bulk/update-cell-certificate/upload/${upload.id}")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS")))
@@ -249,6 +261,10 @@ class CellCertificateUploadResourceIntTest : CommonDataTestBase() {
         .jsonPath("$.locations[0].status").isEqualTo("PROCESSED")
         .jsonPath("$.locations[0].previousWorkingCapacity").isEqualTo(2)
         .jsonPath("$.locations[0].workingCapacity").isEqualTo(1)
+        .jsonPath("$.discrepancyRecords").isEqualTo(1)
+        .jsonPath("$.locations[0].workingCapacityMismatch").isEqualTo(true)
+        .jsonPath("$.locations[0].maxCapacityMismatch").isEqualTo(false)
+        .jsonPath("$.locations[0].certifiedNormalAccommodationMismatch").isEqualTo(false)
     }
 
     @Test


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/MAPA-319

## Why

Two things were wrong with cell certificate ingestion, and more prisons are due to be ingested shortly.

**The generated certificate never reflected the CSV.** `createCellCertificate` derives every value from live location state, so whenever a row could not be applied the certificate silently recorded the prison's operational figures instead of the certified ones that were uploaded.

**A rejected row was discarded wholesale.** Max capacity, working capacity and CNA sat inside one `if`, and `validateCapacityNotBelowOccupancy` threw before anything was written. The row was marked `FAILED`, so the CNA, max capacity, **cell mark and in-cell sanitation** from the CSV went with it, and `recordPreviousValues` never ran — the report showed nothing about what had been attempted.

MAPA-319 also changes the policy: an ingestion should never move a cell's working capacity, even where occupancy would allow it. A difference between the two values does not tell us which is correct.

## What changed

- **Working capacity is never written by an ingestion.** Both values are kept and the difference is reported for a user to resolve.
- **Max capacity and CNA are applied where the cell can take them.** `applyToCell` tries the uploaded pair and degrades one value at a time, catching `CapacityException`. `Cell.setCapacity` validates before it mutates, so a rejected attempt changes nothing. Cell mark and sanitation now always run.
- **The certificate records the CSV verbatim.** `createCellCertificate` takes a per-cell `certifiedCapacityOverrides` map. While overrides are in play, structural locations total their own certificate rows so wing and landing figures agree with the cells beneath them. Every non-upload caller passes no map and is unaffected.
- **Each row records a mismatch** on working capacity, max capacity or CNA, with a `discrepancyRecords` count on the upload. A discrepancy is orthogonal to the row outcome — a cell can keep every value it already held and still be certified at a different working capacity — so it is flags plus a count, not a fourth status value.
- Migration `V1_101__cell_cert_upload_discrepancy.sql`.

## Acceptance criteria

AC5 and AC7 needed no work. The blue banner already compares `capacity.workingCapacity` against `currentCellCertificate.workingCapacity`, and the existing `/location/:locationId/working-capacity-mismatch` journey resolves it in either direction, so the banner clears itself once the two agree.

## Testing

`./gradlew build` green. `CellCertificateUploadProcessingIntTest` covers both Jira scenarios, a max capacity below occupancy, a cell that only differs on working capacity (skipped but still counted), and cells that already match.

## Deploy order

This should merge and deploy **before** the UI PR — the ingestion report reads `discrepancyRecords` and the mismatch flags. Without them the report shows a review count of zero rather than breaking.