### PR TITLE
MAPA-323: Link a cell certificate upload to the approval request it raised

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateUploadDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/dto/CellCertificateUploadDto.kt
@@ -53,6 +53,9 @@ data class CellCertificateUploadDto(
   @param:Schema(description = "ID of the cell certificate generated from this upload, set once complete")
   val cellCertificateId: UUID? = null,
 
+  @param:Schema(description = "ID of the approval request this upload raised, set once complete")
+  val certificationApprovalRequestId: UUID? = null,
+
   @param:Schema(description = "Reason supplied for the change, where required")
   val reasonForChange: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/cellcertupload/CellCertificateUpload.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/cellcertupload/CellCertificateUpload.kt
@@ -68,6 +68,12 @@ open class CellCertificateUpload(
   /** Set once the certificate has been generated from this upload (later step). */
   open var cellCertificateId: UUID? = null,
 
+  /**
+   * The approval request this upload raised when it finished. Lets the cell certificate import request
+   * details page find the ingestion behind it, which nothing else records.
+   */
+  open var certificationApprovalRequestId: UUID? = null,
+
   @SortNatural
   @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinColumn(name = "cell_certificate_upload_id", nullable = false)
@@ -93,6 +99,7 @@ open class CellCertificateUpload(
     startTime = startTime,
     endTime = endTime,
     cellCertificateId = cellCertificateId,
+    certificationApprovalRequestId = certificationApprovalRequestId,
     reasonForChange = reasonForChange,
     locations = if (includeLocations) locations.map { it.toDto() } else null,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateUploadRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/jpa/repository/CellCertificateUploadRepository.kt
@@ -42,6 +42,8 @@ interface CellCertificateUploadRepository : JpaRepository<CellCertificateUpload,
   @Query("update CellCertificateUpload u set u.discrepancyRecords = u.discrepancyRecords + 1 where u.id = :id")
   fun incrementDiscrepancyRecords(@Param("id") id: UUID)
 
+  fun findByCertificationApprovalRequestId(certificationApprovalRequestId: UUID): CellCertificateUpload?
+
   fun findByPrisonIdOrderByRequestedDateDesc(prisonId: String): List<CellCertificateUpload>
 
   fun findByPrisonIdAndStatusInOrderByRequestedDateDesc(prisonId: String, statuses: Collection<CellCertificateUploadStatus>): List<CellCertificateUpload>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/ApiExceptionHandler.kt
@@ -266,6 +266,21 @@ class ApiExceptionHandler {
       )
   }
 
+  @ExceptionHandler(CellCertificateUploadForApprovalRequestNotFoundException::class)
+  fun handleCellCertificateUploadForApprovalRequestNotFoundException(e: CellCertificateUploadForApprovalRequestNotFoundException): ResponseEntity<ErrorResponse> {
+    log.debug("Cell certificate upload for approval request not found exception caught: {}", e.message)
+    return ResponseEntity
+      .status(HttpStatus.NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = HttpStatus.NOT_FOUND,
+          errorCode = ErrorCode.CellCertificateUploadNotFound,
+          userMessage = "Cell certificate upload not found: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
   @ExceptionHandler(CellCertificateUploadNotFoundException::class)
   fun handleCellCertificateUploadNotFoundException(e: CellCertificateUploadNotFoundException): ResponseEntity<ErrorResponse> {
     log.debug("Cell certificate upload not found: {}", e.message)
@@ -860,3 +875,4 @@ class SpecialistCellTypeChangesDoNotRequireApprovalException(key: String) : Exce
 class UsedForTypesOnlyForNormalAccommodationException(key: String) : Exception("Used for types can only be set on normal accommodation cells - $key is not a normal accommodation cell")
 class CellCertificateUploadAlreadyInProgressException(prisonId: String) : Exception("A cell certificate upload is already in progress for prison $prisonId")
 class CellCertificateUploadNotFoundException(id: UUID) : Exception("Cell certificate upload with id $id not found")
+class CellCertificateUploadForApprovalRequestNotFoundException(approvalRequestId: UUID) : Exception("No cell certificate upload was raised by approval request $approvalRequestId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadResource.kt
@@ -136,4 +136,37 @@ class CellCertificateUploadResource(
     @Schema(description = "Upload ID", example = "01912e1e-0000-7000-8000-000000000000", required = true)
     @PathVariable uploadId: UUID,
   ): CellCertificateUploadDto = cellCertificateUploadService.getCellCertificateUpload(uploadId)
+
+  @GetMapping("update-cell-certificate/by-approval-request/{approvalRequestId}")
+  // Called from the cell certificate import request details page, which is served under
+  // ROLE_LOCATION_CERTIFICATION, whereas the rest of this resource is ROLE_MAINTAIN_LOCATIONS.
+  @PreAuthorize("hasAnyRole('ROLE_MAINTAIN_LOCATIONS', 'ROLE_LOCATION_CERTIFICATION')")
+  @Operation(
+    summary = "Get the cell certificate upload behind an approval request, with its per-cell results",
+    description = "Returns the upload that raised the given certification approval request, plus each cell's " +
+      "result, so an approved initial cell certificate import can show what the ingestion did. " +
+      "Requires role MAINTAIN_LOCATIONS or LOCATION_CERTIFICATION.",
+    responses = [
+      ApiResponse(responseCode = "200", description = "Returns the upload and its per-cell results"),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Missing required role. Requires the MAINTAIN_LOCATIONS or LOCATION_CERTIFICATION role.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No cell certificate upload was raised by this approval request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getCellCertificateUploadByApprovalRequest(
+    @Schema(description = "Approval request ID", example = "01912e1e-0000-7000-8000-000000000000", required = true)
+    @PathVariable approvalRequestId: UUID,
+  ): CellCertificateUploadDto = cellCertificateUploadService.getCellCertificateUploadByApprovalRequest(approvalRequestId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadProcessingService.kt
@@ -350,6 +350,7 @@ class CellCertificateUploadProcessingService(
     )
 
     upload.cellCertificateId = cellCertificate.id
+    upload.certificationApprovalRequestId = approvalRequest.id
     upload.status = CellCertificateUploadStatus.FINISHED
     upload.endTime = now
     linkedTransaction.txEndTime = now

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/service/CellCertificateUploadService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.cellcertupload.Cel
 import uk.gov.justice.digital.hmpps.locationsinsideprison.jpa.repository.CellCertificateUploadRepository
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.ApprovalRequestRequiresReasonForChangeException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CellCertificateUploadAlreadyInProgressException
+import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CellCertificateUploadForApprovalRequestNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.CellCertificateUploadNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.PrisonNotFoundException
 import uk.gov.justice.digital.hmpps.locationsinsideprison.resource.UpdateCapacityRequest
@@ -109,6 +110,15 @@ class CellCertificateUploadService(
   fun getCellCertificateUpload(uploadId: UUID): CellCertificateUploadDto = cellCertificateUploadRepository.findById(uploadId)
     .orElseThrow { CellCertificateUploadNotFoundException(uploadId) }
     .toDto(includeLocations = true)
+
+  /**
+   * Returns the upload behind an approval request, with its per-cell results, so the cell certificate import
+   * request details page can show what the ingestion did.
+   */
+  @Transactional(readOnly = true)
+  fun getCellCertificateUploadByApprovalRequest(approvalRequestId: UUID): CellCertificateUploadDto = cellCertificateUploadRepository.findByCertificationApprovalRequestId(approvalRequestId)
+    ?.toDto(includeLocations = true)
+    ?: throw CellCertificateUploadForApprovalRequestNotFoundException(approvalRequestId)
 
   private fun sendStartProcessingMessageAfterCommit(uploadId: UUID) {
     TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/resources/db/migration/V1_102__cell_cert_upload_approval_request.sql
+++ b/src/main/resources/db/migration/V1_102__cell_cert_upload_approval_request.sql
@@ -1,0 +1,16 @@
+-- MAPA-323: the cell certificate import request details page needs to find the ingestion that produced it.
+-- Nothing recorded the approval request on the upload, and the only link ran the other way, through a
+-- loose cell_certificate_id with no index and no finder.
+
+ALTER TABLE cell_certificate_upload
+    ADD COLUMN certification_approval_request_id UUID NULL;
+
+-- Backfill uploads that already produced a certificate, so prisons ingested before this change still
+-- resolve. Uploads that never reached a certificate stay null and simply have no report to show.
+UPDATE cell_certificate_upload u
+   SET certification_approval_request_id = c.certification_approval_request_id
+  FROM cell_certificate c
+ WHERE c.id = u.cell_certificate_id;
+
+CREATE INDEX cell_certificate_upload_approval_request_idx
+    ON cell_certificate_upload (certification_approval_request_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadProcessingIntTest.kt
@@ -81,6 +81,8 @@ class CellCertificateUploadProcessingIntTest : CommonDataTestBase() {
     TransactionTemplate(transactionManager).execute {
       val upload = cellCertificateUploadRepository.findAll().first()
       assertThat(upload.cellCertificateId).isNotNull()
+      // the import request details page finds the ingestion through this link
+      assertThat(upload.certificationApprovalRequestId).isNotNull()
       assertThat(upload.processedRecords).isEqualTo(2) // cell1 changed + inactive cell flagged
       assertThat(upload.skippedRecords).isEqualTo(1) // cell2 unchanged
       assertThat(upload.failedRecords).isEqualTo(0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/locationsinsideprison/resource/CellCertificateUploadResourceIntTest.kt
@@ -268,6 +268,48 @@ class CellCertificateUploadResourceIntTest : CommonDataTestBase() {
     }
 
     @Test
+    fun `finds the upload behind an approval request`() {
+      val approvalRequestId = java.util.UUID.randomUUID()
+      val row = CellCertificateUploadLocation(
+        locationKey = "MDI-Z-1-001",
+        maxCapacity = 2,
+        workingCapacity = 1,
+        certifiedNormalAccommodation = 2,
+      ).apply { markProcessed(LocalDateTime.now(clock)) }
+      val upload = saveUpload("MDI", CellCertificateUploadStatus.FINISHED, daysAgo = 0, rows = listOf(row))
+        .also {
+          it.certificationApprovalRequestId = approvalRequestId
+          cellCertificateUploadRepository.saveAndFlush(it)
+        }
+
+      webTestClient.get().uri("/locations/bulk/update-cell-certificate/by-approval-request/$approvalRequestId")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("$.id").isEqualTo(upload.id.toString())
+        .jsonPath("$.certificationApprovalRequestId").isEqualTo(approvalRequestId.toString())
+        .jsonPath("$.locations.length()").isEqualTo(1)
+        .jsonPath("$.locations[0].locationKey").isEqualTo("MDI-Z-1-001")
+    }
+
+    @Test
+    fun `returns 404 when no upload was raised by the approval request`() {
+      webTestClient.get().uri("/locations/bulk/update-cell-certificate/by-approval-request/${java.util.UUID.randomUUID()}")
+        .headers(setAuthorisation(roles = listOf("ROLE_LOCATION_CERTIFICATION")))
+        .exchange()
+        .expectStatus().isNotFound
+    }
+
+    @Test
+    fun `by-approval-request is forbidden without a suitable role`() {
+      webTestClient.get().uri("/locations/bulk/update-cell-certificate/by-approval-request/${java.util.UUID.randomUUID()}")
+        .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
     fun `returns 404 when the upload does not exist`() {
       webTestClient.get().uri("/locations/bulk/update-cell-certificate/upload/${java.util.UUID.randomUUID()}")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_LOCATIONS")))


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/MAPA-323

Pairs with the UI change in ministryofjustice/hmpps-locations-inside-prison#718, which shows an ingestion's results below the "Initial cell certificate import request details" page. **This needs to merge and deploy first** — the UI calls the new endpoint.

## Why

Nothing recorded which ingestion produced a given approval request, so the details page had no way to find it. The only link ran the other way and only in part:

- `CellCertificateUpload.cellCertificateId` is a loose UUID — no FK, no index, no finder.
- `CertificationApprovalRequestDto.certificateId` is **always null** on `GET /certification/request-approvals/{id}`; it is only ever passed at the moment of approval (`ApprovalDecisionService:122`), and the read path calls `toDto(showLocations = true)` without it.

So even the two-hop route was closed: a client could not obtain a certificate id to start from.

## What changed

- `CellCertificateUpload` gains `certificationApprovalRequestId`, set in `finish()` where the approval request is already in scope, next to the existing `cellCertificateId` assignment.
- Migration `V1_102` adds the column, indexes it, and **backfills** existing rows by joining through `cell_certificate`. This matters — prisons have already been ingested and their reports must still resolve. Uploads that never reached a certificate stay null and simply have no report to show.
- `findByCertificationApprovalRequestId` on the repository, a read method on the service, and `GET /locations/bulk/update-cell-certificate/by-approval-request/{approvalRequestId}` returning the upload with its per-cell results.

